### PR TITLE
fix(link): complete atom review

### DIFF
--- a/src/components/atoms/link/Link.stories.tsx
+++ b/src/components/atoms/link/Link.stories.tsx
@@ -1,181 +1,250 @@
+import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
-import { fn } from '@storybook/test';
-import Link from './Link';
+import type { ReactNode } from 'react';
+import { Link } from './Link';
+
+const StoryCanvas = ({ children }: { children: ReactNode }) => (
+  <section className='mx-auto my-xl flex max-w-4xl flex-col gap-5 p-lg'>{children}</section>
+);
+
+const VariantRow = ({ children }: { children: ReactNode }) => (
+  <div className='flex flex-wrap items-center gap-4'>{children}</div>
+);
 
 /**
+ * ## Description
+ * Link renders navigation and action affordances with Stack-and-Flow typography, focus, and token styling.
  *
- * ## DESCRIPTION
- * Link component for navigation and actions.
+ * ## Dependencies
+ * Uses `lucide-react/dynamic` when the optional `icon` prop is provided.
  *
- * ## DEPENDENCIES
- * - Icon: Uses Icon component from `lucide-react` for icons.
- *
+ * ## Usage Guide
+ * Use `regular` for inline navigation, `outlined` for secondary call-to-action links, and `button` when a link must visually match a primary action while preserving link semantics when `href` is present. When `href` is omitted, Link behaves as a local action control with button semantics and keyboard activation.
  */
-
 const meta: Meta<typeof Link> = {
   title: 'Atoms/Link',
   component: Link,
   parameters: {
+    layout: 'fullscreen',
     docs: {
       autodocs: true
     }
   },
   tags: ['autodocs']
 };
+
 export default meta;
 
 type Story = StoryObj<typeof Link>;
 
+/**
+ * Shows the default inline link for body copy, release notes, and low-emphasis navigation.
+ */
 export const Default: Story = {
   args: {
-    variant: 'regular',
-    href: '',
-    target: '_blank',
-    size: 'md',
-    children: 'Lorem ipsum',
-    className: '',
-    title: ''
-  }
-};
-
-/**
- * - Regular: Default link style.
- * - ⚠️ This variant uses a transparent background by default. To ensure proper visibility, place it inside a container with a solid or plain background.
- */
-
-export const Regular: Story = {
-  render: () => (
-    <div className='flex gap-4 items-center'>
-      <Link size='sm' href='https://github.com/egdev6'>
-        Lorem Ipsum
-      </Link>
-      <Link size='md' href='https://github.com/egdev6'>
-        Lorem Ipsum
-      </Link>
-      <Link size='lg' href='https://github.com/egdev6'>
-        Lorem Ipsum
-      </Link>
-    </div>
+    children: 'Read the release notes',
+    href: 'https://github.com/egdev6'
+  },
+  render: (args) => (
+    <StoryCanvas>
+      <p className='fs-base text-text-light dark:text-text-dark'>
+        Follow the product update in <Link {...args} /> for migration notes and release context.
+      </p>
+    </StoryCanvas>
   )
 };
 
 /**
- * - Outlined: Link with outlined style.
- * - ⚠️ This variant uses a transparent background by default. To ensure proper visibility, place it inside a container with a solid or plain background.
+ * Shows the three visual hierarchy levels: inline, secondary CTA, and primary CTA.
  */
