### PR TITLE
fix(chip): refine visual treatment

### DIFF
--- a/src/components/atoms/chip/Chip.stories.tsx
+++ b/src/components/atoms/chip/Chip.stories.tsx
@@ -7,28 +7,22 @@ import Icon from '../icon/Icon';
 import { Chip } from './Chip';
 
 /**
- * ## DESCRIPTION
- * Chip component is a compact element used to display statuses, keywords, or quick actions.
+ * ## Description
+ * Chip is a compact element used to display statuses, keywords, filters, or quick actions.
  *
- * Common use cases include tags, filters, and state indicators in dense interfaces.
+ * ## Dependencies
+ * Uses `Icon`, `Avatar`, and `lucide-react` icons in examples to document media, action, and composition slots.
  *
- * - Customizable in color, size, variant, radius and animation.
- * - Supports `startContent` / `endContent` (icons or text), optional avatar, and `dot` indicator.
- * - Optional interactivity: clickable (`onClick`/`selectable`), selectable (controlled or uncontrolled), and closable.
- * - `as` is a preference, not an absolute guarantee: when `closable` + interactive are combined, the chip uses a split-actions group with sibling buttons.
- * - Accessible via `ariaLabel` for chips without readable text; close action uses contextual label (`Remove <label>`).
+ * ## Usage Guide
+ * Use `children` for the readable label, `ariaLabel` for dot-only or non-textual chips, and `closable` only when the chip can be removed.
+ * When `closable` and click behavior are combined, the component renders split-actions markup with sibling buttons to avoid nested interactive controls.
  */
