### PR TITLE
[FIX] Header as prop

### DIFF
--- a/src/components/atoms/header/Header.stories.tsx
+++ b/src/components/atoms/header/Header.stories.tsx
@@ -119,17 +119,17 @@ export const SecondaryH1Bold: Story = {
 };
 
 /**
- * - You can use as prop to change the font size of the header not changing the tag.
- *   For example, you can use `as="h1"` to make the header look like an h1 tag but keep it as an h2 tag.
+ * - You can use fontSize prop to change the font size of the header not changing the tag.
+ *   For example, you can use `fontSize="h1"` to make the header look like an h1 tag but keep it as an h2 tag.
  */
 
-export const AsProp: Story = {
+export const FontSize: Story = {
   render: () => (
     <div className='flex flex-col gap-4 items-center justify-center'>
-      <Header tag='h5' as='h1'>
+      <Header tag='h5' fontSize='h1'>
         Lorem Ipsum
       </Header>
-      <Header tag='h1' as='h5'>
+      <Header tag='h1' fontSize='h5'>
         Lorem Ipsum
       </Header>
     </div>

--- a/src/components/atoms/header/Header.tsx
+++ b/src/components/atoms/header/Header.tsx
@@ -9,32 +9,36 @@ const Header = ({
   children,
   srOnly = false,
   id,
-  as,
+  fontSize,
   ...rest
 }: HeaderProps) => {
   const Component = tag;
 
-  const fontByTag = () => {
-    switch (as) {
+  const fontByTag = (fs: string) => {
+    switch (fs) {
       case 'h1':
-        return '!fs-h1 tablet:!fs-tablet-h1';
+        return 'fs-h1 tablet:fs-tablet-h1';
       case 'h2':
-        return '!fs-h2 tablet:!fs-tablet-h2';
+        return 'fs-h2 tablet:fs-tablet-h2';
       case 'h3':
-        return '!fs-h3 tablet:!fs-tablet-h3';
+        return 'fs-h3 tablet:fs-tablet-h3';
       case 'h4':
-        return '!fs-h4 tablet:!fs-tablet-h4';
+        return 'fs-h4 tablet:fs-tablet-h4';
       case 'h5':
-        return '!fs-h5 tablet:!fs-tablet-h5';
+        return 'fs-h5 tablet:fs-tablet-h5';
       case 'h6':
-        return '!fs-h6 tablet:!fs-tablet-h6';
+        return 'fs-h6 tablet:fs-tablet-h6';
       default:
         return '';
     }
   };
 
   const props = {
-    className: cn(headerVariants({ font, tag, prominent, srOnly }), fontByTag(), className),
+    className: cn(
+      headerVariants({ font, prominent, srOnly }),
+      fontSize ? fontByTag(fontSize) : cn(headerVariants({ tag })),
+      className
+    ),
     id: id || undefined,
     ...rest
   };

--- a/src/components/atoms/header/types.ts
+++ b/src/components/atoms/header/types.ts
@@ -44,7 +44,7 @@ export type HeaderProps = {
   /** @control select */
   tag: HeaderVariant;
   /** @control select */
-  as?: HeaderVariant;
+  fontSize?: HeaderVariant;
   /** @control boolean */
   prominent?: boolean;
   /** @control text */


### PR DESCRIPTION
This pull request introduces a change to the `Header` component by replacing the `as` prop with a new `fontSize` prop, simplifying the logic for font size handling and improving clarity in usage. The changes span updates to the component's implementation, its type definitions, and related stories.

### Prop Replacement and Logic Simplification:
* [`src/components/atoms/header/Header.tsx`](diffhunk://#diff-b13490ba79e0ac87abcca1c9bedc8389da1ed0bea801ca07588bb2c4f3355120L12-R41): Replaced the `as` prop with `fontSize` for specifying font sizes independently of the HTML tag. Updated the `fontByTag` function to accept `fontSize` as a parameter and removed unnecessary `!` prefixes in font size classes. Improved `className` logic to conditionally apply font size based on the `fontSize` prop.

### Type Updates:
* [`src/components/atoms/header/types.ts`](diffhunk://#diff-76417b7865cda66509c43d33e8f77fd8e3f7304965ed967feeae044b9552eb83L47-R47): Replaced the `as` prop with `fontSize` in the `HeaderProps` type definition to reflect the new prop name and functionality.

### Story Updates:
* [`src/components/atoms/header/Header.stories.tsx`](diffhunk://#diff-8bc19a1de58b3cfabb8d31180b7158fc3988ffc10c8bfc3bd93e1fe461cf835cL122-R132): Updated the stories to use the new `fontSize` prop instead of `as`. Renamed the story from `AsProp` to `FontSize` for consistency with the updated prop name.