### PR TITLE
docs(skills): require GitHub API fallback for issue comments

### DIFF
--- a/.atl/skills/component-contributor/SKILL.md
+++ b/.atl/skills/component-contributor/SKILL.md
@@ -95,6 +95,8 @@ Before writing a single line of code, extract from the issue:
 6. **Reference URL** — study the linked implementation (HeroUI, Radix, etc.)
 7. **Design notes** — any visual or interaction specifics
 
+If the issue came from GitHub and the rendered page does not expose comments, fetch the issue comments via the GitHub API (`/repos/{owner}/{repo}/issues/{number}/comments`) or `gh api` before extracting the spec. The validated spec may live in a comment thread.
+
 If any of these are missing or ambiguous, **ask the contributor to clarify before proceeding**.
 Do NOT invent props or behaviors that are not in the spec.
 

--- a/.atl/skills/component-spec-proposer/SKILL.md
+++ b/.atl/skills/component-spec-proposer/SKILL.md
@@ -35,7 +35,7 @@ Do not implement the component. Your job is to turn a vague task into a validate
 
 ## Execution Steps
 
-1. Read the GitHub issue, if provided: title, body, comments, assignees, and URL.
+1. Read the GitHub issue, if provided: title, body, comments, assignees, and URL. If the rendered issue page does not expose the comment thread, fetch the issue comments via the GitHub API (`/repos/{owner}/{repo}/issues/{number}/comments`) or `gh api` before continuing.
 2. Fetch and study the reference URL. Extract behavior, states, accessibility, anatomy, and examples.
 3. Compare against project rules from `component-contributor`, especially Phase 1 requirements.
 4. Present a proposed spec using `references/spec-template.md`.


### PR DESCRIPTION
## Summary

- Add a GitHub API fallback to the component-contributor and component-spec-proposer skills when the rendered issue page does not expose comments.
- Prevent the intake flow from missing validated specs that live in issue comment threads.

Closes #170

## Type of change

- [ ] 🧩 New component
- [ ] 🐛 Bug fix
- [ ] 🎨 Design tokens
- [ ] ♿ Accessibility
- [ ] 🏗️ Infrastructure
- [x] 📚 Documentation

## Component checklist (skip if not applicable)

- [x] Follows the 5-file structure (`types.ts`, `use*.ts`, `Component.tsx`, `index.ts`, `*.stories.tsx`)
- [x] CVA variants defined in `types.ts`, not inline
- [x] No hardcoded colors — uses tokens from `theme.css`
- [x] No `any` types — TypeScript strict
- [x] ARIA attributes present and correct
- [x] Keyboard navigable (Tab, Enter, Escape where applicable)
- [x] Dark mode works correctly
- [x] Storybook stories cover: default, variants, states (hover, focus, disabled)
- [x] Tests added or updated

## How to test

1. Open a GitHub issue that stores the validated spec in comments.
2. Verify the skills now instruct the agent to fetch comments through the GitHub API or `gh api` if the rendered page does not expose them.
3. Confirm the repository still passes `pnpm run typecheck` via the pre-commit hook on commit.

## Notes for reviewer

This change is a harness/docs correction only. No runtime component behavior changed.
