### PR TITLE
[FIX] button tests and tooling config alignment

### DIFF
--- a/src/components/atoms/button/Button.test.tsx
+++ b/src/components/atoms/button/Button.test.tsx
@@ -141,13 +141,13 @@ describe('Button — component behavior', () => {
 
   it('applies aria-pressed when the prop is provided', () => {
     render(<Button text='Toggle' aria-pressed={false} />);
-    const btn = screen.getByRole('switch', { name: 'Toggle' });
+    const btn = screen.getByRole('button', { name: 'Toggle' });
     expect(btn).toHaveAttribute('aria-pressed', 'false');
   });
 
-  it('sets role="switch" when aria-pressed prop is provided', () => {
+  it('keeps role="button" when aria-pressed prop is provided', () => {
     render(<Button text='Toggle' aria-pressed={true} />);
-    expect(screen.getByRole('switch', { name: 'Toggle' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Toggle' })).toBeInTheDocument();
   });
 
   it('sets role="button" when aria-pressed prop is NOT provided', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2024",
+    "target": "ES2022",
     "useDefineForClassFields": true,
     "module": "ESNext",
     "skipLibCheck": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,7 +45,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: ['./src/tests/setup.ts'],
+    setupFiles: ['./tests/setup.ts'],
     css: false,
     alias: aliases,
     coverage: {


### PR DESCRIPTION
## Summary

Fixes the current mismatch between Button accessibility test expectations and the project test/tooling configuration.

Closes #141

## Type of change

- [ ] 🧩 New component
- [x] 🐛 Bug fix
- [ ] 🎨 Design tokens
- [ ] ♿ Accessibility
- [x] 🏗️ Infrastructure
- [ ] 📚 Documentation

## Component checklist (skip if not applicable)

- [ ] Follows the 5-file structure (`types.ts`, `use*.ts`, `Component.tsx`, `index.ts`, `*.stories.tsx`)
- [ ] CVA variants defined in `types.ts`, not inline
- [ ] No hardcoded colors — uses tokens from `theme.css`
- [x] No `any` types — TypeScript strict
- [x] ARIA attributes present and correct
- [x] Keyboard navigable (Tab, Enter, Escape where applicable)
- [ ] Dark mode works correctly
- [ ] Storybook stories cover: default, variants, states (hover, focus, disabled)
- [x] Tests added or updated

## How to test

1. Run the related Button tests.
2. Verify `src/components/atoms/button/Button.test.tsx` now expects `role="button"` for `aria-pressed` cases.
3. Check `vite.config.ts` uses `./tests/setup.ts`.
4. Check `tsconfig.json` targets `ES2022`.

## Screenshots / recordings (if applicable)

No aplica.

## Notes for reviewer

- Related to #124, but scoped only to this targeted fix.
- No new Button behavior is introduced.
- This PR only aligns tests and supporting config with the current project setup.