### PR TITLE
fix(header): complete atom review

### DIFF
--- a/src/components/atoms/header/Header.stories.tsx
+++ b/src/components/atoms/header/Header.stories.tsx
@@ -70,13 +70,13 @@ export const VisualSizes: Story = {
 export const Fonts: Story = {
   render: () => (
     <div className={stackClass}>
-      <Header tag='h2' font='primary'>
+      <Header tag='h4' font='primary'>
         Primary heading
       </Header>
-      <Header tag='h2' font='secondary'>
+      <Header tag='h4' font='secondary'>
         Secondary heading
       </Header>
-      <Header tag='h2' font='secondaryBold'>
+      <Header tag='h4' font='secondaryBold'>
         Secondary bold heading
       </Header>
     </div>

--- a/src/components/atoms/header/Header.stories.tsx
+++ b/src/components/atoms/header/Header.stories.tsx
@@ -1,11 +1,20 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import Header from './Header';
+import { Header } from './Header';
+import type { HeaderVariant } from './types';
+
+const stackClass =
+  'flex flex-col gap-4 rounded-md border border-border-light bg-surface-light p-4 dark:border-border-dark dark:bg-surface-dark';
+const headingTags: HeaderVariant[] = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
 
 /**
- * ## DESCRIPTION
- * Header component is used to display headings in various styles and sizes.
- * It supports different fonts, tags, and styles such as prominent and screen reader only.
+ * ## Description
+ * Header renders semantic `h1` through `h6` headings with design-system typography tokens.
+ * Use it to preserve document outline while keeping heading visuals consistent.
  *
+ * ## Usage Guide
+ * Use `tag` for semantic hierarchy and `size` for visual scale. Keep heading levels
+ * in document order for accessibility; do not pick a semantic tag only for styling.
+ * `fontSize` remains supported as a backwards-compatible alias for `size`.
  */
 const meta: Meta<typeof Header> = {
   title: 'Atoms/Header',
@@ -23,170 +32,99 @@ type Story = StoryObj<typeof Header>;
 
 export const Default: Story = {
   args: {
-    children: 'Lorem ipsum',
+    children: 'Build precise interfaces',
+    font: 'primary',
+    tag: 'h1',
     prominent: false,
-    className: '',
     srOnly: false
   }
 };
 
-/**
- * - Different header tags (h1, h2, h3, h4, h5, h6) with primary font.
- */
-
-export const PrimaryHeader: Story = {
+/** Semantic tags map to matching visual heading sizes by default. */
+export const SemanticTags: Story = {
   render: () => (
-    <div className='flex flex-col gap-4 items-center justify-center'>
-      <Header tag='h1' font='primary'>
-        Lorem Ipsum
-      </Header>
-      <Header tag='h2' font='primary'>
-        Lorem Ipsum
-      </Header>
-      <Header tag='h3' font='primary'>
-        Lorem Ipsum
-      </Header>
-      <Header tag='h4' font='primary'>
-        Lorem Ipsum
-      </Header>
-      <Header tag='h5' font='primary'>
-        Lorem Ipsum
-      </Header>
-      <Header tag='h6' font='primary'>
-        Lorem Ipsum
-      </Header>
+    <div className={stackClass}>
+      {headingTags.map((tag) => (
+        <Header key={tag} tag={tag}>
+          {tag.toUpperCase()} semantic heading
+        </Header>
+      ))}
     </div>
   )
 };
 
-/**
- * - Differnt header tags (h1, h2, h3, h4, h5, h6) with secondary font.
- */
-
-export const SecondaryHeader: Story = {
+/** Size changes visual scale without changing semantic level. */
+export const VisualSizes: Story = {
   render: () => (
-    <div className='flex flex-col gap-4 items-center justify-center'>
-      <Header tag='h1' font='secondary'>
-        Lorem Ipsum
+    <div className={stackClass}>
+      {headingTags.map((size) => (
+        <Header key={size} tag='h2' size={size}>
+          h2 rendered with {size.toUpperCase()} visual scale
+        </Header>
+      ))}
+    </div>
+  )
+};
+
+/** Font presets keep the single project font family while changing emphasis. */
+export const Fonts: Story = {
+  render: () => (
+    <div className={stackClass}>
+      <Header tag='h2' font='primary'>
+        Primary heading
       </Header>
       <Header tag='h2' font='secondary'>
-        Lorem Ipsum
-      </Header>
-      <Header tag='h3' font='secondary'>
-        Lorem Ipsum
-      </Header>
-      <Header tag='h4' font='secondary'>
-        Lorem Ipsum
-      </Header>
-      <Header tag='h5' font='secondary'>
-        Lorem Ipsum
-      </Header>
-      <Header tag='h6' font='secondary'>
-        Lorem Ipsum
-      </Header>
-    </div>
-  )
-};
-
-/**
- * - Differnt header tags (h1, h2, h3, h4, h5, h6) with secondaryBold font.
- */
-
-export const SecondaryHeaderBold: Story = {
-  render: () => (
-    <div className='flex flex-col gap-4 items-center justify-center'>
-      <Header tag='h1' font='secondaryBold'>
-        Lorem Ipsum
+        Secondary heading
       </Header>
       <Header tag='h2' font='secondaryBold'>
-        Lorem Ipsum
-      </Header>
-      <Header tag='h3' font='secondaryBold'>
-        Lorem Ipsum
-      </Header>
-      <Header tag='h4' font='secondaryBold'>
-        Lorem Ipsum
-      </Header>
-      <Header tag='h5' font='secondaryBold'>
-        Lorem Ipsum
-      </Header>
-      <Header tag='h6' font='secondaryBold'>
-        Lorem Ipsum
+        Secondary bold heading
       </Header>
     </div>
   )
 };
 
-/**
- * - You can use fontSize prop to change the font size of the header not changing the tag.
- *   For example, you can use `fontSize="h1"` to make the header look like an h1 tag but keep it as an h2 tag.
- */
-
-export const FontSize: Story = {
-  render: () => (
-    <div className='flex flex-col gap-4 items-center justify-center'>
-      <Header tag='h5' fontSize='h1'>
-        Lorem Ipsum
-      </Header>
-      <Header tag='h1' fontSize='h5'>
-        Lorem Ipsum
-      </Header>
-    </div>
-  )
-};
-
-/**
- * - Prominent prop makes the header bold.
- */
+/** Prominent headings increase emphasis without changing semantic level. */
 export const Prominent: Story = {
   args: {
-    children: 'Lorem ipsum',
-    font: 'secondaryBold',
-    tag: 'h1',
+    children: 'Prominent heading',
+    font: 'primary',
+    tag: 'h2',
     prominent: true,
     srOnly: false
   }
 };
 
-/**
- * - The `srOnly` prop hides the header visually but keeps it accessible for screen readers.
- */
-
+/** Screen-reader-only headings provide accessible structure without visible text. */
 export const ScreenReaderOnly: Story = {
   args: {
-    children: 'Lorem ipsum',
-    font: 'secondaryBold',
-    tag: 'h1',
+    children: 'Hidden section heading',
+    font: 'primary',
+    tag: 'h2',
     prominent: false,
     srOnly: true
   }
 };
 
-/**
- * - You can use the `id` prop to set an ID for the header, which is useful for accessibility and linking.
- */
+/** IDs allow headings to be referenced by links and ARIA relationships. */
 export const WithId: Story = {
   args: {
-    children: 'Lorem ipsum',
-    font: 'secondaryBold',
-    tag: 'h1',
+    children: 'Referenced heading',
+    font: 'primary',
+    tag: 'h2',
+    id: 'header-id',
     prominent: false,
-    srOnly: false,
-    id: 'header-id'
+    srOnly: false
   }
 };
 
-/**
- * - You can customize the header with a className.
- */
-
-export const CustomColor: Story = {
+/** Slot-level color overrides should use design-system token utilities. */
+export const CustomTone: Story = {
   args: {
-    children: 'Lorem ipsum',
-    font: 'secondaryBold',
-    tag: 'h1',
+    children: 'Secondary tone heading',
+    font: 'primary',
+    tag: 'h2',
     prominent: false,
     srOnly: false,
-    className: 'text-pink dark:text-pink'
+    className: 'text-text-secondary-light dark:text-text-secondary-dark'
   }
 };

--- a/src/components/atoms/header/Header.test.tsx
+++ b/src/components/atoms/header/Header.test.tsx
@@ -1,0 +1,50 @@
+import { render, renderHook, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Header } from './Header';
+import { useHeader } from './useHeader';
+
+describe('useHeader — logic', () => {
+  it('returns h1 semantics by default', () => {
+    const { result } = renderHook(() => useHeader({ children: 'Heading' }));
+    expect(result.current.tag).toBe('h1');
+  });
+
+  it('uses tag as visual size by default', () => {
+    const { result } = renderHook(() => useHeader({ children: 'Heading', tag: 'h3' }));
+    expect(result.current.className).toContain('fs-h3');
+    expect(result.current.className).not.toContain('fs-h1');
+  });
+
+  it('allows visual size to differ from semantic tag', () => {
+    const { result } = renderHook(() => useHeader({ children: 'Heading', tag: 'h2', size: 'h5' }));
+    expect(result.current.tag).toBe('h2');
+    expect(result.current.className).toContain('fs-h5');
+  });
+
+  it('keeps fontSize as a backwards-compatible visual size alias', () => {
+    const { result } = renderHook(() => useHeader({ children: 'Heading', tag: 'h2', fontSize: 'h4' }));
+    expect(result.current.className).toContain('fs-h4');
+  });
+});
+
+describe('Header — component behavior', () => {
+  it('renders an h1 by default', () => {
+    render(<Header>Heading</Header>);
+    expect(screen.getByRole('heading', { level: 1, name: 'Heading' })).toBeInTheDocument();
+  });
+
+  it('renders the requested semantic heading level', () => {
+    render(<Header tag='h3'>Section heading</Header>);
+    expect(screen.getByRole('heading', { level: 3, name: 'Section heading' })).toBeInTheDocument();
+  });
+
+  it('applies id for accessible references', () => {
+    render(<Header id='heading-id'>Referenced heading</Header>);
+    expect(screen.getByRole('heading', { name: 'Referenced heading' })).toHaveAttribute('id', 'heading-id');
+  });
+
+  it('keeps screen-reader-only heading in the accessibility tree', () => {
+    render(<Header srOnly={true}>Hidden heading</Header>);
+    expect(screen.getByRole('heading', { name: 'Hidden heading' })).toBeInTheDocument();
+  });
+});

--- a/src/components/atoms/header/Header.test.tsx
+++ b/src/components/atoms/header/Header.test.tsx
@@ -26,6 +26,14 @@ describe('useHeader — logic', () => {
     expect(result.current.className).toContain('fs-h4');
   });
 
+  it('applies font weight presets', () => {
+    const secondary = renderHook(() => useHeader({ children: 'Heading', font: 'secondary' }));
+    const secondaryBold = renderHook(() => useHeader({ children: 'Heading', font: 'secondaryBold' }));
+
+    expect(secondary.result.current.className).toContain('font-medium');
+    expect(secondaryBold.result.current.className).toContain('font-bold');
+  });
+
   it('prefers size over the backwards-compatible fontSize alias', () => {
     const { result } = renderHook(() => useHeader({ children: 'Heading', tag: 'h2', size: 'h3', fontSize: 'h4' }));
     expect(result.current.className).toContain('fs-h3');

--- a/src/components/atoms/header/Header.test.tsx
+++ b/src/components/atoms/header/Header.test.tsx
@@ -25,6 +25,12 @@ describe('useHeader — logic', () => {
     const { result } = renderHook(() => useHeader({ children: 'Heading', tag: 'h2', fontSize: 'h4' }));
     expect(result.current.className).toContain('fs-h4');
   });
+
+  it('prefers size over the backwards-compatible fontSize alias', () => {
+    const { result } = renderHook(() => useHeader({ children: 'Heading', tag: 'h2', size: 'h3', fontSize: 'h4' }));
+    expect(result.current.className).toContain('fs-h3');
+    expect(result.current.className).not.toContain('fs-h4');
+  });
 });
 
 describe('Header — component behavior', () => {

--- a/src/components/atoms/header/Header.tsx
+++ b/src/components/atoms/header/Header.tsx
@@ -2,10 +2,9 @@ import type { FC } from 'react';
 import type { HeaderProps } from './types';
 import { useHeader } from './useHeader';
 
-const Header: FC<HeaderProps> = ({ ...props }) => {
+export const Header: FC<HeaderProps> = (props) => {
   const { tag, children, ...rest } = useHeader(props);
-  const Component = tag ?? 'h1';
+  const Component = tag;
+
   return <Component {...rest}>{children}</Component>;
 };
-
-export default Header;

--- a/src/components/atoms/header/index.ts
+++ b/src/components/atoms/header/index.ts
@@ -1,2 +1,2 @@
-export { default as Header } from './Header';
+export { Header } from './Header';
 export * from './types';

--- a/src/components/atoms/header/types.ts
+++ b/src/components/atoms/header/types.ts
@@ -1,15 +1,14 @@
 import { cva, type VariantProps } from 'class-variance-authority';
-import type { ReactNode } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
 
-export const headerVariants = cva(['font-normal leading-[1.2] text-text-light dark:text-text-dark'], {
+export const headerVariants = cva('font-primary text-text-light dark:text-text-dark', {
   variants: {
     font: {
-      // Sistema de una sola fuente — todas las variantes usan Space Grotesk Variable
       primary: 'font-primary',
       secondary: 'font-primary',
       secondaryBold: 'font-primary font-weight-bold'
     },
-    tag: {
+    size: {
       h1: 'fs-h1',
       h2: 'fs-h2',
       h3: 'fs-h3',
@@ -18,7 +17,7 @@ export const headerVariants = cva(['font-normal leading-[1.2] text-text-light da
       h6: 'fs-h6'
     },
     prominent: {
-      true: 'font-bold',
+      true: 'font-weight-bold',
       false: ''
     },
     srOnly: {
@@ -28,30 +27,55 @@ export const headerVariants = cva(['font-normal leading-[1.2] text-text-light da
   },
   defaultVariants: {
     font: 'primary',
-    tag: 'h1',
+    size: 'h1',
     prominent: false,
     srOnly: false
   }
 });
 
+export type HeaderVariantProps = VariantProps<typeof headerVariants>;
 export type HeaderVariant = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-export type HeaderFont = 'primary' | 'secondary' | 'secondaryBold';
+export type HeaderFont = NonNullable<HeaderVariantProps['font']>;
+export type HeaderSize = NonNullable<HeaderVariantProps['size']>;
 
-export type HeaderProps = {
-  /** @control text */
-  children?: ReactNode;
-  /** @control select */
-  font?: HeaderFont;
-  /** @control select */
-  tag: HeaderVariant;
-  /** @control select */
-  fontSize?: HeaderVariant;
-  /** @control boolean */
-  prominent?: boolean;
-  /** @control text */
-  className?: string;
-  /** @control boolean */
-  srOnly?: boolean;
-  /** @control text */
-  id?: string; // Nuevo prop opcional para accesibilidad
-} & VariantProps<typeof headerVariants>;
+type NativeHeaderProps = Omit<HTMLAttributes<HTMLHeadingElement>, 'children' | 'className'>;
+
+export type HeaderProps = Omit<HeaderVariantProps, 'font' | 'size'> &
+  NativeHeaderProps & {
+    /** @control text */
+    children: ReactNode;
+    /**
+     * @control select
+     * @default primary
+     */
+    font?: HeaderFont;
+    /**
+     * @control select
+     * @default h1
+     */
+    tag?: HeaderVariant;
+    /**
+     * @control select
+     * @default h1
+     */
+    size?: HeaderSize;
+    /**
+     * @control select
+     * @default undefined
+     */
+    fontSize?: HeaderSize;
+    /**
+     * @control boolean
+     * @default false
+     */
+    prominent?: boolean;
+    /** @control text */
+    className?: string;
+    /**
+     * @control boolean
+     * @default false
+     */
+    srOnly?: boolean;
+    /** @control text */
+    id?: string;
+  };

--- a/src/components/atoms/header/types.ts
+++ b/src/components/atoms/header/types.ts
@@ -38,7 +38,7 @@ export type HeaderVariant = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 export type HeaderFont = NonNullable<HeaderVariantProps['font']>;
 export type HeaderSize = NonNullable<HeaderVariantProps['size']>;
 
-type NativeHeaderProps = Omit<HTMLAttributes<HTMLHeadingElement>, 'children' | 'className'>;
+type NativeHeaderProps = Omit<HTMLAttributes<HTMLHeadingElement>, 'children' | 'className' | 'dangerouslySetInnerHTML'>;
 
 export type HeaderProps = Omit<HeaderVariantProps, 'font' | 'size'> &
   NativeHeaderProps & {

--- a/src/components/atoms/header/types.ts
+++ b/src/components/atoms/header/types.ts
@@ -5,8 +5,8 @@ export const headerVariants = cva('font-primary text-text-light dark:text-text-d
   variants: {
     font: {
       primary: 'font-primary',
-      secondary: 'font-primary',
-      secondaryBold: 'font-primary font-weight-bold'
+      secondary: 'font-primary font-medium',
+      secondaryBold: 'font-primary font-bold'
     },
     size: {
       h1: 'fs-h1',
@@ -17,7 +17,7 @@ export const headerVariants = cva('font-primary text-text-light dark:text-text-d
       h6: 'fs-h6'
     },
     prominent: {
-      true: 'font-weight-bold',
+      true: 'font-bold',
       false: ''
     },
     srOnly: {

--- a/src/components/atoms/header/useHeader.ts
+++ b/src/components/atoms/header/useHeader.ts
@@ -18,7 +18,7 @@ export const useHeader = ({
   id,
   ...rest
 }: HeaderProps): UseHeaderReturn => {
-  const resolvedSize = fontSize ?? size ?? tag;
+  const resolvedSize = size ?? fontSize ?? tag;
 
   return {
     tag,

--- a/src/components/atoms/header/useHeader.ts
+++ b/src/components/atoms/header/useHeader.ts
@@ -1,49 +1,30 @@
 import { cn } from '@/lib/utils';
 import { type HeaderProps, headerVariants } from './types';
 
+type UseHeaderReturn = HeaderProps & {
+  tag: NonNullable<HeaderProps['tag']>;
+  className: string;
+};
+
 export const useHeader = ({
   font = 'primary',
   tag = 'h1',
+  size,
+  fontSize,
   prominent = false,
   className,
   children,
   srOnly = false,
   id,
-  fontSize,
   ...rest
-}: HeaderProps) => {
-  const fontByTag = (fs: string) => {
-    switch (fs) {
-      case 'h1':
-        return 'fs-h1';
-      case 'h2':
-        return 'fs-h2';
-      case 'h3':
-        return 'fs-h3';
-      case 'h4':
-        return 'fs-h4';
-      case 'h5':
-        return 'fs-h5';
-      case 'h6':
-        return 'fs-h6';
-      default:
-        return '';
-    }
-  };
-
-  const prop = {
-    className: cn(
-      fontSize ? fontByTag(fontSize) : headerVariants({ tag }),
-      headerVariants({ font, prominent, srOnly }),
-      className
-    ),
-    id: id || undefined,
-    ...rest
-  };
+}: HeaderProps): UseHeaderReturn => {
+  const resolvedSize = fontSize ?? size ?? tag;
 
   return {
     tag,
     children,
-    ...prop
+    className: cn(headerVariants({ font, size: resolvedSize, prominent, srOnly }), className),
+    id: id || undefined,
+    ...rest
   };
 };


### PR DESCRIPTION
## Summary

Completes the Header atom review checklist.

Closes #128

## Type of change

- [ ] 🧩 New component
- [x] 🐛 Bug fix
- [ ] 🎨 Design tokens
- [x] ♿ Accessibility
- [ ] 🏗️ Infrastructure
- [ ] 📚 Documentation

## Component checklist (skip if not applicable)

- [x] Follows the 5-file structure (`types.ts`, `use*.ts`, `Component.tsx`, `index.ts`, `*.stories.tsx`)
- [x] CVA variants defined in `types.ts`, not inline
- [x] No hardcoded colors — uses tokens from `theme.css`
- [x] No `any` types — TypeScript strict
- [x] ARIA attributes present and correct
- [x] Keyboard navigable (Tab, Enter, Escape where applicable)
- [x] Dark mode works correctly
- [x] Storybook stories cover: default, variants, states (hover, focus, disabled)
- [x] Tests added or updated

## How to test

1. `pnpm test -- src/components/atoms/header/Header.test.tsx`
2. `pnpm exec biome check src/components/atoms/header`
3. `pnpm exec tsc --noEmit`
4. `pnpm run storybook-build`
5. Open Storybook and verify Header stories for semantic tags, visual sizes, sr-only, id, and custom tone.

## Screenshots / recordings (if applicable)

Not included.

## Notes for reviewer

- Fixes the previous class composition bug where a requested heading size could also receive the default `fs-h1` class.
- `tag` controls semantic heading level. `size` controls visual scale. `fontSize` remains supported as a backwards-compatible alias for `size`.
- Header is non-interactive, so keyboard behavior is native/not applicable beyond standard heading semantics.