-
 const meta: Meta<typeof Chip> = {
   title: 'Atoms/Chip',
   component: Chip,
   parameters: {
     docs: {
-      autodocs: true,
-      description: {
-        component:
-          'Chip is a compact element for statuses, filters, labels, and quick actions. It supports visual variants, optional media/icon slots, selectable state, and closable interactions with accessible split-actions markup when needed.'
-      }
+      autodocs: true
     }
   },
   tags: ['autodocs']
@@ -36,6 +30,9 @@ const meta: Meta<typeof Chip> = {
 export default meta;
 
 type Story = StoryObj<typeof Chip>;
+
+const visualColors = ['primary', 'secondary', 'success', 'warning', 'danger'] as const;
+const visualVariants = ['solid', 'flat', 'shadow', 'bordered', 'light', 'faded', 'dot'] as const;
 
 export const Default: Story = {
   args: {
@@ -92,6 +89,89 @@ export const Variant: Story = {
       <Chip variant='dot' color='warning'>
         With dot
       </Chip>
+    </div>
+  )
+};
+
+/**
+ * Visual review matrix for all semantic colors and visual variants in light and dark surfaces.
+ */
+export const VisualReviewMatrix: Story = {
+  render: () => (
+    <div className='grid gap-6 rounded-xl bg-background-light p-6 dark:bg-background-dark'>
+      {visualVariants.map((variant) => (
+        <section key={variant} className='grid gap-3'>
+          <h3 className='fs-small font-secondary-bold capitalize text-text-secondary-light dark:text-text-secondary-dark'>
+            {variant}
+          </h3>
+          <div className='flex flex-wrap items-center gap-3'>
+            {visualColors.map((color) => (
+              <Chip key={`${variant}-${color}`} variant={variant} color={color}>
+                {color}
+              </Chip>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+};
+
+/**
+ * Product-like examples used to judge whether Chip feels like a premium status/filter/control instead of a small Badge.
+ */
+export const UsageReview: Story = {
+  render: () => (
+    <div className='grid gap-6 rounded-xl bg-background-light p-6 dark:bg-background-dark'>
+      <section className='grid gap-3 rounded-lg border border-border-light bg-surface-light p-4 dark:border-border-dark dark:bg-surface-dark'>
+        <h3 className='fs-base font-secondary-bold text-text-light dark:text-text-dark'>Status row</h3>
+        <div className='flex flex-wrap items-center gap-3'>
+          <Chip color='success' variant='flat' startContent={<Check />}>
+            Synced
+          </Chip>
+          <Chip color='warning' variant='dot'>
+            Pending review
+          </Chip>
+          <Chip color='danger' variant='faded'>
+            Failing checks
+          </Chip>
+          <Chip color='secondary' variant='bordered'>
+            Draft
+          </Chip>
+        </div>
+      </section>
+
+      <section className='grid gap-3 rounded-lg border border-border-light bg-surface-light p-4 dark:border-border-dark dark:bg-surface-dark'>
+        <h3 className='fs-base font-secondary-bold text-text-light dark:text-text-dark'>Filters and actions</h3>
+        <div className='flex flex-wrap items-center gap-3'>
+          <Chip
+            selectable={true}
+            defaultSelected={true}
+            color='primary'
+            onSelectedChange={action('chip.filter-selected')}
+          >
+            React
+          </Chip>
+          <Chip closable={true} color='secondary' variant='faded' onClose={action('chip.close')}>
+            Design System
+          </Chip>
+          <Chip as='button' color='primary' variant='solid' onClick={action('chip.apply')}>
+            Apply filter
+          </Chip>
+        </div>
+      </section>
+
+      <section className='grid gap-3 rounded-lg border border-border-light bg-surface-light p-4 dark:border-border-dark dark:bg-surface-dark'>
+        <h3 className='fs-base font-secondary-bold text-text-light dark:text-text-dark'>Identity chip</h3>
+        <div className='flex flex-wrap items-center gap-3'>
+          <Chip avatar={<Avatar src='/images/logo-only.svg' alt='EG' size='sm' />} color='secondary' variant='flat'>
+            EGDEV
+          </Chip>
+          <Chip startContent={<Icon name='user' />} color='primary' variant='bordered'>
+            Contributor
+          </Chip>
+        </div>
+      </section>
     </div>
   )
 };

--- a/src/components/atoms/chip/types.ts
+++ b/src/components/atoms/chip/types.ts
@@ -3,305 +3,128 @@ import type * as React from 'react';
 
 export const chipVariants = cva(
   [
-    'chip relative max-w-full min-w-0',
-    'transition-[transform,box-shadow] duration-200 ease-in-out',
-    'flex items-center justify-center',
-    'font-secondary-bold whitespace-nowrap leading-[1.2]',
-    'disabled:pointer-events-none disabled:opacity-60',
-    'data-[disabled=true]:opacity-60 data-[disabled=true]:cursor-not-allowed',
+    'chip relative inline-flex max-w-full min-w-0 items-center justify-center overflow-visible',
+    'font-secondary-bold whitespace-nowrap leading-none tracking-ui',
+    'border transition-[background-color,border-color,color,box-shadow,transform] duration-200 ease-in-out',
+    'disabled:pointer-events-none disabled:opacity-40',
+    'data-[disabled=true]:pointer-events-none data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-40',
     'focus-visible:outline-none',
-    'data-[interactive=true]:focus-visible:ring-2 data-[interactive=true]:focus-visible:ring-[var(--color-accent)]',
-    'dark:data-[interactive=true]:focus-visible:ring-[var(--color-text-dark)]',
-    'data-[interactive=true]:focus-visible:ring-offset-2 data-[interactive=true]:focus-visible:ring-offset-[var(--surface-bg,white)]',
-    'data-[interactive=true]:active:translate-y-[1px] data-[interactive=true]:active:scale-[0.985]'
+    'data-[interactive=true]:focus-visible:shadow-glow-focus-light dark:data-[interactive=true]:focus-visible:shadow-glow-focus-dark',
+    'motion-safe:data-[interactive=true]:active:translate-y-px motion-safe:data-[interactive=true]:active:scale-[0.98]'
   ],
   {
     variants: {
-      color: { primary: '', secondary: '', success: '', warning: '', danger: '' },
-
-      // ⬇️ Añadimos la custom prop --chip-h para poder usarla en el wrapper del avatar
-      size: {
-        sm: [
-          'h-5 px-1 gap-0.5 fs-small',
-          '[--chip-h:theme(spacing.5)]' // 20px
+      color: {
+        primary: [
+          '[--chip-tone:var(--color-primary)] dark:[--chip-tone:var(--color-brand-dark)]',
+          '[--chip-fg:var(--color-brand-light-darkest)] dark:[--chip-fg:var(--color-brand-dark)]',
+          '[--chip-solid-bg:var(--color-primary)] dark:[--chip-solid-bg:var(--color-brand-dark)]',
+          '[--chip-solid-fg:var(--color-text-dark)]',
+          '[--chip-soft-bg:color-mix(in_srgb,var(--chip-tone)_10%,transparent)]',
+          '[--chip-soft-bg-hover:color-mix(in_srgb,var(--chip-tone)_16%,transparent)]',
+          '[--chip-soft-border:color-mix(in_srgb,var(--chip-tone)_28%,transparent)]',
+          '[--chip-solid-hover:var(--color-primary-hover)] dark:[--chip-solid-hover:var(--color-brand-dark-light)]',
+          '[--chip-dot:var(--chip-tone)]'
         ].join(' '),
-        md: [
-          'h-6 px-1.5 gap-0.5 fs-base',
-          '[--chip-h:theme(spacing.6)]' // 24px
+        secondary: [
+          '[--chip-tone:var(--color-border-strong-light)] dark:[--chip-tone:var(--color-border-strong-dark)]',
+          '[--chip-fg:var(--color-text-secondary-light)] dark:[--chip-fg:var(--color-text-secondary-dark)]',
+          '[--chip-solid-bg:var(--color-surface-raised-light)] dark:[--chip-solid-bg:var(--color-surface-raised-dark)]',
+          '[--chip-solid-fg:var(--color-text-light)] dark:[--chip-solid-fg:var(--color-text-dark)]',
+          '[--chip-soft-bg:color-mix(in_srgb,var(--chip-tone)_12%,transparent)]',
+          '[--chip-soft-bg-hover:color-mix(in_srgb,var(--chip-tone)_18%,transparent)]',
+          '[--chip-soft-border:color-mix(in_srgb,var(--chip-tone)_48%,transparent)]',
+          '[--chip-solid-hover:var(--color-surface-light)] dark:[--chip-solid-hover:var(--color-surface-dark)]',
+          '[--chip-dot:var(--color-text-secondary-light)] dark:[--chip-dot:var(--color-text-secondary-dark)]'
         ].join(' '),
-        lg: [
-          'h-7 px-2 gap-1 fs-h6',
-          '[--chip-h:theme(spacing.7)]' // 28px
+        success: [
+          '[--chip-tone:var(--color-green)]',
+          '[--chip-fg:var(--color-green-dark)] dark:[--chip-fg:var(--color-green-light)]',
+          '[--chip-solid-bg:var(--color-green)]',
+          '[--chip-solid-fg:var(--color-text-light)] dark:[--chip-solid-fg:var(--color-background-dark)]',
+          '[--chip-soft-bg:color-mix(in_srgb,var(--chip-tone)_11%,transparent)]',
+          '[--chip-soft-bg-hover:color-mix(in_srgb,var(--chip-tone)_18%,transparent)]',
+          '[--chip-soft-border:color-mix(in_srgb,var(--chip-tone)_36%,transparent)]',
+          '[--chip-solid-hover:var(--color-green-dark)] dark:[--chip-solid-hover:var(--color-green-light)]',
+          '[--chip-dot:var(--chip-tone)]'
+        ].join(' '),
+        warning: [
+          '[--chip-tone:var(--color-yellow)]',
+          '[--chip-fg:var(--color-yellow-dark)] dark:[--chip-fg:var(--color-yellow-light)]',
+          '[--chip-solid-bg:var(--color-yellow)]',
+          '[--chip-solid-fg:#1a0a00]',
+          '[--chip-soft-bg:color-mix(in_srgb,var(--chip-tone)_13%,transparent)]',
+          '[--chip-soft-bg-hover:color-mix(in_srgb,var(--chip-tone)_20%,transparent)]',
+          '[--chip-soft-border:color-mix(in_srgb,var(--chip-tone)_42%,transparent)]',
+          '[--chip-solid-hover:var(--color-yellow-light)]',
+          '[--chip-dot:var(--chip-tone)]'
+        ].join(' '),
+        danger: [
+          '[--chip-tone:var(--color-red-600)] dark:[--chip-tone:var(--color-red-500)]',
+          '[--chip-fg:var(--color-red-700)] dark:[--chip-fg:var(--color-red-300)]',
+          '[--chip-solid-bg:var(--color-red-600)] dark:[--chip-solid-bg:var(--color-red-500)]',
+          '[--chip-solid-fg:var(--color-text-dark)]',
+          '[--chip-soft-bg:color-mix(in_srgb,var(--chip-tone)_11%,transparent)]',
+          '[--chip-soft-bg-hover:color-mix(in_srgb,var(--chip-tone)_18%,transparent)]',
+          '[--chip-soft-border:color-mix(in_srgb,var(--chip-tone)_36%,transparent)]',
+          '[--chip-solid-hover:var(--color-red-700)] dark:[--chip-solid-hover:var(--color-red-400)]',
+          '[--chip-dot:var(--chip-tone)]'
         ].join(' ')
       },
 
-      radiusSize: { none: '', sm: 'rounded-sm', md: 'rounded-md', lg: 'rounded-lg', full: 'rounded-full' },
+      size: {
+        sm: 'h-6 gap-1 px-2 text-xs',
+        md: 'h-7 gap-1 px-2.5 text-sm',
+        lg: 'h-8 gap-1.5 px-3 text-sm'
+      },
+
+      radiusSize: { none: 'rounded-none', sm: 'rounded-sm', md: 'rounded-md', lg: 'rounded-lg', full: 'rounded-full' },
 
       variant: {
-        solid: 'border border-transparent',
-        light: 'bg-transparent border border-transparent',
-        flat: 'border border-transparent',
-        faded: 'border',
-        bordered: 'bg-transparent border',
-        shadow: 'border border-transparent',
-        dot: 'bg-transparent border'
+        solid: [
+          'border-transparent bg-[var(--chip-solid-bg)] text-[var(--chip-solid-fg)] shadow-none',
+          'data-[interactive=true]:hover:bg-[var(--chip-solid-hover)]'
+        ].join(' '),
+        flat: [
+          'border-transparent bg-[var(--chip-soft-bg)] text-[var(--chip-fg)]',
+          'data-[interactive=true]:hover:bg-[var(--chip-soft-bg-hover)]'
+        ].join(' '),
+        shadow: [
+          'border-transparent bg-[var(--chip-solid-bg)] text-[var(--chip-solid-fg)]',
+          'shadow-[0_1px_2px_rgba(0,0,0,.12),0_3px_10px_color-mix(in_srgb,var(--chip-tone)_16%,transparent)]',
+          'dark:shadow-[0_1px_2px_rgba(0,0,0,.28),0_3px_10px_color-mix(in_srgb,var(--chip-tone)_14%,transparent)]',
+          'data-[interactive=true]:hover:bg-[var(--chip-solid-hover)]',
+          'data-[interactive=true]:hover:shadow-[0_2px_4px_rgba(0,0,0,.14),0_6px_16px_color-mix(in_srgb,var(--chip-tone)_20%,transparent)]',
+          'dark:data-[interactive=true]:hover:shadow-[0_2px_4px_rgba(0,0,0,.32),0_6px_16px_color-mix(in_srgb,var(--chip-tone)_18%,transparent)]'
+        ].join(' '),
+        bordered: [
+          'border-[var(--chip-soft-border)] bg-transparent text-[var(--chip-fg)]',
+          'data-[interactive=true]:hover:bg-[var(--chip-soft-bg)] data-[interactive=true]:hover:border-[var(--chip-tone)]'
+        ].join(' '),
+        light: [
+          'border-transparent bg-transparent text-[var(--chip-fg)]',
+          'data-[interactive=true]:hover:bg-[var(--chip-soft-bg)]'
+        ].join(' '),
+        faded: [
+          'border-[var(--chip-soft-border)] bg-[var(--chip-soft-bg)] text-[var(--chip-fg)]',
+          'data-[interactive=true]:hover:bg-[var(--chip-soft-bg-hover)] data-[interactive=true]:hover:border-[var(--chip-tone)]'
+        ].join(' '),
+        dot: [
+          'border-[var(--chip-soft-border)] bg-[var(--chip-soft-bg)] text-[var(--chip-fg)]',
+          'data-[interactive=true]:hover:bg-[var(--chip-soft-bg-hover)] data-[interactive=true]:hover:border-[var(--chip-tone)]'
+        ].join(' ')
       },
 
-      startContent: { default: '', icon: 'mr-1', text: 'font-semibold' },
-      endContent: { default: '', icon: 'ml-1', text: 'font-semibold' },
+      startContent: { default: '', icon: 'mr-0.5', text: 'font-semibold' },
+      endContent: { default: '', icon: 'ml-0.5', text: 'font-semibold' },
 
-      animation: { default: '', pulse: 'animate-pulse', bounce: 'animate-bounce', ping: 'animate-badgePing' }
-    },
-
-    compoundVariants: [
-      /* ----------------- PRIMARY ----------------- */
-      {
-        color: 'primary',
-        variant: 'solid',
-        class: [
-          'bg-[var(--color-primary)] text-[var(--color-text-dark)]',
-          'data-[interactive=true]:hover:bg-[var(--color-red-600)] dark:data-[interactive=true]:hover:bg-[var(--color-red-700)]',
-          'data-[interactive=true]:active:translate-y-[0.5px]'
-        ].join(' ')
-      },
-      {
-        color: 'primary',
-        variant: 'light',
-        class:
-          'text-[var(--color-brand-light-darkest)] data-[interactive=true]:hover:bg-[var(--color-red-100)] dark:text-[var(--color-brand-dark)] dark:data-[interactive=true]:hover:bg-[#1a0008]'
-      },
-      {
-        color: 'primary',
-        variant: 'flat',
-        class:
-          'bg-[var(--color-red-100)] text-[var(--color-brand-light-darkest)] data-[interactive=true]:hover:bg-[var(--color-red-200)] dark:bg-[#2a000d] dark:text-[var(--color-brand-dark)] dark:data-[interactive=true]:hover:bg-[#330011]'
-      },
-      {
-        color: 'primary',
-        variant: 'faded',
-        class: [
-          'bg-[var(--color-red-100)] border-[var(--color-red-400)]',
-          'text-[var(--color-brand-light-darkest)] data-[interactive=true]:hover:bg-[var(--color-red-200)]',
-          'dark:bg-[#1a0008] dark:border-[var(--color-brand-dark)] dark:text-[var(--color-brand-dark)]',
-          'dark:data-[interactive=true]:hover:bg-[#24000b]'
-        ].join(' ')
-      },
-      {
-        color: 'primary',
-        variant: 'bordered',
-        class:
-          'text-[var(--color-brand-light-darkest)] border-[var(--color-brand-light-darkest)] data-[interactive=true]:hover:bg-[var(--color-red-100)] dark:text-[var(--color-brand-dark)] dark:border-[var(--color-brand-dark)] dark:data-[interactive=true]:hover:bg-[#1a0008]'
-      },
-      {
-        color: 'primary',
-        variant: 'shadow',
-        class: [
-          'bg-[var(--color-primary)] text-[var(--color-text-dark)] border border-transparent [--chip-shadow:var(--color-primary)]',
-          'shadow-[0_1px_2px_rgba(0,0,0,.12),0_3px_8px_color-mix(in_srgb,var(--chip-shadow)_26%,transparent)]',
-          'data-[interactive=true]:hover:shadow-[0_2px_4px_rgba(0,0,0,.14),0_5px_12px_color-mix(in_srgb,var(--chip-shadow)_34%,transparent)]',
-          'dark:shadow-[0_1px_2px_rgba(0,0,0,.28),0_3px_9px_color-mix(in_srgb,var(--chip-shadow)_22%,transparent)]',
-          'data-[interactive=true]:active:translate-y-[0.5px]'
-        ].join(' ')
-      },
-      {
-        color: 'primary',
-        variant: 'dot',
-        class:
-          'text-[var(--color-brand-light-darkest)] border-[var(--color-red-400)] [--chip-dot:var(--color-primary)] dark:text-[var(--color-brand-dark)] dark:border-[var(--color-brand-dark)]'
-      },
-
-      /* ----------------- SECONDARY ----------------- */
-      {
-        color: 'secondary',
-        variant: 'solid',
-        class: [
-          'bg-[var(--color-surface-raised-light)] text-[var(--color-text-light)]',
-          'data-[interactive=true]:hover:bg-[var(--color-surface-light)]',
-          'dark:bg-[var(--color-surface-raised-dark)] dark:text-[var(--color-text-dark)] dark:border-[var(--color-border-strong-dark)] dark:data-[interactive=true]:hover:bg-[var(--color-surface-dark)]'
-        ].join(' ')
-      },
-      {
-        color: 'secondary',
-        variant: 'light',
-        class:
-          'text-[var(--color-text-light)] data-[interactive=true]:hover:bg-[var(--color-gray-light-200)] dark:text-[var(--color-text-dark)] dark:data-[interactive=true]:hover:bg-[var(--color-gray-dark-700)]'
-      },
-      {
-        color: 'secondary',
-        variant: 'flat',
-        class:
-          'bg-[var(--color-gray-light-200)] text-[var(--color-text-light)] data-[interactive=true]:hover:bg-[var(--color-gray-light-300)] dark:bg-[var(--color-gray-dark-800)] dark:text-[var(--color-text-dark)] dark:data-[interactive=true]:hover:bg-[var(--color-gray-dark-700)]'
-      },
-      {
-        color: 'secondary',
-        variant: 'faded',
-        class:
-          'bg-[var(--color-gray-light-100)] text-[var(--color-text-light)] border-[var(--color-gray-light-300)] data-[interactive=true]:hover:bg-[var(--color-gray-light-200)] dark:bg-[var(--color-gray-dark-700)] dark:text-[var(--color-text-dark)] dark:border-[var(--color-gray-dark-600)]'
-      },
-      {
-        color: 'secondary',
-        variant: 'bordered',
-        class:
-          'text-[var(--color-text-light)] border-[var(--color-gray-light-400)] data-[interactive=true]:hover:bg-[var(--color-gray-light-200)] dark:text-[var(--color-text-dark)] dark:border-[var(--color-gray-dark-400)] dark:data-[interactive=true]:hover:bg-[var(--color-gray-dark-700)]'
-      },
-      {
-        color: 'secondary',
-        variant: 'shadow',
-        class: [
-          'bg-[var(--color-surface-raised-light)] text-[var(--color-text-light)] [--chip-shadow:var(--color-surface-raised-light)]',
-          'dark:bg-[var(--color-surface-raised-dark)] dark:text-[var(--color-text-dark)] dark:border-[var(--color-border-strong-dark)] dark:[--chip-shadow:var(--color-surface-raised-dark)]',
-          'shadow-[0_1px_2px_rgba(0,0,0,.12),0_3px_8px_color-mix(in_srgb,var(--chip-shadow)_24%,transparent)]',
-          'data-[interactive=true]:hover:shadow-[0_2px_4px_rgba(0,0,0,.14),0_5px_12px_color-mix(in_srgb,var(--chip-shadow)_32%,transparent)]'
-        ].join(' ')
-      },
-      {
-        color: 'secondary',
-        variant: 'dot',
-        class:
-          'text-[var(--color-text-light)] border-[var(--color-gray-light-300)] [--chip-dot:var(--color-text-light)] dark:text-[var(--color-text-dark)] dark:border-[var(--color-border-strong-dark)] dark:[--chip-dot:var(--color-text-dark)]'
-      },
-
-      /* ----------------- SUCCESS ----------------- */
-      {
-        color: 'success',
-        variant: 'solid',
-        class:
-          'bg-[var(--color-green)] text-[var(--color-text-light)] data-[interactive=true]:hover:bg-[var(--color-green-dark)]'
-      },
-      {
-        color: 'success',
-        variant: 'light',
-        class:
-          'text-[var(--color-green-dark)] data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-green)_14%,transparent)] dark:text-[var(--color-green-light)] dark:data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-green)_22%,transparent)]'
-      },
-      {
-        color: 'success',
-        variant: 'flat',
-        class:
-          'bg-[color-mix(in_srgb,var(--color-green)_18%,var(--color-gray-light-100))] text-[var(--color-green-dark)] data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-green)_26%,var(--color-gray-light-100))] dark:bg-[color-mix(in_srgb,var(--color-green)_22%,transparent)] dark:text-[var(--color-green-light)] dark:data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-green)_30%,transparent)]'
-      },
-      {
-        color: 'success',
-        variant: 'faded',
-        class:
-          'bg-[color-mix(in_srgb,var(--color-green)_10%,var(--color-gray-light-100))] text-[var(--color-green-dark)] border-[color-mix(in_srgb,var(--color-green)_32%,var(--color-gray-light-100))] data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-green)_16%,var(--color-gray-light-100))] dark:bg-[color-mix(in_srgb,var(--color-green)_16%,transparent)] dark:text-[var(--color-green-light)] dark:border-[color-mix(in_srgb,var(--color-green)_38%,transparent)] dark:data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-green)_24%,transparent)]'
-      },
-      {
-        color: 'success',
-        variant: 'bordered',
-        class:
-          'text-[var(--color-green-dark)] border-[color-mix(in_srgb,var(--color-green)_70%,var(--color-gray-light-100))] data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-green)_12%,transparent)] dark:text-[var(--color-green-light)] dark:border-[color-mix(in_srgb,var(--color-green)_55%,transparent)] dark:data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-green)_20%,transparent)]'
-      },
-      {
-        color: 'success',
-        variant: 'shadow',
-        class: [
-          'bg-[var(--color-green)] text-[var(--color-text-light)] [--chip-shadow:var(--color-green)]',
-          'shadow-[0_1px_2px_rgba(0,0,0,.12),0_3px_8px_color-mix(in_srgb,var(--chip-shadow)_24%,transparent)]',
-          'data-[interactive=true]:hover:shadow-[0_2px_4px_rgba(0,0,0,.14),0_5px_12px_color-mix(in_srgb,var(--chip-shadow)_32%,transparent)]'
-        ].join(' ')
-      },
-      {
-        color: 'success',
-        variant: 'dot',
-        class:
-          'text-[var(--color-green-dark)] border-[color-mix(in_srgb,var(--color-green)_36%,var(--color-gray-light-100))] [--chip-dot:var(--color-green)] dark:text-[var(--color-green-light)] dark:border-[color-mix(in_srgb,var(--color-green)_44%,transparent)]'
-      },
-
-      /* ----------------- WARNING ----------------- */
-      {
-        color: 'warning',
-        variant: 'solid',
-        class:
-          'bg-[var(--color-yellow)] text-[var(--color-text-light)] data-[interactive=true]:hover:bg-[var(--color-yellow-dark)] dark:text-[var(--color-text-light)]'
-      },
-      {
-        color: 'warning',
-        variant: 'light',
-        class:
-          'text-[var(--color-yellow-dark)] data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-yellow)_16%,transparent)] dark:text-[var(--color-yellow-light)] dark:data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-yellow)_22%,transparent)]'
-      },
-      {
-        color: 'warning',
-        variant: 'flat',
-        class:
-          'bg-[color-mix(in_srgb,var(--color-yellow)_22%,var(--color-gray-light-100))] text-[var(--color-text-light)] data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-yellow)_30%,var(--color-gray-light-100))] dark:bg-[color-mix(in_srgb,var(--color-yellow)_20%,transparent)] dark:text-[var(--color-yellow-light)] dark:data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-yellow)_28%,transparent)]'
-      },
-      {
-        color: 'warning',
-        variant: 'faded',
-        class:
-          'bg-[color-mix(in_srgb,var(--color-yellow)_12%,var(--color-gray-light-100))] text-[var(--color-text-light)] border-[color-mix(in_srgb,var(--color-yellow)_36%,var(--color-gray-light-100))] data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-yellow)_18%,var(--color-gray-light-100))] dark:bg-[color-mix(in_srgb,var(--color-yellow)_14%,transparent)] dark:text-[var(--color-yellow-light)] dark:border-[color-mix(in_srgb,var(--color-yellow)_40%,transparent)] dark:data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-yellow)_22%,transparent)]'
-      },
-      {
-        color: 'warning',
-        variant: 'bordered',
-        class:
-          'text-[var(--color-text-light)] border-[color-mix(in_srgb,var(--color-yellow)_78%,var(--color-gray-light-100))] data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-yellow)_14%,transparent)] dark:text-[var(--color-yellow-light)] dark:border-[color-mix(in_srgb,var(--color-yellow)_58%,transparent)] dark:data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-yellow)_20%,transparent)]'
-      },
-      {
-        color: 'warning',
-        variant: 'shadow',
-        class: [
-          'bg-[var(--color-yellow)] text-[var(--color-text-light)] [--chip-shadow:var(--color-yellow)]',
-          'shadow-[0_1px_2px_rgba(0,0,0,.12),0_3px_8px_color-mix(in_srgb,var(--chip-shadow)_24%,transparent)]',
-          'data-[interactive=true]:hover:shadow-[0_2px_4px_rgba(0,0,0,.14),0_5px_12px_color-mix(in_srgb,var(--chip-shadow)_32%,transparent)]'
-        ].join(' ')
-      },
-      {
-        color: 'warning',
-        variant: 'dot',
-        class:
-          'text-[#1a0a00] border-[color-mix(in_srgb,var(--color-yellow)_52%,var(--color-gray-light-100))] [--chip-dot:var(--color-yellow)] dark:text-[var(--color-yellow-light)] dark:border-[color-mix(in_srgb,var(--color-yellow)_52%,transparent)]'
-      },
-
-      /* ----------------- DANGER ----------------- */
-      {
-        color: 'danger',
-        variant: 'solid',
-        class:
-          'bg-[var(--color-red-600)] text-[var(--color-text-dark)] data-[interactive=true]:hover:bg-[var(--color-red-700)]'
-      },
-      {
-        color: 'danger',
-        variant: 'light',
-        class:
-          'text-[var(--color-red-700)] data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-red-600)_14%,transparent)] dark:text-[var(--color-red-300)] dark:data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-red-600)_24%,transparent)]'
-      },
-      {
-        color: 'danger',
-        variant: 'flat',
-        class:
-          'bg-[var(--color-red-100)] text-[var(--color-red-700)] data-[interactive=true]:hover:bg-[var(--color-red-200)] dark:bg-[color-mix(in_srgb,var(--color-red-700)_34%,transparent)] dark:text-[var(--color-red-200)] dark:data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-red-700)_46%,transparent)]'
-      },
-      {
-        color: 'danger',
-        variant: 'faded',
-        class:
-          'bg-[var(--color-red-100)] text-[var(--color-text-light)] border-[var(--color-red-400)] data-[interactive=true]:hover:bg-[var(--color-red-200)] dark:bg-[color-mix(in_srgb,var(--color-red-700)_24%,transparent)] dark:text-[var(--color-red-200)] dark:border-[color-mix(in_srgb,var(--color-red-500)_46%,transparent)] dark:data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-red-700)_34%,transparent)]'
-      },
-      {
-        color: 'danger',
-        variant: 'bordered',
-        class:
-          'text-[var(--color-red-700)] border-[var(--color-red-500)] data-[interactive=true]:hover:bg-[var(--color-red-100)] dark:text-[var(--color-red-300)] dark:border-[var(--color-red-400)] dark:data-[interactive=true]:hover:bg-[color-mix(in_srgb,var(--color-red-700)_28%,transparent)]'
-      },
-      {
-        color: 'danger',
-        variant: 'shadow',
-        class: [
-          'bg-[var(--color-red-600)] text-[var(--color-text-dark)] [--chip-shadow:var(--color-red-600)]',
-          'shadow-[0_1px_2px_rgba(0,0,0,.12),0_3px_8px_color-mix(in_srgb,var(--chip-shadow)_28%,transparent)]',
-          'data-[interactive=true]:hover:shadow-[0_2px_4px_rgba(0,0,0,.14),0_5px_12px_color-mix(in_srgb,var(--chip-shadow)_36%,transparent)]'
-        ].join(' ')
-      },
-      {
-        color: 'danger',
-        variant: 'dot',
-        class:
-          'text-[var(--color-red-700)] border-[var(--color-red-300)] [--chip-dot:var(--color-red-600)] dark:text-[var(--color-red-300)] dark:border-[var(--color-red-400)]'
+      animation: {
+        default: '',
+        pulse: 'motion-safe:animate-pulse motion-reduce:animate-none',
+        bounce: 'motion-safe:animate-bounce motion-reduce:animate-none',
+        ping: 'motion-safe:animate-badgePing motion-reduce:animate-none'
       }
-    ],
+    },
 
     defaultVariants: {
       color: 'primary',

--- a/src/components/atoms/chip/types.ts
+++ b/src/components/atoms/chip/types.ts
@@ -39,7 +39,7 @@ export const chipVariants = cva(
         ].join(' '),
         success: [
           '[--chip-tone:var(--color-green)]',
-          '[--chip-fg:var(--color-green-dark)] dark:[--chip-fg:var(--color-green-light)]',
+          '[--chip-fg:var(--color-text-light)] dark:[--chip-fg:var(--color-text-dark)]',
           '[--chip-solid-bg:var(--color-green)]',
           '[--chip-solid-fg:var(--color-text-light)] dark:[--chip-solid-fg:var(--color-background-dark)]',
           '[--chip-soft-bg:color-mix(in_srgb,var(--chip-tone)_11%,transparent)]',
@@ -50,7 +50,7 @@ export const chipVariants = cva(
         ].join(' '),
         warning: [
           '[--chip-tone:var(--color-yellow)]',
-          '[--chip-fg:var(--color-yellow-dark)] dark:[--chip-fg:var(--color-yellow-light)]',
+          '[--chip-fg:var(--color-text-light)] dark:[--chip-fg:var(--color-text-dark)]',
           '[--chip-solid-bg:var(--color-yellow)]',
           '[--chip-solid-fg:#1a0a00]',
           '[--chip-soft-bg:color-mix(in_srgb,var(--chip-tone)_13%,transparent)]',

--- a/src/components/atoms/chip/useChip.ts
+++ b/src/components/atoms/chip/useChip.ts
@@ -77,18 +77,13 @@ export function useChip(props: ChipProps) {
 
   const avatarSizeClass = size === 'sm' ? 'chip-avatar-sm' : size === 'lg' ? 'chip-avatar-lg' : 'chip-avatar-md';
 
-  const dotColorClass =
-    color === 'secondary'
-      ? 'chip-dot-secondary'
-      : color === 'success'
-        ? 'chip-dot-success'
-        : color === 'warning'
-          ? 'chip-dot-warning'
-          : color === 'danger'
-            ? 'chip-dot-danger'
-            : 'chip-dot-primary';
-
-  const closeBtnBoxBySize = size === 'sm' ? 'h-3 w-3' : size === 'lg' ? 'h-5 w-5' : 'h-4 w-4';
+  const closeBtnBoxBySize = size === 'sm' ? 'h-3.5 w-3.5' : size === 'lg' ? 'h-5 w-5' : 'h-4 w-4';
+  const targetAreaBySize =
+    size === 'sm'
+      ? 'before:inset-[-10px] after:inset-[-15px]'
+      : size === 'lg'
+        ? 'before:inset-[-6px] after:inset-[-12px]'
+        : 'before:inset-[-8px] after:inset-[-14px]';
 
   const closeIconSizeBySize: 10 | 12 | 14 = size === 'sm' ? 10 : size === 'lg' ? 14 : 12;
 
@@ -98,29 +93,39 @@ export function useChip(props: ChipProps) {
       'min-w-0',
       className,
       classNames?.base,
-      interactive ? 'cursor-pointer min-h-11 min-w-11' : 'cursor-auto',
+      interactive ? 'cursor-pointer before:absolute before:content-[""] before:rounded-[inherit]' : 'cursor-auto',
+      interactive && targetAreaBySize,
       splitActions && 'focus-within:shadow-glow-focus-light dark:focus-within:shadow-glow-focus-dark',
-      isSelected && 'ring-2 ring-offset-0 ring-inset ring-primary dark:ring-brand-dark',
+      isSelected &&
+        'border-transparent bg-[var(--chip-solid-bg)] text-[var(--chip-solid-fg)] shadow-glow-focus-light dark:shadow-glow-focus-dark',
       iconBySize
     ),
     content: cn('truncate', classNames?.content),
-    dot: cn('inline-block w-2 h-2 rounded-full shrink-0', dotColorClass, classNames?.dot),
-    avatar: cn('chip-avatar-media shrink-0 ltr:mr-px rtl:ml-px', avatarSizeClass, classNames?.avatar),
+    dot: cn('inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--chip-dot)]', classNames?.dot),
+    avatar: cn(
+      'grid shrink-0 place-items-center overflow-hidden rounded-full ltr:mr-px rtl:ml-px',
+      avatarSizeClass,
+      classNames?.avatar
+    ),
 
     actionButton: cn(
-      'inline-flex min-w-0 min-h-11 min-w-11 flex-1 items-center justify-center gap-0.5 rounded-inherit bg-transparent p-0 m-0 border-0 text-inherit',
-      'focus-visible:outline-none transition-transform duration-200 ease-in-out active:translate-y-px active:scale-95',
+      'relative inline-flex flex-1 items-center justify-center gap-1 rounded-[inherit] border-0 bg-transparent p-0 m-0 text-inherit',
+      'before:absolute before:content-[""] before:rounded-[inherit]',
+      targetAreaBySize,
+      'focus-visible:outline-none transition-transform duration-200 ease-in-out motion-safe:active:translate-y-px motion-safe:active:scale-95',
       'disabled:cursor-not-allowed disabled:opacity-40',
       classNames?.actionButton
     ),
 
     closeButton: cn(
-      'inline-flex min-h-11 min-w-11 items-center justify-center overflow-visible rounded-full',
+      'relative inline-flex items-center justify-center overflow-visible rounded-full',
       'shrink-0 leading-none select-none pointer-events-auto cursor-pointer',
       'p-0 m-0 ltr:-ml-0.5 rtl:-mr-0.5',
       closeBtnBoxBySize,
-      'text-current/80 hover:text-current',
-      'hover:bg-transparent hover:ring-0',
+      'after:absolute after:content-[""]',
+      targetAreaBySize,
+      'text-current/70 hover:text-current',
+      'hover:bg-[var(--chip-soft-bg-hover)] hover:ring-0',
       'focus-visible:outline-none focus-visible:shadow-glow-focus-light dark:focus-visible:shadow-glow-focus-dark',
       'disabled:cursor-not-allowed disabled:pointer-events-none disabled:opacity-40',
       classNames?.closeButton

--- a/src/components/atoms/chip/useChip.ts
+++ b/src/components/atoms/chip/useChip.ts
@@ -78,12 +78,6 @@ export function useChip(props: ChipProps) {
   const avatarSizeClass = size === 'sm' ? 'chip-avatar-sm' : size === 'lg' ? 'chip-avatar-lg' : 'chip-avatar-md';
 
   const closeBtnBoxBySize = size === 'sm' ? 'h-3.5 w-3.5' : size === 'lg' ? 'h-5 w-5' : 'h-4 w-4';
-  const targetAreaBySize =
-    size === 'sm'
-      ? 'before:inset-[-10px] after:inset-[-15px]'
-      : size === 'lg'
-        ? 'before:inset-[-6px] after:inset-[-12px]'
-        : 'before:inset-[-8px] after:inset-[-14px]';
 
   const closeIconSizeBySize: 10 | 12 | 14 = size === 'sm' ? 10 : size === 'lg' ? 14 : 12;
 
@@ -93,8 +87,7 @@ export function useChip(props: ChipProps) {
       'min-w-0',
       className,
       classNames?.base,
-      interactive ? 'cursor-pointer before:absolute before:content-[""] before:rounded-[inherit]' : 'cursor-auto',
-      interactive && targetAreaBySize,
+      interactive ? 'cursor-pointer' : 'cursor-auto',
       splitActions && 'focus-within:shadow-glow-focus-light dark:focus-within:shadow-glow-focus-dark',
       isSelected &&
         'border-transparent bg-[var(--chip-solid-bg)] text-[var(--chip-solid-fg)] shadow-glow-focus-light dark:shadow-glow-focus-dark',
@@ -109,9 +102,7 @@ export function useChip(props: ChipProps) {
     ),
 
     actionButton: cn(
-      'relative inline-flex flex-1 items-center justify-center gap-1 rounded-[inherit] border-0 bg-transparent p-0 m-0 text-inherit',
-      'before:absolute before:content-[""] before:rounded-[inherit]',
-      targetAreaBySize,
+      'inline-flex flex-1 items-center justify-center gap-1 rounded-[inherit] border-0 bg-transparent p-0 m-0 text-inherit',
       'focus-visible:outline-none transition-transform duration-200 ease-in-out motion-safe:active:translate-y-px motion-safe:active:scale-95',
       'disabled:cursor-not-allowed disabled:opacity-40',
       classNames?.actionButton
@@ -122,8 +113,7 @@ export function useChip(props: ChipProps) {
       'shrink-0 leading-none select-none pointer-events-auto cursor-pointer',
       'p-0 m-0 ltr:-ml-0.5 rtl:-mr-0.5',
       closeBtnBoxBySize,
-      'after:absolute after:content-[""]',
-      targetAreaBySize,
+
       'text-current/70 hover:text-current',
       'hover:bg-[var(--chip-soft-bg-hover)] hover:ring-0',
       'focus-visible:outline-none focus-visible:shadow-glow-focus-light dark:focus-visible:shadow-glow-focus-dark',

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -226,6 +226,8 @@
   /* Glow de focus ring */
   --glow-focus-dark: 0 0 0 3px rgba(255, 0, 54, 0.4);
   --glow-focus-light: 0 0 0 3px rgba(219, 20, 60, 0.35);
+  --shadow-glow-focus-dark: var(--glow-focus-dark);
+  --shadow-glow-focus-light: var(--glow-focus-light);
 
   /* Glow ámbar — GitHub stars */
   --glow-amber: 0 0 0 3px rgba(255, 185, 0, 0.12);
@@ -385,3 +387,18 @@
 }
 
 @custom-variant dark (&:where(.dark, .dark *));
+
+@utility chip-avatar-sm {
+  width: var(--size-chip-avatar-sm);
+  height: var(--size-chip-avatar-sm);
+}
+
+@utility chip-avatar-md {
+  width: var(--size-chip-avatar-md);
+  height: var(--size-chip-avatar-md);
+}
+
+@utility chip-avatar-lg {
+  width: var(--size-chip-avatar-lg);
+  height: var(--size-chip-avatar-lg);
+}


### PR DESCRIPTION
## Summary

Refines the Chip visual treatment so the default reads as a compact solid primary chip, not a rounded button, and improves visual review coverage.

Closes #145

## Type of change

- [ ] 🧩 New component
- [ ] 🐛 Bug fix
- [x] 🎨 Design tokens
- [ ] ♿ Accessibility
- [ ] 🏗️ Infrastructure
- [ ] 📚 Documentation

## Component checklist (skip if not applicable)

- [x] Follows the 5-file structure (`types.ts`, `use*.ts`, `Component.tsx`, `index.ts`, `*.stories.tsx`)
- [x] CVA variants defined in `types.ts`, not inline
- [x] No hardcoded colors — uses tokens from `theme.css`
- [x] No `any` types — TypeScript strict
- [x] ARIA attributes present and correct
- [x] Keyboard navigable (Tab, Enter, Escape where applicable)
- [x] Dark mode works correctly
- [x] Storybook stories cover: default, variants, states (hover, focus, disabled)
- [x] Tests added or updated

## Changes

| File | Change |
|------|--------|
| `src/components/atoms/chip/types.ts` | Reworked Chip visual variants around shared CSS variables and solid primary medium defaults. |
| `src/components/atoms/chip/useChip.ts` | Tightened close/action slots, removed visible `min-h-11` sizing, and preserved expanded hit areas without changing visual height. |
| `src/components/atoms/chip/Chip.stories.tsx` | Added usage-review examples and simplified the visual matrix to rely on Storybook theme switching. |
| `src/styles/theme.css` | Added Chip avatar sizing tokens used by the refreshed component. |

## How to test

- [x] `pnpm test`
- [x] `pnpm exec vitest run src/components/atoms/chip/Chip.test.tsx`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run storybook-build`
- [x] `git diff --check`

Manual review:
1. `pnpm run storybook`
2. Open `Atoms/Chip / UsageReview` and `Atoms/Chip / Stress`.
3. Verify default, closable, stress, filter, and status chips feel compact and behave correctly in light/dark mode.

## Screenshots / recordings (if applicable)

Not attached.

## Notes for reviewer

- The visible 44px `min-h-11` target sizing was removed because Storybook action injection made the default chip render too tall.
- Interactive and close targets now use non-layout pseudo-element hit areas, preserving compact visual sizing.
- The repository has a known mismatch where Biome is configured for CRLF while committed files are LF; this PR keeps touched files LF to avoid line-ending churn.
