### PR TITLE
fix(text): complete atom review

### DIFF
--- a/src/components/atoms/text/Text.stories.tsx
+++ b/src/components/atoms/text/Text.stories.tsx
@@ -1,12 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import Text from './Text';
+import { Text } from './Text';
 
 /**
- * ## DESCRIPTION
+ * ## Description
+ * Text renders short and long-form copy with design-system typography tokens.
  *
- * Text component is used to display text content with various styles and options.
- * It supports different fonts, tags, and can render HTML content if it's necessary.
- *
+ * ## Usage Guide
+ * Use `tag` to choose the semantic element, `font` for typography weight presets,
+ * `prominent` for emphasis, and `srOnly` for screen-reader-only helper copy.
+ * HTML rendering is available for trusted rich text and is sanitized before render.
  */
 const meta: Meta<typeof Text> = {
   title: 'Atoms/Text',
@@ -26,52 +28,49 @@ export const Default: Story = {
   args: {
     children: 'Lorem ipsum',
     font: 'secondary',
-    tag: 'p',
     prominent: false,
     srOnly: false,
     isHtml: false
   }
 };
 
-/**
- * - This option allows you to render the text as bold and prominent.
- * - It is useful for highlighting important text.
- */
+/** The `tag` prop controls semantic output while keeping tokenized typography. */
+export const Tags: Story = {
+  render: () => (
+    <div className='grid gap-3'>
+      <Text tag='p'>Paragraph text uses the base body rhythm.</Text>
+      <Text tag='span'>Span text is inline-friendly and keeps the base size.</Text>
+      <Text tag='small'>Small text is intended for captions, hints, and metadata.</Text>
+    </div>
+  )
+};
 
+/** Font presets map to the project typography tokens. */
+export const Fonts: Story = {
+  render: () => (
+    <div className='grid gap-3'>
+      <Text font='primary'>Primary font preset</Text>
+      <Text font='secondary'>Secondary font preset</Text>
+      <Text font='secondaryBold'>Secondary bold font preset</Text>
+    </div>
+  )
+};
+
+/** Use `prominent` for stronger emphasis without changing the semantic tag. */
 export const Prominent: Story = {
   args: {
-    children: 'Lorem ipsum',
+    children: 'Important supporting copy',
     font: 'secondary',
-    tag: 'p',
     prominent: true,
     srOnly: false,
     isHtml: false
   }
 };
 
-/**
- * - This option allows you to render a custom tag instead of the default paragraph (`<p>`).
- * - You can specify any valid HTML tag such as `<span>` or `<small>`.
- */
-export const CustomTag: Story = {
-  args: {
-    children: 'Lorem ipsum',
-    font: 'secondary',
-    tag: 'p',
-    prominent: false,
-    srOnly: false,
-    isHtml: false
-  }
-};
-
-/**
- * - You can asign a id if you need to reference the text element in your application.
- * - This is useful for linking to specific sections or elements within the page.
- */
-
+/** You can assign an `id` when the text needs to be referenced by another element. */
 export const WithId: Story = {
   args: {
-    children: 'Lorem ipsum',
+    children: 'Referenced text content',
     font: 'secondary',
     tag: 'p',
     prominent: false,
@@ -81,30 +80,24 @@ export const WithId: Story = {
   }
 };
 
-/**
- * - You can assign a role to the text element for accessibility purposes.
- */
-
+/** Use live-region roles only when content is dynamic. */
 export const WithRole: Story = {
   args: {
-    children: 'Lorem ipsum',
+    children: 'Saved successfully',
     font: 'secondary',
     tag: 'p',
     prominent: false,
     srOnly: false,
     isHtml: false,
-    role: 'status'
+    role: 'status',
+    ariaLive: 'polite'
   }
 };
 
-/**
- * - This option allows you to render the text as HTML.
- * - Use this when you need to include HTML tags within the text content.
- */
-
+/** HTML content is sanitized before rendering. */
 export const WithHtml: Story = {
   args: {
-    children: '<i>Lorem ipsum</i>',
+    children: '<strong>Formatted</strong> text with <em>safe inline emphasis</em>.',
     font: 'secondary',
     tag: 'p',
     prominent: false,
@@ -113,47 +106,36 @@ export const WithHtml: Story = {
   }
 };
 
-/**
- * - This option allows you to customize the text color using Tailwind CSS classes.
- * - You can specify any valid Tailwind CSS color class to change the text color.
- */
-
-export const CustomColors: Story = {
+/** Slot-level overrides should still use design-system token utilities. */
+export const CustomTone: Story = {
   args: {
-    children: 'Lorem ipsum',
+    children: 'Secondary text tone',
     font: 'secondary',
     tag: 'p',
     prominent: false,
     srOnly: false,
     isHtml: false,
-    className: 'text-yellow dark:text-pink'
+    className: 'text-text-secondary-light dark:text-text-secondary-dark'
   }
 };
-/**
- * - This option allows you to customize the text size using Tailwind CSS classes.
- * - You can specify any valid Tailwind CSS size class to change the text size.
- */
 
+/** Size overrides should use the project fluid type scale. */
 export const CustomSize: Story = {
   args: {
-    children: 'Lorem ipsum',
+    children: 'Heading-sized body copy',
     font: 'secondary',
     tag: 'p',
     prominent: false,
     srOnly: false,
     isHtml: false,
-    className: 'text-2xl'
+    className: 'fs-h6'
   }
 };
 
-/**
- * - This option allows you to set the `aria-live` attribute for accessibility.
- * - It is useful for indicating to screen readers that the content may change dynamically.
- */
-
+/** `aria-live` announces dynamic text changes to assistive technology. */
 export const AriaLive: Story = {
   args: {
-    children: 'Lorem ipsum',
+    children: 'Background sync complete',
     font: 'secondary',
     tag: 'p',
     prominent: false,
@@ -163,15 +145,12 @@ export const AriaLive: Story = {
   }
 };
 
-/**
- * - This option allows you to render the text as screen reader only.
- * - It is useful for providing additional context or information that is not visible to sighted users.
- */
+/** Screen-reader-only text provides accessible context without visible copy. */
 export const ScreenReaderOnly: Story = {
   args: {
-    children: 'Lorem ipsum',
+    children: 'Additional screen reader context',
     font: 'secondary',
-    tag: 'p',
+    tag: 'span',
     prominent: false,
     srOnly: true,
     isHtml: false

--- a/src/components/atoms/text/Text.test.tsx
+++ b/src/components/atoms/text/Text.test.tsx
@@ -22,6 +22,8 @@ describe('useText', () => {
           '<a href="javascript:alert(1)">link</a>',
           '<a href="jav&#x61;script:alert(1)">encoded</a>',
           '<a href="jav&#x09;ascript:alert(1)">control</a>',
+          '<form action="jav&#x09;ascript:alert(1)"></form>',
+          '<button formaction="javascript:alert(1)">submit</button>',
           '<img src="d&#x61;ta:text/html,foo">',
           '<iframe srcdoc="<script>alert(1)</script>"></iframe>',
           '<object data="javascript:alert(1)"></object>',
@@ -30,7 +32,9 @@ describe('useText', () => {
       })
     );
 
-    expect(result.current.sanitizedHtml).toBe('<strong>Safe</strong><a>link</a><a>encoded</a><a>control</a><img>');
+    expect(result.current.sanitizedHtml).toBe(
+      '<strong>Safe</strong><a>link</a><a>encoded</a><a>control</a><form></form><button>submit</button><img>'
+    );
   });
 });
 

--- a/src/components/atoms/text/Text.test.tsx
+++ b/src/components/atoms/text/Text.test.tsx
@@ -1,0 +1,82 @@
+import { render, renderHook, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Text } from './Text';
+import { useText } from './useText';
+
+describe('useText', () => {
+  it('defaults to a paragraph tag and secondary font', () => {
+    const { result } = renderHook(() => useText({ children: 'Default text' }));
+
+    expect(result.current.tag).toBe('p');
+    expect(result.current.className).toContain('font-primary');
+    expect(result.current.className).toContain('fs-base');
+  });
+
+  it('sanitizes html content before rendering', () => {
+    const { result } = renderHook(() =>
+      useText({
+        isHtml: true,
+        children: [
+          '<strong onclick="alert(1)">Safe</strong>',
+          '<script>alert(1)</script>',
+          '<a href="javascript:alert(1)">link</a>',
+          '<a href="jav&#x61;script:alert(1)">encoded</a>',
+          '<img src="d&#x61;ta:text/html,foo">',
+          '<script>alert(1)'
+        ].join('')
+      })
+    );
+
+    expect(result.current.sanitizedHtml).toBe('<strong>Safe</strong><a>link</a><a>encoded</a><img>');
+  });
+});
+
+describe('Text', () => {
+  it('renders as a paragraph by default', () => {
+    render(<Text>Body copy</Text>);
+
+    expect(screen.getByText('Body copy').tagName).toBe('P');
+  });
+
+  it('renders the requested semantic tag', () => {
+    render(<Text tag='small'>Caption</Text>);
+
+    expect(screen.getByText('Caption').tagName).toBe('SMALL');
+  });
+
+  it('applies screen-reader-only styling when srOnly is true', () => {
+    render(
+      <Text tag='span' srOnly={true}>
+        Assistive copy
+      </Text>
+    );
+
+    expect(screen.getByText('Assistive copy')).toHaveClass('sr-only');
+  });
+
+  it('maps ariaLive to the aria-live attribute', () => {
+    render(
+      <Text role='status' ariaLive='polite'>
+        Saved
+      </Text>
+    );
+
+    const status = screen.getByRole('status');
+    expect(status).toHaveAttribute('aria-live', 'polite');
+    expect(status).toHaveTextContent('Saved');
+  });
+
+  it('renders sanitized HTML content', () => {
+    render(
+      <Text isHtml={true}>{'<strong onclick="alert(1)">Safe</strong><a href="javascript:alert(1)">link</a>'}</Text>
+    );
+
+    const strong = screen.getByText('Safe');
+    const link = screen.getByText('link');
+
+    expect(strong.tagName).toBe('STRONG');
+    expect(strong).not.toHaveAttribute('onclick');
+    expect(link.tagName).toBe('A');
+    expect(link).not.toHaveAttribute('href');
+  });
+});

--- a/src/components/atoms/text/Text.test.tsx
+++ b/src/components/atoms/text/Text.test.tsx
@@ -21,13 +21,16 @@ describe('useText', () => {
           '<script>alert(1)</script>',
           '<a href="javascript:alert(1)">link</a>',
           '<a href="jav&#x61;script:alert(1)">encoded</a>',
+          '<a href="jav&#x09;ascript:alert(1)">control</a>',
           '<img src="d&#x61;ta:text/html,foo">',
+          '<iframe srcdoc="<script>alert(1)</script>"></iframe>',
+          '<object data="javascript:alert(1)"></object>',
           '<script>alert(1)'
         ].join('')
       })
     );
 
-    expect(result.current.sanitizedHtml).toBe('<strong>Safe</strong><a>link</a><a>encoded</a><img>');
+    expect(result.current.sanitizedHtml).toBe('<strong>Safe</strong><a>link</a><a>encoded</a><a>control</a><img>');
   });
 });
 

