### PR TITLE
[FIX] Dropdown render

### DIFF
--- a/src/components/atoms/dropdown/Dropdown.tsx
+++ b/src/components/atoms/dropdown/Dropdown.tsx
@@ -1,6 +1,7 @@
 import { cn } from '@/lib/utils';
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import { ChevronRightIcon } from 'lucide-react';
+import { useState } from 'react';
 import { SpinnerCircular } from 'spinners-react';
 import type { DropdownElement, DropdownProps } from './types';
 
@@ -98,12 +99,14 @@ const Dropdown = ({
   offset = 1,
   closeOnSelect = true,
   items,
-  loading = false, // New prop
+  loading = false,
   children,
   className,
   ariaLabelledby,
   ariaDescribedby
 }: DropdownProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
   const marginClasses = {
     top: 'mb-2',
     bottom: 'mt-2',
@@ -118,17 +121,15 @@ const Dropdown = ({
   const accessibleLabelId = firstLabelId || fallbackId;
 
   return (
-    <DropdownMenuPrimitive.Root>
-      {({ open }) => (
-        <DropdownMenuPrimitive.Trigger
-          asChild={true}
-          aria-labelledby={ariaLabelledby || accessibleLabelId}
-          aria-describedby={ariaDescribedby}
-          aria-expanded={open}
-        >
-          <div>{children}</div>
-        </DropdownMenuPrimitive.Trigger>
-      )}
+    <DropdownMenuPrimitive.Root onOpenChange={setIsOpen}>
+      <DropdownMenuPrimitive.Trigger
+        asChild={true}
+        aria-labelledby={ariaLabelledby || accessibleLabelId}
+        aria-describedby={ariaDescribedby}
+        aria-expanded={isOpen}
+      >
+        <div>{children}</div>
+      </DropdownMenuPrimitive.Trigger>
       <DropdownMenuPrimitive.Content
         role='menu'
         aria-labelledby={accessibleLabelId}


### PR DESCRIPTION
This pull request introduces a state management improvement to the `Dropdown` component in the `src/components/atoms/dropdown/Dropdown.tsx` file. The most notable change is the replacement of the `open` prop with a local `isOpen` state, allowing better control over the dropdown's open/close behavior.

### State management improvements:

* Added a `useState` hook to manage the `isOpen` state in the `Dropdown` component. This replaces the previous reliance on the `open` prop provided by `DropdownMenuPrimitive`. (`[[1]](diffhunk://#diff-62db825ffaefc21246c707abaaf8f70b4cbdc59ea7bf4b1e68828762e3c91552R4)`, `[[2]](diffhunk://#diff-62db825ffaefc21246c707abaaf8f70b4cbdc59ea7bf4b1e68828762e3c91552L101-R109)`)
* Updated the `DropdownMenuPrimitive.Root` to use the `onOpenChange` callback to update the `isOpen` state, ensuring synchronization between the dropdown's state and its UI. (`[src/components/atoms/dropdown/Dropdown.tsxL121-L131](diffhunk://#diff-62db825ffaefc21246c707abaaf8f70b4cbdc59ea7bf4b1e68828762e3c91552L121-L131)`)
* Modified the `aria-expanded` attribute to use the local `isOpen` state for accessibility compliance and accurate state representation. (`[src/components/atoms/dropdown/Dropdown.tsxL121-L131](diffhunk://#diff-62db825ffaefc21246c707abaaf8f70b4cbdc59ea7bf4b1e68828762e3c91552L121-L131)`)