### PR TITLE
fix(avatar): improve accessibility and visual affordance

### DIFF
--- a/src/components/atoms/avatar/Avatar.stories.tsx
+++ b/src/components/atoms/avatar/Avatar.stories.tsx
@@ -1,15 +1,16 @@
+import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, fn, userEvent, within } from '@storybook/test';
 import { Avatar } from './Avatar';
 
 /**
- * ## DESCRIPTION
- * Avatar component is used to display user profile images or icons.
- * It supports different sizes and can show a fallback text when the image is not available.
+ * ## Description
+ * Avatar displays a user or organization image with an initials fallback when the image is missing or unavailable.
  *
- * ## DEPENDENCIES
- * - [Radix UI Avatar](https://www.radix-ui.com/docs/primitives/components/avatar)
+ * ## Dependencies
+ * Uses Radix UI Avatar for image loading and fallback behavior.
  *
+ * ## Usage Guide
+ * Use `alt` as the accessible name. Passing `onClick` renders the avatar as a real button for account menus, profile triggers, or identity actions.
  */
 const meta: Meta<typeof Avatar> = {
   title: 'Atoms/Avatar',
@@ -25,54 +26,38 @@ export default meta;
 
 type Story = StoryObj<typeof Avatar>;
 
+/**
+ * Default avatar with the component default size and radius.
+ */
 export const Default: Story = {
   args: {
-    size: 'md',
-    alt: 'EG',
-    className: ''
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Verify avatar is rendered with correct role
-    const avatar = canvas.getByRole('img', { name: /EG/i });
-    await expect(avatar).toBeInTheDocument();
+    alt: 'El Gentleman',
+    onClick: undefined
   }
 };
 
 /**
- * - If you don't provide an image, the component will show a fallback text.
- * - The fallback text is set to "EG" by default, but you can change it by providing a different `alt` prop.
+ * Avatars can render initials when no image source is available.
  */
-
 export const WithoutImage: Story = {
   render: () => (
-    <div className='flex gap-4 items-center'>
-      <Avatar src={''} size='sm' alt='EG' />
-      <Avatar src={''} size='md' alt='EG' />
-      <Avatar src={''} size='lg' alt='EG' />
-      <Avatar src={''} size='xl' alt='EG' />
-      <Avatar src={''} size='2xl' alt='EG' />
-      <Avatar src={''} size='3xl' alt='EG' />
+    <div className='flex items-center gap-4'>
+      <Avatar size='sm' alt='El Gentleman' />
+      <Avatar size='md' alt='El Gentleman' />
+      <Avatar size='lg' alt='El Gentleman' />
+      <Avatar size='xl' alt='El Gentleman' />
+      <Avatar size='2xl' alt='El Gentleman' />
+      <Avatar size='3xl' alt='El Gentleman' />
     </div>
-  ),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Verify all avatars render
-    const avatars = canvas.getAllByRole('img');
-    await expect(avatars.length).toBeGreaterThan(0);
-  }
+  )
 };
 
 /**
- * - You can use the `src` prop to provide an image URL.
- * - The `alt` prop is used for accessibility and should describe the image.
+ * The `src` prop displays an image while keeping `alt` as the accessible avatar name.
  */
-
 export const WithImage: Story = {
   render: () => (
-    <div className='flex gap-4 items-center'>
+    <div className='flex items-center gap-4'>
       <Avatar src='/images/logo-only.svg' alt='EG Logo' size='sm' />
       <Avatar src='/images/logo-only.svg' alt='EG Logo' size='md' />
       <Avatar src='/images/logo-only.svg' alt='EG Logo' size='lg' />
@@ -80,70 +65,41 @@ export const WithImage: Story = {
       <Avatar src='/images/logo-only.svg' alt='EG Logo' size='2xl' />
       <Avatar src='/images/logo-only.svg' alt='EG Logo' size='3xl' />
     </div>
-  ),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Verify all avatars are rendered
-    const avatars = canvas.getAllByRole('img');
-    await expect(avatars.length).toBeGreaterThan(0);
-  }
+  )
 };
 
 /**
- *  - You can round the avatar using the `rounded` prop.
- *  - The available options are 'md', 'full', and 'none'.
- *  - The default value is 'md'.
- *  - This prop allows for customization of the avatar's appearance.
+ * The `rounded` prop changes the corner radius.
  */