--- a/src/components/atoms/text/Text.tsx
+++ b/src/components/atoms/text/Text.tsx
@@ -1,18 +1,15 @@
-import type { FC } from 'react';
 import type { TextProps } from './types';
 import { useText } from './useText';
 
-const Text: FC<TextProps> = ({ ...props }) => {
+export const Text = (props: TextProps) => {
   const { tag, isHtml, sanitizedHtml, children, ...rest } = useText(props);
   const Component = tag ?? 'p';
   if (isHtml && typeof sanitizedHtml === 'string') {
     return (
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: HTML input is sanitized in useText before rendering.
       <Component {...rest} dangerouslySetInnerHTML={{ __html: sanitizedHtml }} />
     );
   }
 
   return <Component {...rest}>{children}</Component>;
 };
-
-export default Text;

--- a/src/components/atoms/text/index.ts
+++ b/src/components/atoms/text/index.ts
@@ -1,2 +1,2 @@
-export { default as Text } from './Text';
+export { Text } from './Text';
 export * from './types';

--- a/src/components/atoms/text/types.ts
+++ b/src/components/atoms/text/types.ts
@@ -1,10 +1,9 @@
 import { cva, type VariantProps } from 'class-variance-authority';
-import type { ReactNode } from 'react';
+import type { AriaRole, HTMLAttributes, ReactNode } from 'react';
 
 export const textVariants = cva(['font-weight-regular text-text-light dark:text-text-dark'], {
   variants: {
     font: {
-      // Sistema de una sola fuente — todas las variantes usan Space Grotesk Variable
       primary: 'font-primary',
       secondary: 'font-primary',
       secondaryBold: 'font-primary font-weight-bold'
@@ -34,7 +33,9 @@ export const textVariants = cva(['font-weight-regular text-text-light dark:text-
 export type TextVariant = 'p' | 'small' | 'span';
 export type TextFont = 'primary' | 'secondary' | 'secondaryBold';
 
-type BaseTextProps = {
+type NativeTextProps = Omit<HTMLAttributes<HTMLElement>, 'children' | 'className' | 'role'>;
+
+type BaseTextProps = NativeTextProps & {
   /**
    * @control select
    * @default secondary
@@ -44,7 +45,7 @@ type BaseTextProps = {
    * @control select
    * @default p
    */
-  tag: TextVariant;
+  tag?: TextVariant;
   /**
    * @control boolean
    * @default false
@@ -60,7 +61,7 @@ type BaseTextProps = {
   /** @control text */
   className?: string;
   /** @control select */
-  role?: 'status' | 'alert' | 'log' | 'marquee' | 'none';
+  role?: Extract<AriaRole, 'status' | 'alert' | 'log' | 'marquee' | 'none'>;
   /** @control text */
   id?: string;
 } & VariantProps<typeof textVariants>;

--- a/src/components/atoms/text/types.ts
+++ b/src/components/atoms/text/types.ts
@@ -33,7 +33,7 @@ export const textVariants = cva(['font-weight-regular text-text-light dark:text-
 export type TextVariant = 'p' | 'small' | 'span';
 export type TextFont = 'primary' | 'secondary' | 'secondaryBold';
 
-type NativeTextProps = Omit<HTMLAttributes<HTMLElement>, 'children' | 'className' | 'role'>;
+type NativeTextProps = Omit<HTMLAttributes<HTMLElement>, 'children' | 'className' | 'dangerouslySetInnerHTML' | 'role'>;
 
 type BaseTextProps = NativeTextProps & {
   /**

--- a/src/components/atoms/text/useText.ts
+++ b/src/components/atoms/text/useText.ts
@@ -15,7 +15,7 @@ export const useText = ({
   id,
   ...rest
 }: TextProps) => {
-  const sanitizedHtml = isHtml ? sanitizeHtml(children as string) : undefined;
+  const sanitizedHtml = isHtml && typeof children === 'string' ? sanitizeHtml(children) : undefined;
 
   const props = {
     className: cn(textVariants({ font, tag, prominent, srOnly }), className),

--- a/src/utils/sanitizeHtml.ts
+++ b/src/utils/sanitizeHtml.ts
@@ -1,7 +1,7 @@
 const UNSAFE_URL_PATTERN = /^(javascript|data):/i;
 const UNSAFE_ELEMENTS = new Set(['embed', 'iframe', 'object']);
 const UNSAFE_ATTRIBUTES = new Set(['srcdoc']);
-const URL_ATTRIBUTES = new Set(['href', 'src', 'xlink:href']);
+const URL_ATTRIBUTES = new Set(['action', 'formaction', 'href', 'poster', 'src', 'xlink:href']);
 
 const removeControlAndWhitespace = (value: string) =>
   [...value]

--- a/src/utils/sanitizeHtml.ts
+++ b/src/utils/sanitizeHtml.ts
@@ -1,5 +1,15 @@
-const UNSAFE_URL_PATTERN = /^\s*(javascript|data):/i;
+const UNSAFE_URL_PATTERN = /^(javascript|data):/i;
+const UNSAFE_ELEMENTS = new Set(['embed', 'iframe', 'object']);
+const UNSAFE_ATTRIBUTES = new Set(['srcdoc']);
 const URL_ATTRIBUTES = new Set(['href', 'src', 'xlink:href']);
+
+const removeControlAndWhitespace = (value: string) =>
+  [...value]
+    .filter((char) => {
+      const code = char.charCodeAt(0);
+      return code > 0x20 && code !== 0x7f;
+    })
+    .join('');
 
 export function sanitizeHtml(html: string): string {
   const document = new DOMParser().parseFromString(html, 'text/html');
@@ -7,16 +17,21 @@ export function sanitizeHtml(html: string): string {
   document.querySelectorAll('script').forEach((script) => script.remove());
 
   document.querySelectorAll('*').forEach((element) => {
+    if (UNSAFE_ELEMENTS.has(element.tagName.toLowerCase())) {
+      element.remove();
+      return;
+    }
+
     [...element.attributes].forEach((attribute) => {
       const attributeName = attribute.name.toLowerCase();
-      const attributeValue = attribute.value;
+      const normalizedAttributeValue = removeControlAndWhitespace(attribute.value);
 
-      if (attributeName.startsWith('on')) {
+      if (attributeName.startsWith('on') || UNSAFE_ATTRIBUTES.has(attributeName)) {
         element.removeAttribute(attribute.name);
         return;
       }
 
-      if (URL_ATTRIBUTES.has(attributeName) && UNSAFE_URL_PATTERN.test(attributeValue)) {
+      if (URL_ATTRIBUTES.has(attributeName) && UNSAFE_URL_PATTERN.test(normalizedAttributeValue)) {
         element.removeAttribute(attribute.name);
       }
     });

--- a/src/utils/sanitizeHtml.ts
+++ b/src/utils/sanitizeHtml.ts
@@ -1,18 +1,26 @@
+const UNSAFE_URL_PATTERN = /^\s*(javascript|data):/i;
+const URL_ATTRIBUTES = new Set(['href', 'src', 'xlink:href']);
+
 export function sanitizeHtml(html: string): string {
-  const template = document.createElement('template');
-  template.innerHTML = html;
+  const document = new DOMParser().parseFromString(html, 'text/html');
 
-  const scripts = template.content.querySelectorAll('script');
-  scripts.forEach((script) => script.remove());
+  document.querySelectorAll('script').forEach((script) => script.remove());
 
-  const elements = template.content.querySelectorAll('*');
-  elements.forEach((el) => {
-    [...el.attributes].forEach((attr) => {
-      if (attr.name.startsWith('on')) {
-        el.removeAttribute(attr.name);
+  document.querySelectorAll('*').forEach((element) => {
+    [...element.attributes].forEach((attribute) => {
+      const attributeName = attribute.name.toLowerCase();
+      const attributeValue = attribute.value;
+
+      if (attributeName.startsWith('on')) {
+        element.removeAttribute(attribute.name);
+        return;
+      }
+
+      if (URL_ATTRIBUTES.has(attributeName) && UNSAFE_URL_PATTERN.test(attributeValue)) {
+        element.removeAttribute(attribute.name);
       }
     });
   });
 
-  return template.innerHTML;
+  return document.body.innerHTML;
 }


### PR DESCRIPTION
## Summary

Completes the Text atom review checklist by tightening the public API, improving Storybook coverage, adding tests, and hardening sanitized HTML rendering.

Closes #137

## Type of change

- [ ] 🧩 New component
- [x] 🐛 Bug fix
- [ ] 🎨 Design tokens
- [x] ♿ Accessibility
- [ ] 🏗️ Infrastructure
- [x] 📚 Documentation

## Component checklist (skip if not applicable)

- [x] Follows the 5-file structure (`types.ts`, `use*.ts`, `Component.tsx`, `index.ts`, `*.stories.tsx`)
- [x] CVA variants defined in `types.ts`, not inline
- [x] No hardcoded colors — uses tokens from `theme.css`
- [x] No `any` types — TypeScript strict
- [x] ARIA attributes present and correct
- [x] Keyboard navigable (Tab, Enter, Escape where applicable)
- [x] Dark mode works correctly
- [x] Storybook stories cover: default, variants, states (hover, focus, disabled)
- [x] Tests added or updated

## Changes

| File | Change |
|------|--------|
| `src/components/atoms/text/Text.tsx` | Switches to a named component export and keeps sanitized HTML rendering explicit. |
| `src/components/atoms/text/types.ts` | Makes `tag` optional, broadens native text attributes safely, and keeps CVA variants in `types.ts`. |
| `src/components/atoms/text/useText.ts` | Removes avoidable children casting in the HTML branch. |
| `src/components/atoms/text/Text.stories.tsx` | Documents tag, font, ARIA, sr-only, HTML, and token override cases. |
| `src/components/atoms/text/Text.test.tsx` | Adds regression coverage for defaults, semantic tags, srOnly, aria-live, and sanitized HTML. |
| `src/utils/sanitizeHtml.ts` | Hardens rich-text sanitization against scripts, inline handlers, and unsafe URL schemes. |

## How to test

- [x] `pnpm exec vitest run src/components/atoms/text/Text.test.tsx`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run storybook-build`
- [x] `pnpm exec biome check --write src/components/atoms/text/Text.stories.tsx src/components/atoms/text/Text.tsx src/components/atoms/text/Text.test.tsx src/components/atoms/text/index.ts src/components/atoms/text/types.ts src/components/atoms/text/useText.ts src/utils/sanitizeHtml.ts`

Manual review:
1. `pnpm run storybook`
2. Open `Atoms/Text`.
3. Verify default text, tags, fonts, live region, screen-reader-only, and HTML stories render correctly.

## Screenshots / recordings (if applicable)

Not attached.

## Notes for reviewer

- Text files follow the repo's current Biome CRLF configuration.
- `sanitizeHtml` uses DOM parsing so encoded unsafe URL schemes are normalized before attribute removal.