-
-export const Outlined: Story = {
+export const Variants: Story = {
   render: () => (
-    <div className='flex gap-4 items-center'>
-      <Link size='sm' variant='outlined' href='https://github.com/egdev6'>
-        Lorem Ipsum
-      </Link>
-      <Link size='md' variant='outlined' href='https://github.com/egdev6'>
-        Lorem Ipsum
-      </Link>
-      <Link size='lg' variant='outlined' href='https://github.com/egdev6'>
-        Lorem Ipsum
-      </Link>
-    </div>
-  )
-};
-/**
- * - Button: Link styled as a button.
- */
-
-export const Button: Story = {
-  render: () => (
-    <div className='flex gap-4 items-center'>
-      <Link size='sm' variant='button' onClick={fn()}>
-        Lorem Ipsum
-      </Link>
-      <Link size='md' variant='button' onClick={fn()}>
-        Lorem Ipsum
-      </Link>
-      <Link size='lg' variant='button' onClick={fn()}>
-        Lorem Ipsum
-      </Link>
-    </div>
+    <StoryCanvas>
+      <VariantRow>
+        <Link href='https://github.com/egdev6'>Inline link</Link>
+        <Link variant='outlined' href='https://github.com/egdev6'>
+          Secondary CTA
+        </Link>
+        <Link variant='button' href='https://github.com/egdev6' onClick={action('primary-link-click')}>
+          Primary CTA
+        </Link>
+      </VariantRow>
+    </StoryCanvas>
   )
 };
 
 /**
- * - With Icon: Link with an icon.
+ * Shows CTA-style links with their default glow and with glow disabled for quieter layouts.
+ * Regular inline links stay glowless regardless of this option.
  */
+export const Shadow: Story = {
+  render: () => (
+    <StoryCanvas>
+      <div className='grid gap-4'>
+        <VariantRow>
+          <Link variant='outlined' href='https://github.com/egdev6'>
+            Outlined with glow
+          </Link>
+          <Link variant='outlined' shadow={false} href='https://github.com/egdev6'>
+            Outlined without glow
+          </Link>
+        </VariantRow>
+        <VariantRow>
+          <Link variant='button' href='https://github.com/egdev6'>
+            Primary with glow
+          </Link>
+          <Link variant='button' shadow={false} href='https://github.com/egdev6'>
+            Primary without glow
+          </Link>
+        </VariantRow>
+      </div>
+    </StoryCanvas>
+  )
+};
 
+/**
+ * Shows how size changes typography and horizontal rhythm while preserving each variant treatment.
+ */
+export const Sizes: Story = {
+  render: () => (
+    <StoryCanvas>
+      <div className='grid gap-4'>
+        <VariantRow>
+          <Link size='sm' href='https://github.com/egdev6'>
+            Small inline
+          </Link>
+          <Link size='md' href='https://github.com/egdev6'>
+            Medium inline
+          </Link>
+          <Link size='lg' href='https://github.com/egdev6'>
+            Large inline
+          </Link>
+        </VariantRow>
+        <VariantRow>
+          <Link size='sm' variant='outlined' href='https://github.com/egdev6'>
+            Small outlined
+          </Link>
+          <Link size='md' variant='outlined' href='https://github.com/egdev6'>
+            Medium outlined
+          </Link>
+          <Link size='lg' variant='outlined' href='https://github.com/egdev6'>
+            Large outlined
+          </Link>
+        </VariantRow>
+        <VariantRow>
+          <Link size='sm' variant='button' href='https://github.com/egdev6'>
+            Small button
+          </Link>
+          <Link size='md' variant='button' href='https://github.com/egdev6'>
+            Medium button
+          </Link>
+          <Link size='lg' variant='button' href='https://github.com/egdev6'>
+            Large button
+          </Link>
+        </VariantRow>
+      </div>
+    </StoryCanvas>
+  )
+};
+
+/**
+ * Shows icons inheriting current text color and keeping alignment consistent across variants.
+ */
 export const WithIcon: Story = {
   render: () => (
-    <div className='flex gap-4 items-center'>
-      <Link size='md' icon='image' href='https://github.com/egdev6'>
-        Lorem Ipsum
-      </Link>
-      <Link size='md' variant='outlined' icon='image' href='https://github.com/egdev6'>
-        Lorem Ipsum
-      </Link>
-      <Link size='md' variant='button' icon='image' onClick={fn()}>
-        Lorem Ipsum
-      </Link>
-    </div>
+    <StoryCanvas>
+      <VariantRow>
+        <Link icon='external-link' href='https://github.com/egdev6'>
+          External link
+        </Link>
+        <Link variant='outlined' icon='arrow-right' href='https://github.com/egdev6'>
+          Continue
+        </Link>
+        <Link variant='button' icon='download' href='https://github.com/egdev6'>
+          Download
+        </Link>
+      </VariantRow>
+    </StoryCanvas>
   )
 };
 
 /**
- * - You can change the target of the link to open in a new tab or the same tab.
- * - Use the `target` prop to specify the link behavior.
+ * Shows disabled links preserving their color treatment while reducing affordance through opacity and cursor state.
+ */
+export const Disabled: Story = {
+  render: () => (
+    <StoryCanvas>
+      <VariantRow>
+        <Link disabled={true} href='https://github.com/egdev6'>
+          Inline disabled
+        </Link>
+        <Link disabled={true} variant='outlined' href='https://github.com/egdev6'>
+          Outlined disabled
+        </Link>
+        <Link disabled={true} variant='button' href='https://github.com/egdev6'>
+          Button disabled
+        </Link>
+      </VariantRow>
+    </StoryCanvas>
+  )
+};
+
+/**
+ * Shows target values changing navigation behavior while preserving accessible link semantics.
  */
 export const Target: Story = {
   render: () => (
-    <div className='flex gap-4 items-center'>
-      <Link size='md' href='https://github.com/egdev6' target='_blank' title='Open in new tab'>
-        Open in new tab
-      </Link>
-      <Link size='md' href='https://github.com/egdev6' target='_self' title='Open in same tab'>
-        Open in same tab
-      </Link>
-      <Link size='md' href='https://github.com/egdev6' target='_parent' title='Open in parent frame'>
-        Open in parent frame
-      </Link>
-      <Link size='md' href='https://github.com/egdev6' target='_top' title='Open in top frame'>
-        Open in top frame
-      </Link>
-    </div>
+    <StoryCanvas>
+      <VariantRow>
+        <Link href='https://github.com/egdev6' target='_blank' title='Open in new tab'>
+          New tab
+        </Link>
+        <Link href='https://github.com/egdev6' target='_self' title='Open in same tab'>
+          Same tab
+        </Link>
+        <Link href='https://github.com/egdev6' target='_parent' title='Open in parent frame'>
+          Parent frame
+        </Link>
+        <Link href='https://github.com/egdev6' target='_top' title='Open in top frame'>
+          Top frame
+        </Link>
+      </VariantRow>
+    </StoryCanvas>
   )
 };
 
 /**
- * - Accessibility: The `title` prop is used to provide a tooltip or description for the link.
- * - Use the `title` attribute to provide additional context for screen readers.
+ * Shows title-backed accessible labels when visible text alone is not enough.
  */
-
 export const Accessibility: Story = {
   render: () => (
-    <div className='flex gap-4 items-center'>
-      <Link size='md' href='https://github.com/egdev6' title='GitHub Profile'>
-        GitHub Profile
-      </Link>
-    </div>
+    <StoryCanvas>
+      <VariantRow>
+        <Link href='https://github.com/egdev6' title='Open the Stack and Flow GitHub profile'>
+          GitHub profile
+        </Link>
+        <Link variant='button' href='https://github.com/egdev6' title='Open documentation in a new tab'>
+          Documentation
+        </Link>
+      </VariantRow>
+    </StoryCanvas>
   )
 };
 
 /**
- * - Custom Class: You can add custom classes to the link for additional styling.
- * - You need to override the default classes using `!important` to ensure your styles take precedence.
+ * Shows local action behavior when no `href` is provided; these controls expose button semantics and support pointer plus keyboard activation.
  */
-
-export const CustomClass: Story = {
+export const ActionSemantics: Story = {
   render: () => (
-    <div className='flex gap-4 items-center'>
-      <Link size='md' href='https://github.com/egdev6' icon='arrow-right' className='!flex-row-reverse'>
-        Custom Class Link
-      </Link>
-      <Link
-        size='md'
-        variant='outlined'
-        href='https://github.com/egdev6'
-        className='!border-blue-dark !bg-blue-dark !text-white hover:!bg-blue hover:!border-blue hover:!shadow-blue-dark'
-      >
-        Custom Class Link
-      </Link>
-    </div>
+    <StoryCanvas>
+      <VariantRow>
+        <Link variant='button' onClick={action('local-link-action')}>
+          Run local action
+        </Link>
+        <Link variant='outlined' onClick={action('secondary-local-link-action')}>
+          Secondary action
+        </Link>
+      </VariantRow>
+    </StoryCanvas>
   )
 };

--- a/src/components/atoms/link/Link.test.tsx
+++ b/src/components/atoms/link/Link.test.tsx
@@ -121,6 +121,16 @@ describe('Link — component behavior', () => {
     expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute('rel', 'nofollow noopener noreferrer');
   });
 
+  it('preserves caller aria-label over derived labels', () => {
+    render(
+      <Link href='https://example.com' aria-label='Read migration guide' title='Open docs'>
+        Docs
+      </Link>
+    );
+    const link = screen.getByRole('link', { name: 'Read migration guide' });
+    expect(link).toHaveAttribute('title', 'Open docs');
+  });
+
   it('uses title as aria-label and title attribute', () => {
     render(
       <Link href='https://example.com' title='Open docs'>
@@ -139,6 +149,15 @@ describe('Link — component behavior', () => {
     );
     expect(screen.getByRole('link', { name: 'Docs' })).toBeInTheDocument();
     expect(screen.getByTestId('link-icon')).toHaveAttribute('data-icon', 'image');
+  });
+
+  it('uses caller aria-label for icon-only links', () => {
+    render(
+      <Link href='https://example.com' icon='image' aria-label='Open image gallery'>
+        <span aria-hidden='true' />
+      </Link>
+    );
+    expect(screen.getByRole('link', { name: 'Open image gallery' })).toBeInTheDocument();
   });
 
   it('does not leak visual variant, size, or shadow props to the DOM', () => {

--- a/src/components/atoms/link/Link.test.tsx
+++ b/src/components/atoms/link/Link.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * Link.test.tsx — behavior tests for Stack-and-Flow Design System
+ *
+ * Strategy:
+ * - Hook (useLink): tested with renderHook for derived attributes and state.
+ * - Component (Link): tested with render/screen/userEvent for observable behavior.
+ *
+ * We test behavior, not internal CSS class strings.
+ */
+
+import { render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+// --- Mocks (declared before component import) ---
+
+vi.mock('lucide-react/dynamic', () => ({
+  // biome-ignore lint/style/useNamingConvention: must match library export name
+  DynamicIcon: ({ name }: { name: string }) => <span aria-hidden='true' data-icon={name} data-testid='link-icon' />
+}));
+
+// --- Imports after mocks ---
+
+import { Link } from './Link';
+import { useLink } from './useLink';
+
+// ─────────────────────────────────────────────
+// HOOK TESTS — useLink
+// ─────────────────────────────────────────────
+
+describe('useLink — logic', () => {
+  it('returns target _blank by default', () => {
+    const { result } = renderHook(() => useLink({ children: 'Docs' }));
+    expect(result.current.target).toBe('_blank');
+  });
+
+  it('marks _blank links as external', () => {
+    const { result } = renderHook(() => useLink({ children: 'Docs', target: '_blank' }));
+    expect(result.current.isExternal).toBe(true);
+  });
+
+  it('does not mark _self links as external', () => {
+    const { result } = renderHook(() => useLink({ children: 'Docs', target: '_self' }));
+    expect(result.current.isExternal).toBe(false);
+  });
+
+  it('uses title as accessible label when provided', () => {
+    const { result } = renderHook(() => useLink({ children: 'Docs', title: 'Open docs' }));
+    expect(result.current.ariaLabel).toBe('Open docs');
+  });
+
+  it('falls back to string children as accessible label', () => {
+    const { result } = renderHook(() => useLink({ children: 'Docs' }));
+    expect(result.current.ariaLabel).toBe('Docs');
+  });
+
+  it('returns disabled false by default', () => {
+    const { result } = renderHook(() => useLink({ children: 'Docs' }));
+    expect(result.current.disabled).toBe(false);
+  });
+
+  it('keeps navigational visual variants exposed as links when href is present', () => {
+    const { result } = renderHook(() => useLink({ children: 'Docs', href: 'https://example.com', variant: 'button' }));
+    expect(result.current.role).toBe('link');
+  });
+
+  it('exposes button role only when no href is present', () => {
+    const { result } = renderHook(() => useLink({ children: 'Docs', variant: 'button' }));
+    expect(result.current.role).toBe('button');
+  });
+
+  it('makes action-style links keyboard-focusable by default', () => {
+    const { result } = renderHook(() => useLink({ children: 'Docs', variant: 'button' }));
+    expect(result.current.tabIndex).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────
+// COMPONENT TESTS — Link
+// ─────────────────────────────────────────────
+
+describe('Link — component behavior', () => {
+  it('renders an anchor with link role by default', () => {
+    render(<Link href='https://example.com'>Docs</Link>);
+    expect(screen.getByRole('link', { name: 'Docs' })).toBeInTheDocument();
+  });
+
+  it('sets rel for external links opened in a new tab', () => {
+    render(
+      <Link href='https://example.com' target='_blank'>
+        Docs
+      </Link>
+    );
+    expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('does not set rel for same-tab links', () => {
+    render(
+      <Link href='https://example.com' target='_self'>
+        Docs
+      </Link>
+    );
+    expect(screen.getByRole('link', { name: 'Docs' })).not.toHaveAttribute('rel');
+  });
+
+  it('uses title as aria-label and title attribute', () => {
+    render(
+      <Link href='https://example.com' title='Open docs'>
+        Docs
+      </Link>
+    );
+    const link = screen.getByRole('link', { name: 'Open docs' });
+    expect(link).toHaveAttribute('title', 'Open docs');
+  });
+
+  it('renders an icon when icon prop is provided', () => {
+    render(
+      <Link href='https://example.com' icon='image'>
+        Docs
+      </Link>
+    );
+    expect(screen.getByRole('link', { name: 'Docs' })).toBeInTheDocument();
+    expect(screen.getByTestId('link-icon')).toHaveAttribute('data-icon', 'image');
+  });
+
+  it('does not leak visual variant, size, or shadow props to the DOM', () => {
+    render(
+      <Link href='https://example.com' variant='button' size='lg' shadow={false}>
+        Docs
+      </Link>
+    );
+
+    const link = screen.getByRole('link', { name: 'Docs' });
+    expect(link).not.toHaveAttribute('variant');
+    expect(link).not.toHaveAttribute('size');
+    expect(link).not.toHaveAttribute('shadow');
+  });
+
+  it('keeps button-styled links exposed as links when href is present', () => {
+    render(
+      <Link href='https://example.com' variant='button'>
+        Docs
+      </Link>
+    );
+    expect(screen.getByRole('link', { name: 'Docs' })).toBeInTheDocument();
+  });
+
+  it('uses button semantics only when no href is present', () => {
+    render(<Link variant='button'>Action</Link>);
+    expect(screen.getByRole('button', { name: 'Action' })).toBeInTheDocument();
+  });
+
+  it('keeps action-style links in the tab order when enabled', async () => {
+    const user = userEvent.setup();
+    render(<Link variant='button'>Action</Link>);
+
+    const actionLink = screen.getByRole('button', { name: 'Action' });
+    await user.tab();
+
+    expect(actionLink).toHaveFocus();
+  });
+
+  it('calls onClick for action-style links when clicked', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(
+      <Link variant='button' onClick={handleClick}>
+        Action
+      </Link>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Action' }));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('activates action-style links with Enter and Space', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(
+      <Link variant='button' onClick={handleClick}>
+        Action
+      </Link>
+    );
+
+    const actionLink = screen.getByRole('button', { name: 'Action' });
+    actionLink.focus();
+
+    await user.keyboard('{Enter}');
+    await user.keyboard(' ');
+
+    expect(handleClick).toHaveBeenCalledTimes(2);
+  });
+
+  it('calls onClick when clicked and enabled', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(
+      <Link href='https://example.com' onClick={handleClick}>
+        Docs
+      </Link>
+    );
+
+    await user.click(screen.getByRole('link', { name: 'Docs' }));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks disabled links with aria-disabled and removes them from tab order', () => {
+    render(
+      <Link href='https://example.com' disabled={true}>
+        Docs
+      </Link>
+    );
+
+    const link = screen.getByRole('link', { name: 'Docs' });
+    expect(link).toHaveAttribute('aria-disabled', 'true');
+    expect(link).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('does not call onClick when disabled', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(
+      <Link href='https://example.com' disabled={true} onClick={handleClick}>
+        Docs
+      </Link>
+    );
+
+    await user.click(screen.getByRole('link', { name: 'Docs' }));
+
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/atoms/link/Link.test.tsx
+++ b/src/components/atoms/link/Link.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * Link.test.tsx — behavior tests for Stack-and-Flow Design System
+ *
+ * Strategy:
+ * - Hook (useLink): tested with renderHook for derived attributes and state.
+ * - Component (Link): tested with render/screen/userEvent for observable behavior.
+ *
+ * We test behavior, not internal CSS class strings.
+ */
+
+import { render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+// --- Mocks (declared before component import) ---
+
+vi.mock('lucide-react/dynamic', () => ({
+  // biome-ignore lint/style/useNamingConvention: must match library export name
+  DynamicIcon: ({ name }: { name: string }) => <span aria-hidden='true' data-icon={name} data-testid='link-icon' />
+}));
+
+// --- Imports after mocks ---
+
+import { Link } from './Link';
+import { useLink } from './useLink';
+
+// ─────────────────────────────────────────────
+// HOOK TESTS — useLink
+// ─────────────────────────────────────────────
+
+describe('useLink — logic', () => {
+  it('returns target _blank by default', () => {
+    const { result } = renderHook(() => useLink({ children: 'Docs' }));
+    expect(result.current.target).toBe('_blank');
+  });
+
+  it('marks _blank links as external', () => {
+    const { result } = renderHook(() => useLink({ children: 'Docs', target: '_blank' }));
+    expect(result.current.isExternal).toBe(true);
+  });
+
+  it('does not mark _self links as external', () => {
+    const { result } = renderHook(() => useLink({ children: 'Docs', target: '_self' }));
+    expect(result.current.isExternal).toBe(false);
+  });
+
+  it('uses title as accessible label when provided', () => {
+    const { result } = renderHook(() => useLink({ children: 'Docs', title: 'Open docs' }));
+    expect(result.current.ariaLabel).toBe('Open docs');
+  });
+
+  it('falls back to string children as accessible label', () => {
+    const { result } = renderHook(() => useLink({ children: 'Docs' }));
+    expect(result.current.ariaLabel).toBe('Docs');
+  });
+
+  it('returns disabled false by default', () => {
+    const { result } = renderHook(() => useLink({ children: 'Docs' }));
+    expect(result.current.disabled).toBe(false);
+  });
+
+  it('keeps navigational visual variants exposed as links when href is present', () => {
+    const { result } = renderHook(() => useLink({ children: 'Docs', href: 'https://example.com', variant: 'button' }));
+    expect(result.current.role).toBe('link');
+  });
+
+  it('exposes button role only when no href is present', () => {
+    const { result } = renderHook(() => useLink({ children: 'Docs', variant: 'button' }));
+    expect(result.current.role).toBe('button');
+  });
+
+  it('makes action-style links keyboard-focusable by default', () => {
+    const { result } = renderHook(() => useLink({ children: 'Docs', variant: 'button' }));
+    expect(result.current.tabIndex).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────
+// COMPONENT TESTS — Link
+// ─────────────────────────────────────────────
+
+describe('Link — component behavior', () => {
+  it('renders an anchor with link role by default', () => {
+    render(<Link href='https://example.com'>Docs</Link>);
+    expect(screen.getByRole('link', { name: 'Docs' })).toBeInTheDocument();
+  });
+
+  it('sets rel for external links opened in a new tab', () => {
+    render(
+      <Link href='https://example.com' target='_blank'>
+        Docs
+      </Link>
+    );
+    expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('does not set rel for same-tab links when no rel is provided', () => {
+    render(
+      <Link href='https://example.com' target='_self'>
+        Docs
+      </Link>
+    );
+    expect(screen.getByRole('link', { name: 'Docs' })).not.toHaveAttribute('rel');
+  });
+
+  it('preserves caller rel for same-tab links', () => {
+    render(
+      <Link href='https://example.com' target='_self' rel='nofollow'>
+        Docs
+      </Link>
+    );
+    expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute('rel', 'nofollow');
+  });
+
+  it('preserves caller rel tokens when securing new-tab links', () => {
+    render(
+      <Link href='https://example.com' target='_blank' rel='nofollow noopener'>
+        Docs
+      </Link>
+    );
+    expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute('rel', 'nofollow noopener noreferrer');
+  });
+
+  it('uses title as aria-label and title attribute', () => {
+    render(
+      <Link href='https://example.com' title='Open docs'>
+        Docs
+      </Link>
+    );
+    const link = screen.getByRole('link', { name: 'Open docs' });
+    expect(link).toHaveAttribute('title', 'Open docs');
+  });
+
+  it('renders an icon when icon prop is provided', () => {
+    render(
+      <Link href='https://example.com' icon='image'>
+        Docs
+      </Link>
+    );
+    expect(screen.getByRole('link', { name: 'Docs' })).toBeInTheDocument();
+    expect(screen.getByTestId('link-icon')).toHaveAttribute('data-icon', 'image');
+  });
+
+  it('does not leak visual variant, size, or shadow props to the DOM', () => {
+    render(
+      <Link href='https://example.com' variant='button' size='lg' shadow={false}>
+        Docs
+      </Link>
+    );
+
+    const link = screen.getByRole('link', { name: 'Docs' });
+    expect(link).not.toHaveAttribute('variant');
+    expect(link).not.toHaveAttribute('size');
+    expect(link).not.toHaveAttribute('shadow');
+  });
+
+  it('keeps button-styled links exposed as links when href is present', () => {
+    render(
+      <Link href='https://example.com' variant='button'>
+        Docs
+      </Link>
+    );
+    expect(screen.getByRole('link', { name: 'Docs' })).toBeInTheDocument();
+  });
+
+  it('uses button semantics only when no href is present', () => {
+    render(<Link variant='button'>Action</Link>);
+    expect(screen.getByRole('button', { name: 'Action' })).toBeInTheDocument();
+  });
+
+  it('keeps action-style links in the tab order when enabled', async () => {
+    const user = userEvent.setup();
+    render(<Link variant='button'>Action</Link>);
+
+    const actionLink = screen.getByRole('button', { name: 'Action' });
+    await user.tab();
+
+    expect(actionLink).toHaveFocus();
+  });
+
+  it('calls onClick for action-style links when clicked', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(
+      <Link variant='button' onClick={handleClick}>
+        Action
+      </Link>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Action' }));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('activates action-style links with Enter and Space', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(
+      <Link variant='button' onClick={handleClick}>
+        Action
+      </Link>
+    );
+
+    const actionLink = screen.getByRole('button', { name: 'Action' });
+    actionLink.focus();
+
+    await user.keyboard('{Enter}');
+    await user.keyboard(' ');
+
+    expect(handleClick).toHaveBeenCalledTimes(2);
+  });
+
+  it('calls onClick when clicked and enabled', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(
+      <Link href='https://example.com' onClick={handleClick}>
+        Docs
+      </Link>
+    );
+
+    await user.click(screen.getByRole('link', { name: 'Docs' }));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks disabled links with aria-disabled and removes them from tab order', () => {
+    render(
+      <Link href='https://example.com' disabled={true}>
+        Docs
+      </Link>
+    );
+
+    const link = screen.getByRole('link', { name: 'Docs' });
+    expect(link).toHaveAttribute('aria-disabled', 'true');
+    expect(link).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('does not call onClick when disabled', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(
+      <Link href='https://example.com' disabled={true} onClick={handleClick}>
+        Docs
+      </Link>
+    );
+
+    await user.click(screen.getByRole('link', { name: 'Docs' }));
+
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/atoms/link/Link.tsx
+++ b/src/components/atoms/link/Link.tsx
@@ -1,31 +1,47 @@
-import type { VariantProps } from 'class-variance-authority';
 import { DynamicIcon } from 'lucide-react/dynamic';
-import type { ComponentProps, FC } from 'react';
-import { cn } from '@/lib/utils';
-import { type LinkProps, linkVariants } from './types';
+import type { FC } from 'react';
+import type { LinkProps } from './types';
 import { useLink } from './useLink';
 
-const Link: FC<LinkProps & VariantProps<typeof linkVariants> & ComponentProps<'a'>> = ({ ...props }) => {
-  const { href, target, isExternal, title, children, variant, size, className, icon, iconWidth, ...rest } =
-    useLink(props);
+export const Link: FC<LinkProps> = (props) => {
+  const {
+    href,
+    target,
+    rel,
+    title,
+    children,
+    className,
+    icon,
+    iconWidth,
+    disabled,
+    isExternal: _isExternal,
+    ariaLabel,
+    role,
+    tabIndex,
+    handleClick,
+    handleKeyDown,
+    ...rest
+  } = useLink(props);
 
   return (
     <a
       {...rest}
       href={href}
       target={target}
-      rel={isExternal ? 'noopener noreferrer' : undefined}
-      aria-label={title || children}
-      aria-current={props['aria-current'] || undefined}
-      role={variant === 'button' || variant === 'outlined' ? 'button' : 'link'}
-      title={title ?? children}
-      tabIndex={0}
-      className={cn(linkVariants({ variant, size, className }))}
+      rel={rel}
+      aria-label={ariaLabel}
+      aria-disabled={disabled ? true : undefined}
+      data-disabled={disabled ? true : undefined}
+      data-external={_isExternal ? true : undefined}
+      role={role}
+      title={title ?? ariaLabel}
+      tabIndex={tabIndex}
+      className={className}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
     >
-      {icon && <DynamicIcon name={icon} color='currentColor' size={iconWidth} />}
+      {icon && <DynamicIcon name={icon} color='currentColor' size={iconWidth} aria-hidden={true} />}
       {children}
     </a>
   );
 };
-
-export default Link;

--- a/src/components/atoms/link/index.ts
+++ b/src/components/atoms/link/index.ts
@@ -1,2 +1,2 @@
-export { default as Link } from './Link';
+export { Link } from './Link';
 export * from './types';

--- a/src/components/atoms/link/types.ts
+++ b/src/components/atoms/link/types.ts
@@ -1,92 +1,99 @@
-import { cva } from 'class-variance-authority';
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { ComponentProps, ReactNode } from 'react';
 import type { DynamicIconName } from '@/types';
 
 export const linkVariants = cva(
   [
-    'link w-auto relative cursor-pointer',
-    'flex gap-1 items-center justify-start',
-    'font-medium whitespace-nowrap line-clamp-1 leading-[1.2]',
-    'focus-visible:outline-none focus-visible:shadow-glow-focus-light dark:focus-visible:shadow-glow-focus-dark'
+    'link relative w-auto cursor-pointer font-medium leading-normal',
+    'focus-visible:outline-none focus-visible:shadow-glow-focus-light dark:focus-visible:shadow-glow-focus-dark',
+    'data-[disabled=true]:pointer-events-none data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-40'
   ],
   {
     variants: {
       variant: {
         regular: [
-          'font-bold transition-[color,border-color] duration-200 ease-[ease]',
-          'text-brand-dark-lighter dark:text-brand-dark-lighter',
-          'hover:text-brand-dark-lightest dark:hover:text-brand-dark-lightest',
-          'border-b border-[rgba(255,77,109,0.4)] hover:border-[rgba(255,128,153,0.7)]',
-          'no-underline'
+          'inline border-b font-bold no-underline',
+          'border-brand-light/60 text-brand-light dark:border-brand-dark-dark dark:text-brand-dark-dark',
+          'transition-[color,border-color] duration-200 ease-[ease]',
+          'hover:border-brand-light-dark/80 hover:text-brand-light-dark dark:hover:border-brand-dark-light dark:hover:text-brand-dark-light',
+          '[&>svg]:mr-1 [&>svg]:inline-block [&>svg]:align-[-0.125em]'
         ],
         button: [
-          'min-h-[44px]',
-          'transition-[box-shadow,background,border-color] duration-[250ms] ease-[ease]',
-          'px-4 py-2',
-          'rounded-md',
-          'border',
-          'text-white',
-          'bg-[image:var(--background-image-btn-primary)]',
-          'border-transparent',
-          'shadow-glow-btn-primary-light dark:shadow-glow-btn-primary',
-          'hover:bg-[image:var(--background-image-btn-primary-hover)]',
-          'hover:shadow-glow-btn-primary-hover-light dark:hover:shadow-glow-btn-primary-hover'
+          'inline-flex items-center justify-center gap-1 whitespace-nowrap rounded-pill border border-transparent font-semibold tracking-ui text-white no-underline',
+          'bg-btn-primary shadow-glow-btn-primary-light dark:shadow-glow-btn-primary',
+          'transition-[box-shadow,background,transform] duration-250 ease-[ease]',
+          'hover:bg-btn-primary-hover hover:text-white hover:shadow-glow-btn-primary-hover-light dark:hover:shadow-glow-btn-primary-hover',
+          'motion-safe:active:scale-[0.98]'
         ],
         outlined: [
-          'min-h-[44px]',
-          'transition-[box-shadow,background,border-color] duration-[250ms] ease-[ease]',
-          'px-4 py-2',
-          'rounded-md',
-          'border',
-          'text-brand-light dark:text-brand-dark',
-          'border-brand-light dark:border-brand-dark',
-          'bg-transparent',
-          'hover:text-white dark:hover:text-white',
-          'hover:bg-[image:var(--background-image-btn-primary)]',
-          'hover:border-transparent',
-          'hover:shadow-glow-btn-primary-hover-light dark:hover:shadow-glow-btn-primary-hover'
+          'inline-flex items-center justify-center gap-1 whitespace-nowrap rounded-pill border font-semibold tracking-ui no-underline',
+          'border-red-tint-border bg-red-tint-subtle text-brand-light shadow-glow-btn-secondary-light dark:text-text-dark dark:shadow-glow-btn-secondary',
+          'transition-[box-shadow,background,border-color,transform] duration-250 ease-[ease]',
+          'hover:border-brand-light/80 hover:bg-red-tint-low hover:text-brand-light-darkest hover:shadow-glow-btn-secondary-hover-light',
+          'dark:hover:border-brand-dark-light dark:hover:bg-red-tint-active dark:hover:text-text-dark dark:hover:shadow-glow-btn-secondary-hover',
+          'motion-safe:active:scale-[0.98]'
         ]
       },
       size: {
-        md: 'px-md fs-base',
-        lg: 'px-lg fs-h6',
-        sm: 'px-sm fs-small'
+        sm: 'fs-small',
+        md: 'fs-base',
+        lg: 'fs-h5'
+      },
+      shadow: {
+        true: '',
+        false: 'shadow-none hover:shadow-none dark:shadow-none dark:hover:shadow-none'
       }
     },
+    compoundVariants: [
+      { variant: ['button', 'outlined'], size: 'sm', class: 'h-9 px-sm' },
+      { variant: ['button', 'outlined'], size: 'md', class: 'h-11 px-md' },
+      { variant: ['button', 'outlined'], size: 'lg', class: 'h-12 px-lg' }
+    ],
     defaultVariants: {
       variant: 'regular',
-      size: 'md'
+      size: 'md',
+      shadow: true
     }
   }
 );
 
-type ButtonVariants = 'regular' | 'button' | 'outlined';
-type TargetVariants = '_blank' | '_self' | '_parent' | '_top';
-type LinkSizes = 'sm' | 'md' | 'lg';
+export type LinkVariant = 'regular' | 'button' | 'outlined';
+export type LinkTarget = '_blank' | '_self' | '_parent' | '_top';
+export type LinkSize = 'sm' | 'md' | 'lg';
 
-export type LinkProps = {
-  /**
-   * @control select
-   * @default regular
-   * */
-  variant?: ButtonVariants;
-  /** @control text */
-  href?: string;
-  /**
-   * @control text
-   * @default _blank
-   * */
-  target?: TargetVariants;
-  /**
-   * @control select
-   * @default md
-   * */
-  size: LinkSizes;
-  /** @control text */
-  icon?: DynamicIconName;
-  /** @control text */
-  title?: string;
-  /** @control text */
-  className?: string;
-  /** @control text */
-  children: string;
-};
+export type LinkProps = Omit<ComponentProps<'a'>, 'children' | 'disabled' | 'target'> &
+  VariantProps<typeof linkVariants> & {
+    /**
+     * @control text
+     */
+    children: ReactNode;
+    /**
+     * @control select
+     * @default regular
+     */
+    variant?: LinkVariant;
+    /**
+     * @control select
+     * @default md
+     */
+    size?: LinkSize;
+    /**
+     * @control select
+     * @default _blank
+     */
+    target?: LinkTarget;
+    /**
+     * @control text
+     */
+    icon?: DynamicIconName;
+    /**
+     * @control boolean
+     * @default true
+     */
+    shadow?: boolean;
+    /**
+     * @control boolean
+     * @default false
+     */
+    disabled?: boolean;
+  };

--- a/src/components/atoms/link/useLink.ts
+++ b/src/components/atoms/link/useLink.ts
@@ -27,6 +27,7 @@ export const useLink = ({
   href,
   title,
   rel,
+  'aria-label': ariaLabelProp,
   disabled = false,
   onClick,
   onKeyDown,
@@ -34,7 +35,7 @@ export const useLink = ({
 }: LinkProps): UseLinkReturn => {
   const iconWidth = { sm: 18, md: 20, lg: 24 }[size] ?? 20;
   const isExternal = target === '_blank';
-  const ariaLabel = title ?? (typeof children === 'string' ? children : undefined);
+  const ariaLabel = ariaLabelProp ?? title ?? (typeof children === 'string' ? children : undefined);
   const isAction = !href;
   const role = isAction ? 'button' : 'link';
 

--- a/src/components/atoms/link/useLink.ts
+++ b/src/components/atoms/link/useLink.ts
@@ -1,20 +1,95 @@
-import type { VariantProps } from 'class-variance-authority';
-import type { ComponentProps } from 'react';
-import type { LinkProps, linkVariants } from './types';
+import type { KeyboardEvent, MouseEvent } from 'react';
+import { cn } from '@/lib/utils';
+import { type LinkProps, linkVariants } from './types';
+
+type UseLinkReturn = Omit<LinkProps, 'onClick' | 'onKeyDown'> & {
+  ariaLabel: string | undefined;
+  className: string;
+  disabled: boolean;
+  handleClick: (event: MouseEvent<HTMLAnchorElement>) => void;
+  handleKeyDown: (event: KeyboardEvent<HTMLAnchorElement>) => void;
+  iconWidth: number;
+  isExternal: boolean;
+  rel: string | undefined;
+  role: 'button' | 'link';
+  tabIndex: number | undefined;
+  target: NonNullable<LinkProps['target']>;
+};
 
 export const useLink = ({
   children,
   icon = undefined,
   variant = 'regular',
   size = 'md',
+  shadow = true,
   target = '_blank',
   className,
   href,
   title,
+  rel,
+  disabled = false,
+  onClick,
+  onKeyDown,
   ...rest
-}: LinkProps & VariantProps<typeof linkVariants> & ComponentProps<'a'>) => {
-  const iconWidth = { sm: 18, md: 20, lg: 24 }[size] || 22;
+}: LinkProps): UseLinkReturn => {
+  const iconWidth = { sm: 18, md: 20, lg: 24 }[size] ?? 20;
   const isExternal = target === '_blank';
+  const ariaLabel = title ?? (typeof children === 'string' ? children : undefined);
+  const isAction = !href;
+  const role = isAction ? 'button' : 'link';
 
-  return { href, target, isExternal, title, children, variant, size, className, icon, iconWidth, ...rest };
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (disabled) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    onClick?.(event);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLAnchorElement>) => {
+    if (disabled) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    onKeyDown?.(event);
+
+    if (event.defaultPrevented || !isAction || (event.key !== 'Enter' && event.key !== ' ')) {
+      return;
+    }
+
+    event.preventDefault();
+    event.currentTarget.click();
+  };
+
+  return {
+    ...rest,
+    href,
+    target,
+    rel: getSafeRel(rel, isExternal),
+    isExternal,
+    title,
+    children,
+    className: cn(linkVariants({ variant, size, shadow }), className),
+    icon,
+    iconWidth,
+    disabled,
+    ariaLabel,
+    role,
+    tabIndex: disabled ? -1 : (rest.tabIndex ?? (isAction ? 0 : undefined)),
+    handleClick,
+    handleKeyDown
+  };
+};
+
+const getSafeRel = (rel: string | undefined, isExternal: boolean): string | undefined => {
+  if (!isExternal) {
+    return rel;
+  }
+
+  const tokens = new Set([...(rel?.split(/\s+/).filter(Boolean) ?? []), 'noopener', 'noreferrer']);
+  return Array.from(tokens).join(' ');
 };

--- a/src/components/atoms/link/useLink.ts
+++ b/src/components/atoms/link/useLink.ts
@@ -1,20 +1,85 @@
-import type { VariantProps } from 'class-variance-authority';
-import type { ComponentProps } from 'react';
-import type { LinkProps, linkVariants } from './types';
+import type { KeyboardEvent, MouseEvent } from 'react';
+import { cn } from '@/lib/utils';
+import { type LinkProps, linkVariants } from './types';
+
+type UseLinkReturn = Omit<LinkProps, 'onClick' | 'onKeyDown'> & {
+  ariaLabel: string | undefined;
+  className: string;
+  disabled: boolean;
+  handleClick: (event: MouseEvent<HTMLAnchorElement>) => void;
+  handleKeyDown: (event: KeyboardEvent<HTMLAnchorElement>) => void;
+  iconWidth: number;
+  isExternal: boolean;
+  rel: string | undefined;
+  role: 'button' | 'link';
+  tabIndex: number | undefined;
+  target: NonNullable<LinkProps['target']>;
+};
 
 export const useLink = ({
   children,
   icon = undefined,
   variant = 'regular',
   size = 'md',
+  shadow = true,
   target = '_blank',
   className,
   href,
   title,
+  disabled = false,
+  onClick,
+  onKeyDown,
   ...rest
-}: LinkProps & VariantProps<typeof linkVariants> & ComponentProps<'a'>) => {
-  const iconWidth = { sm: 18, md: 20, lg: 24 }[size] || 22;
+}: LinkProps): UseLinkReturn => {
+  const iconWidth = { sm: 18, md: 20, lg: 24 }[size] ?? 20;
   const isExternal = target === '_blank';
+  const ariaLabel = title ?? (typeof children === 'string' ? children : undefined);
+  const isAction = !href;
+  const role = isAction ? 'button' : 'link';
 
-  return { href, target, isExternal, title, children, variant, size, className, icon, iconWidth, ...rest };
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (disabled) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    onClick?.(event);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLAnchorElement>) => {
+    if (disabled) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    onKeyDown?.(event);
+
+    if (event.defaultPrevented || !isAction || (event.key !== 'Enter' && event.key !== ' ')) {
+      return;
+    }
+
+    event.preventDefault();
+    event.currentTarget.click();
+  };
+
+  return {
+    ...rest,
+    href,
+    target,
+    rel: isExternal ? 'noopener noreferrer' : undefined,
+    isExternal,
+    title,
+    children,
+    className: cn(linkVariants({ variant, size, shadow }), className),
+    icon,
+    iconWidth,
+    disabled,
+    ariaLabel,
+    role,
+    tabIndex: disabled ? -1 : (rest.tabIndex ?? (isAction ? 0 : undefined)),
+    handleClick,
+    handleKeyDown
+  };
 };

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -223,6 +223,16 @@
   --glow-chip-danger-hover:
     0 2px 4px rgba(0, 0, 0, 0.14), 0 5px 12px color-mix(in srgb, var(--color-red-600) 36%, transparent);
 
+  /* Tailwind shadow utility aliases — shadow-glow-* classes */
+  --shadow-glow-btn-primary: var(--glow-btn-primary);
+  --shadow-glow-btn-primary-hover: var(--glow-btn-primary-hover);
+  --shadow-glow-btn-primary-light: var(--glow-btn-primary-light);
+  --shadow-glow-btn-primary-hover-light: var(--glow-btn-primary-hover-light);
+  --shadow-glow-btn-secondary: var(--glow-btn-secondary);
+  --shadow-glow-btn-secondary-hover: var(--glow-btn-secondary-hover);
+  --shadow-glow-btn-secondary-light: var(--glow-btn-secondary-light);
+  --shadow-glow-btn-secondary-hover-light: var(--glow-btn-secondary-hover-light);
+
   /* Glow de focus ring */
   --glow-focus-dark: 0 0 0 3px rgba(255, 0, 54, 0.4);
   --glow-focus-light: 0 0 0 3px rgba(219, 20, 60, 0.35);


### PR DESCRIPTION
## Summary

Completes the Link atom review and validation.

- Fixes Link action-mode accessibility, including keyboard activation and disabled behavior.
- Aligns Link visual variants with Stack-and-Flow inline/CTA semantics and exposes glow shadow utilities.
- Reworks Link stories and adds focused unit coverage for Link behavior.

Closes #132

## Type of change

- [ ] 🧩 New component
- [x] 🐛 Bug fix
- [x] 🎨 Design tokens
- [x] ♿ Accessibility
- [ ] 🏗️ Infrastructure
- [ ] 📚 Documentation

## Component checklist (skip if not applicable)

- [x] Follows the 5-file structure (`types.ts`, `use*.ts`, `Component.tsx`, `index.ts`, `*.stories.tsx`)
- [x] CVA variants defined in `types.ts`, not inline
- [x] No hardcoded colors — uses tokens from `theme.css`
- [x] No `any` types — TypeScript strict
- [x] ARIA attributes present and correct
- [x] Keyboard navigable (Tab, Enter, Escape where applicable)
- [x] Dark mode works correctly
- [x] Storybook stories cover: default, variants, states (hover, focus, disabled)
- [x] Tests added or updated

## How to test

1. `pnpm test -- src/components/atoms/link/Link.test.tsx`
2. `pnpm exec tsc --noEmit`
3. `pnpm run build`
4. `pnpm run storybook-build`
5. Navigate to `Atoms/Link` and verify inline, CTA, shadow, size, disabled, target, and action-mode stories.

## Screenshots / recordings (if applicable)

Not included.

## Notes for reviewer

- `regular` is now a true inline link; `button` maps to primary CTA; `outlined` maps to secondary CTA.
- `shadow={false}` disables CTA glow while preserving focus ring accessibility.
- `src/styles/theme.css` adds Tailwind shadow utility aliases for existing `--glow-btn-*` tokens so `shadow-glow-btn-*` classes generate correctly.
- Fresh pre-PR review passed. Review workload note: the diff is bounded to Link plus theme aliases, but it is over 400 changed lines due to story/test coverage.