-
 export const Rounded: Story = {
   render: () => (
-    <div className='flex gap-4 items-center'>
-      <Avatar src='' alt='EG' size='md' rounded='md' />
-      <Avatar src='' alt='EG' size='md' rounded='full' />
-      <Avatar src='' alt='EG' size='md' rounded='none' />
+    <div className='flex items-center gap-4'>
+      <Avatar alt='Square Avatar' rounded='none' />
+      <Avatar alt='Soft Avatar' rounded='md' />
+      <Avatar alt='Pill Avatar' rounded='full' />
     </div>
-  ),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
+  )
+};
 
-    // Verify all rounded variants are rendered
-    const avatars = canvas.getAllByRole('img');
-    await expect(avatars.length).toBe(3);
+/**
+ * Passing `onClick` renders Avatar as a button with keyboard and focus semantics.
+ */
+export const Interactive: Story = {
+  args: {
+    alt: 'Open profile',
+    rounded: 'full',
+    onClick: action('avatar.click')
   }
 };
 
 /**
- * - When the avatar is clickable (e.g. profile link, account dropdown trigger), pass `onClick`.
- * - Hover/active scale effect and `cursor-pointer` are enabled automatically.
+ * Disabled interactive avatars keep button semantics while blocking activation.
  */
-export const Interactive: Story = {
-  render: () => {
-    const handleClick = fn();
-    return (
-      <div className='flex gap-4 items-center'>
-        <Avatar src='' alt='User 1' size='sm' onClick={handleClick} />
-        <Avatar src='' alt='User 2' size='md' onClick={handleClick} />
-        <Avatar src='' alt='User 3' size='lg' onClick={handleClick} />
-        <Avatar src='/images/logo-only.svg' alt='User 4' size='xl' onClick={handleClick} />
-        <Avatar src='/images/logo-only.svg' alt='User 5' size='2xl' onClick={handleClick} />
-        <Avatar src='/images/logo-only.svg' alt='User 6' size='3xl' onClick={handleClick} />
-      </div>
-    );
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Verify all avatars are rendered
-    const avatars = canvas.getAllByRole('img');
-    await expect(avatars.length).toBeGreaterThan(0);
-
-    // Click on the first avatar
-    const firstAvatar = avatars[0];
-    await userEvent.click(firstAvatar);
-
-    // Verify cursor-pointer class is applied
-    await expect(firstAvatar).toHaveClass('cursor-pointer');
+export const Disabled: Story = {
+  args: {
+    alt: 'Profile unavailable',
+    rounded: 'full',
+    disabled: true,
+    onClick: action('avatar.click')
   }
 };

--- a/src/components/atoms/avatar/Avatar.test.tsx
+++ b/src/components/atoms/avatar/Avatar.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Avatar.test.tsx — behavior coverage for Stack-and-Flow Design System
+ *
+ * STRATEGY:
+ * - Hook (useAvatar): tested with renderHook → derived accessibility and fallback logic
+ * - Component (Avatar): tested with render + screen + userEvent → observable DOM behavior
+ *
+ * WHAT we test: fallback text, image/fallback accessibility, interactive button semantics, click behavior
+ * WHAT we do NOT test: specific CSS class strings or Radix internals
+ */
+
+import { render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Avatar } from './Avatar';
+import { useAvatar } from './useAvatar';
+
+// ─────────────────────────────────────────────
+// HOOK TESTS — useAvatar
+// ─────────────────────────────────────────────
+
+describe('useAvatar — logic', () => {
+  it('derives initials from the accessible name', () => {
+    const { result } = renderHook(() => useAvatar({ alt: 'El Gentleman' }));
+    expect(result.current.fallback).toBe('EG');
+  });
+
+  it('uses a stable fallback initial when alt is blank', () => {
+    const { result } = renderHook(() => useAvatar({ alt: '   ' }));
+    expect(result.current.fallback).toBe('A');
+  });
+
+  it('marks the avatar as non-interactive by default', () => {
+    const { result } = renderHook(() => useAvatar({ alt: 'User avatar' }));
+    expect(result.current.interactive).toBe(false);
+  });
+
+  it('marks the avatar as interactive when onClick is provided', () => {
+    const { result } = renderHook(() => useAvatar({ alt: 'Open profile', onClick: vi.fn() }));
+    expect(result.current.interactive).toBe(true);
+  });
+
+  it('returns a computed className for visual variants', () => {
+    const { result } = renderHook(() => useAvatar({ alt: 'User avatar', size: 'lg', rounded: 'full' }));
+    expect(result.current.className).toEqual(expect.any(String));
+  });
+});
+
+// ─────────────────────────────────────────────
+// COMPONENT TESTS — Avatar
+// ─────────────────────────────────────────────
+
+describe('Avatar — component behavior', () => {
+  it('renders a named image region when not interactive', () => {
+    render(<Avatar alt='El Gentleman' />);
+    expect(screen.getByRole('img', { name: 'El Gentleman' })).toBeInTheDocument();
+  });
+
+  it('shows initials fallback when no image source is provided', () => {
+    render(<Avatar alt='El Gentleman' />);
+    expect(screen.getByText('EG')).toBeInTheDocument();
+  });
+
+  it('renders a named image region when src is provided', () => {
+    render(<Avatar src='/images/logo-only.svg' alt='EG Logo' />);
+    expect(screen.getByRole('img', { name: 'EG Logo' })).toBeInTheDocument();
+  });
+
+  it('renders a real button when onClick is provided', () => {
+    render(<Avatar alt='Open profile' onClick={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Open profile' })).toBeInTheDocument();
+  });
+
+  it('calls onClick when the interactive avatar is clicked', async () => {
+    const handleClick = vi.fn();
+    render(<Avatar alt='Open profile' onClick={handleClick} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open profile' }));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClick when the interactive avatar is activated by keyboard', async () => {
+    const handleClick = vi.fn();
+    render(<Avatar alt='Open profile' onClick={handleClick} />);
+
+    screen.getByRole('button', { name: 'Open profile' }).focus();
+    await userEvent.keyboard('{Enter}');
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClick when disabled', async () => {
+    const handleClick = vi.fn();
+    render(<Avatar alt='Open profile' disabled={true} onClick={handleClick} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open profile' }));
+
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/atoms/avatar/Avatar.test.tsx
+++ b/src/components/atoms/avatar/Avatar.test.tsx
@@ -28,6 +28,7 @@ describe('useAvatar — logic', () => {
 
   it('uses a stable fallback initial when alt is blank', () => {
     const { result } = renderHook(() => useAvatar({ alt: '   ' }));
+    expect(result.current.alt).toBe('Avatar');
     expect(result.current.fallback).toBe('A');
   });
 
@@ -65,6 +66,11 @@ describe('Avatar — component behavior', () => {
   it('renders a named image region when src is provided', () => {
     render(<Avatar src='/images/logo-only.svg' alt='EG Logo' />);
     expect(screen.getByRole('img', { name: 'EG Logo' })).toBeInTheDocument();
+  });
+
+  it('falls back to a default accessible name when alt is blank', () => {
+    render(<Avatar alt='   ' />);
+    expect(screen.getByRole('img', { name: 'Avatar' })).toBeInTheDocument();
   });
 
   it('renders a real button when onClick is provided', () => {

--- a/src/components/atoms/avatar/Avatar.tsx
+++ b/src/components/atoms/avatar/Avatar.tsx
@@ -1,67 +1,46 @@
 import * as AvatarPrimitive from '@radix-ui/react-avatar';
-import type { ComponentProps, FC } from 'react';
-import { cn } from '@/lib/utils';
+import type { FC } from 'react';
 import type { AvatarProps } from './types';
 import { useAvatar } from './useAvatar';
 
-function AvatarContainer({ className, ...props }: ComponentProps<typeof AvatarPrimitive.Root>) {
-  return (
+export const Avatar: FC<AvatarProps> = (props) => {
+  const { src, alt, imageAlt, fallback, className, interactive, handleClick, disabled, type, ...rootProps } =
+    useAvatar(props);
+
+  const content = (
+    <>
+      <AvatarPrimitive.Image data-slot='avatar-image' className='aspect-square size-full' src={src} alt={imageAlt} />
+      <AvatarPrimitive.Fallback data-slot='avatar-fallback' className='flex size-full items-center justify-center'>
+        {fallback}
+      </AvatarPrimitive.Fallback>
+    </>
+  );
+
+  return interactive ? (
+    <AvatarPrimitive.Root asChild={true}>
+      <button
+        data-slot='avatar'
+        data-interactive={true}
+        className={className}
+        type={type}
+        aria-label={alt}
+        onClick={handleClick}
+        disabled={disabled}
+        {...rootProps}
+      >
+        {content}
+      </button>
+    </AvatarPrimitive.Root>
+  ) : (
     <AvatarPrimitive.Root
       data-slot='avatar'
-      className={cn('relative flex size-8 shrink-0 overflow-hidden', className)}
-      {...props}
-    />
-  );
-}
-
-function AvatarImage({ className, ...props }: ComponentProps<typeof AvatarPrimitive.Image>) {
-  return (
-    <AvatarPrimitive.Image data-slot='avatar-image' className={cn('aspect-square size-full', className)} {...props} />
-  );
-}
-
-function AvatarFallback({ className, ...props }: ComponentProps<typeof AvatarPrimitive.Fallback>) {
-  return (
-    <AvatarPrimitive.Fallback
-      data-slot='avatar-fallback'
-      className={cn('flex size-full items-center justify-center', className)}
-      {...props}
-    />
-  );
-}
-
-export const Avatar: FC<AvatarProps> = ({ ...props }) => {
-  const { src, alt, initials, sizeClass, className, textClass, roundedClass, onClick } = useAvatar({ ...props });
-  const interactive = !!onClick;
-
-  return (
-    <AvatarContainer
-      className={cn(
-        'bg-surface-raised-light dark:bg-surface-raised-dark',
-        'avatar-inset-ring',
-        'flex items-center justify-center',
-        interactive && 'cursor-pointer transition-transform duration-200 ease-out hover:scale-110 active:scale-100',
-        roundedClass,
-        className
-      )}
-      style={{ width: sizeClass, height: sizeClass }}
+      data-interactive={false}
+      className={className}
       role='img'
       aria-label={alt}
-      onClick={onClick}
+      {...rootProps}
     >
-      <AvatarImage src={src} style={{ width: sizeClass, height: sizeClass }} alt={alt} />
-      <AvatarFallback
-        className={cn(
-          'bg-surface-raised-light dark:bg-surface-raised-dark',
-          'avatar-inset-ring',
-          'text-text-light dark:text-text-dark',
-          'font-semibold leading-[1.2] pt-[0.2em]',
-          roundedClass,
-          textClass
-        )}
-      >
-        {initials}
-      </AvatarFallback>
-    </AvatarContainer>
+      {content}
+    </AvatarPrimitive.Root>
   );
 };

--- a/src/components/atoms/avatar/types.ts
+++ b/src/components/atoms/avatar/types.ts
@@ -1,16 +1,69 @@
-import type { ThemeRounded } from '@/types';
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { ComponentProps } from 'react';
 
-export type AvatarProps = {
-  /** @control src */
-  src: string;
-  /** @control select */
-  size?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl';
-  /** @control text */
-  alt: string;
+export const avatarVariants = cva(
+  [
+    'relative inline-flex shrink-0 overflow-hidden items-center justify-center',
+    'bg-surface-raised-light dark:bg-surface-raised-dark',
+    'border border-border-strong-light dark:border-border-strong-dark',
+    'text-text-light dark:text-text-dark font-semibold leading-none',
+    'data-[interactive=true]:cursor-pointer',
+    'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-40',
+    'data-[interactive=true]:transition-[box-shadow,transform] data-[interactive=true]:duration-200 data-[interactive=true]:ease-out',
+    'data-[interactive=true]:hover:scale-110 data-[interactive=true]:active:scale-100',
+    'data-[interactive=true]:focus-visible:outline-none',
+    'data-[interactive=true]:focus-visible:shadow-glow-focus-light dark:data-[interactive=true]:focus-visible:shadow-glow-focus-dark'
+  ],
+  {
+    variants: {
+      size: {
+        sm: 'size-8 text-xs data-[interactive=true]:min-h-11 data-[interactive=true]:min-w-11',
+        md: 'size-10 text-sm data-[interactive=true]:min-h-11 data-[interactive=true]:min-w-11',
+        lg: 'size-12 text-base',
+        xl: 'size-14 text-lg',
+        '2xl': 'size-16 text-xl',
+        '3xl': 'size-20 text-2xl'
+      },
+      rounded: {
+        none: 'rounded-none',
+        xs: 'rounded-xs',
+        sm: 'rounded-sm',
+        md: 'rounded-md',
+        lg: 'rounded-lg',
+        full: 'rounded-full'
+      }
+    },
+    defaultVariants: {
+      size: 'md',
+      rounded: 'md'
+    }
+  }
+);
+
+type AvatarVariantProps = VariantProps<typeof avatarVariants>;
+type NativeButtonProps = Omit<ComponentProps<'button'>, 'className' | 'children'>;
+
+export type AvatarProps = NativeButtonProps & {
+  /**
+   * @control text
+   * @default undefined
+   */
+  src?: string;
+  /**
+   * @control text
+   * @default Avatar
+   */
+  alt?: string;
+  /**
+   * @control select
+   * @default md
+   */
+  size?: NonNullable<AvatarVariantProps['size']>;
+  /**
+   * @control select
+   * @default md
+   */
+  rounded?: NonNullable<AvatarVariantProps['rounded']>;
   /** @control text */
   className?: string;
-  /** @control select */
-  rounded?: ThemeRounded;
-  /** Passing onClick enables hover/active scale effect and cursor-pointer automatically */
-  onClick?: () => void;
 };

--- a/src/components/atoms/avatar/useAvatar.ts
+++ b/src/components/atoms/avatar/useAvatar.ts
@@ -1,43 +1,62 @@
-import type { AvatarProps } from './types';
+import type { MouseEvent } from 'react';
+import { cn } from '@/lib/utils';
+import { type AvatarProps, avatarVariants } from './types';
 
-export const useAvatar = ({ src, alt = 'EG', className, size = 'md', rounded = 'md', onClick }: AvatarProps) => {
-  const sizeClasses = {
-    sm: '30px',
-    md: '40px',
-    lg: '50px',
-    xl: '60px',
-    '2xl': '70px',
-    '3xl': '80px'
+type UseAvatarReturn = Omit<AvatarProps, 'onClick'> & {
+  alt: string;
+  className: string;
+  fallback: string;
+  imageAlt: string;
+  interactive: boolean;
+  handleClick: (event: MouseEvent<HTMLButtonElement>) => void;
+};
+
+export const useAvatar = ({
+  src,
+  alt = 'Avatar',
+  className,
+  size = 'md',
+  rounded = 'md',
+  onClick,
+  disabled = false,
+  type = 'button',
+  ...props
+}: AvatarProps): UseAvatarReturn => {
+  const interactive = typeof onClick === 'function';
+
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    if (disabled) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    onClick?.(event);
   };
-  const textClasses = {
-    sm: 'text-[0.8em]',
-    md: 'text-[1em]',
-    lg: 'text-[1.2em]',
-    xl: 'text-[1.4em]',
-    '2xl': 'text-[1.6em]',
-    '3xl': 'text-[1.8em]'
+
+  return {
+    ...props,
+    src,
+    alt,
+    disabled,
+    type,
+    interactive,
+    imageAlt: '',
+    fallback: getInitials(alt),
+    className: cn(avatarVariants({ size, rounded }), className),
+    handleClick
   };
+};
 
-  const roundedClass = rounded ? `rounded-${rounded}` : '';
-  const sizeClass = sizeClasses[size];
-  const textClass = textClasses[size];
-
+const getInitials = (alt: string): string => {
   const initials = alt
     .trim()
     .split(/\s+/)
+    .filter(Boolean)
     .slice(0, 2)
     .map((word) => word[0])
     .join('')
     .toUpperCase();
 
-  return {
-    src,
-    alt,
-    initials,
-    className,
-    sizeClass,
-    textClass,
-    roundedClass,
-    onClick
-  };
+  return initials || 'A';
 };

--- a/src/components/atoms/avatar/useAvatar.ts
+++ b/src/components/atoms/avatar/useAvatar.ts
@@ -22,6 +22,7 @@ export const useAvatar = ({
   type = 'button',
   ...props
 }: AvatarProps): UseAvatarReturn => {
+  const normalizedAlt = normalizeAlt(alt);
   const interactive = typeof onClick === 'function';
 
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
@@ -37,15 +38,20 @@ export const useAvatar = ({
   return {
     ...props,
     src,
-    alt,
+    alt: normalizedAlt,
     disabled,
     type,
     interactive,
     imageAlt: '',
-    fallback: getInitials(alt),
+    fallback: getInitials(normalizedAlt),
     className: cn(avatarVariants({ size, rounded }), className),
     handleClick
   };
+};
+
+const normalizeAlt = (alt: string): string => {
+  const trimmedAlt = alt.trim();
+  return trimmedAlt || 'Avatar';
 };
 
 const getInitials = (alt: string): string => {


### PR DESCRIPTION
## Summary

Fixes Avatar accessibility, test coverage, variant structure, and visual affordance so the component is usable both as a static image/fallback and as an interactive profile trigger.

Closes #174

## Type of change

- [ ] 🧩 New component
- [x] 🐛 Bug fix
- [ ] 🎨 Design tokens
- [x] ♿ Accessibility
- [ ] 🏗️ Infrastructure
- [ ] 📚 Documentation

## Component checklist (skip if not applicable)

- [x] Follows the 5-file structure (`types.ts`, `use*.ts`, `Component.tsx`, `index.ts`, `*.stories.tsx`)
- [x] CVA variants defined in `types.ts`, not inline
- [x] No hardcoded colors — uses tokens from `theme.css`
- [x] No `any` types — TypeScript strict
- [x] ARIA attributes present and correct
- [x] Keyboard navigable (Tab, Enter, Escape where applicable)
- [x] Dark mode works correctly
- [x] Storybook stories cover: default, variants, states (hover, focus, disabled)
- [x] Tests added or updated

## Changes

| File | Change |
|------|--------|
| `src/components/atoms/avatar/types.ts` | Adds CVA variants, tokenized border/focus/disabled/size states, and typed props. |
| `src/components/atoms/avatar/useAvatar.ts` | Moves Avatar logic into the hook with typed return, fallback initials, and interactive/disabled behavior. |
| `src/components/atoms/avatar/Avatar.tsx` | Renders interactive avatars as real buttons and non-interactive avatars as named image regions. |
| `src/components/atoms/avatar/Avatar.test.tsx` | Adds hook and component tests for fallback, semantics, click, keyboard, and disabled behavior. |
| `src/components/atoms/avatar/Avatar.stories.tsx` | Cleans Storybook docs/actions, removes play functions, and adds disabled state coverage. |

## How to test

1. `pnpm vitest run src/components/atoms/avatar/Avatar.test.tsx --reporter=dot`
2. `pnpm tsc --noEmit`
3. `pnpm test` via pre-push hook
4. `pnpm run storybook`
5. Navigate to `Atoms/Avatar` and verify Default, WithoutImage, WithImage, Rounded, Interactive, and Disabled states.

## Screenshots / recordings (if applicable)

N/A

## Notes for reviewer

- Issue #174 is approved and linked.
- The Avatar border is intentionally tokenized (`border-border-strong-*`) so fallback avatars remain visible on same-color cards/surfaces without adding an always-on glow.
- Storybook's global `actions.argTypesRegex` can inject `onClick`; the Default story explicitly sets `onClick: undefined` to remain non-interactive.
