### PR TITLE
test(storybook): require explicit story examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ opencode.json
 .pi-lens/
 .atl/.skill-registry.cache.json
 .atl/
+
+# Local SDD/OpenSpec artifacts
+openspec/

--- a/src/components/atoms/badge/Badge.stories.tsx
+++ b/src/components/atoms/badge/Badge.stories.tsx
@@ -5,11 +5,6 @@ import { Button } from '../button';
 import Icon from '../icon/Icon';
 import { Badge } from './Badge';
 
-const colors = ['primary', 'secondary', 'success', 'warning', 'danger'] as const;
-const sizes = ['sm', 'md', 'lg'] as const;
-const variants = ['solid', 'flat', 'subtle'] as const;
-const placements = ['top-right', 'bottom-right', 'top-left', 'bottom-left'] as const;
-
 /**
  * ## Description
  * A small status, count, or label indicator for notification counts, presence dots, and compact metadata.
@@ -53,16 +48,15 @@ export const Default: Story = {
 export const Size: Story = {
   render: () => (
     <div className='flex items-center gap-4'>
-      {sizes.map((size) => (
-        <Badge key={size} content='1' size={size} ariaLabel={`${size} notification badge`}>
-          <Avatar
-            src={`https://i.pravatar.cc/300?u=badge-size-${size}`}
-            alt={`${size} avatar`}
-            rounded='full'
-            size='lg'
-          />
-        </Badge>
-      ))}
+      <Badge content='1' size='sm' ariaLabel='Small notification badge'>
+        <Avatar src='https://i.pravatar.cc/300?u=badge-size-sm' alt='Small avatar' rounded='full' size='lg' />
+      </Badge>
+      <Badge content='1' size='md' ariaLabel='Medium notification badge'>
+        <Avatar src='https://i.pravatar.cc/300?u=badge-size-md' alt='Medium avatar' rounded='full' size='lg' />
+      </Badge>
+      <Badge content='1' size='lg' ariaLabel='Large notification badge'>
+        <Avatar src='https://i.pravatar.cc/300?u=badge-size-lg' alt='Large avatar' rounded='full' size='lg' />
+      </Badge>
     </div>
   )
 };
@@ -73,16 +67,26 @@ export const Size: Story = {
 export const Color: Story = {
   render: () => (
     <div className='flex items-center gap-4'>
-      {colors.map((color, index) => (
-        <Badge key={color} content={index + 1} color={color} ariaLabel={`${color} badge`}>
-          <Avatar
-            src={`https://i.pravatar.cc/300?u=badge-color-${color}`}
-            alt={`${color} avatar`}
-            rounded='full'
-            size='lg'
-          />
-        </Badge>
-      ))}
+      <Badge content={1} color='primary' ariaLabel='Primary badge'>
+        <Avatar src='https://i.pravatar.cc/300?u=badge-color-primary' alt='Primary avatar' rounded='full' size='lg' />
+      </Badge>
+      <Badge content={2} color='secondary' ariaLabel='Secondary badge'>
+        <Avatar
+          src='https://i.pravatar.cc/300?u=badge-color-secondary'
+          alt='Secondary avatar'
+          rounded='full'
+          size='lg'
+        />
+      </Badge>
+      <Badge content={3} color='success' ariaLabel='Success badge'>
+        <Avatar src='https://i.pravatar.cc/300?u=badge-color-success' alt='Success avatar' rounded='full' size='lg' />
+      </Badge>
+      <Badge content={4} color='warning' ariaLabel='Warning badge'>
+        <Avatar src='https://i.pravatar.cc/300?u=badge-color-warning' alt='Warning avatar' rounded='full' size='lg' />
+      </Badge>
+      <Badge content={5} color='danger' ariaLabel='Danger badge'>
+        <Avatar src='https://i.pravatar.cc/300?u=badge-color-danger' alt='Danger avatar' rounded='full' size='lg' />
+      </Badge>
     </div>
   )
 };
@@ -93,13 +97,27 @@ export const Color: Story = {
 export const Variant: Story = {
   render: () => (
     <div className='grid gap-3'>
-      {variants.map((variant) => (
-        <div key={variant} className='flex flex-wrap items-center gap-2'>
-          {colors.map((color) => (
-            <Badge key={`${variant}-${color}`} content={color} color={color} variant={variant} rounded={false} />
-          ))}
-        </div>
-      ))}
+      <div className='flex flex-wrap items-center gap-2'>
+        <Badge content='primary' color='primary' variant='solid' rounded={false} />
+        <Badge content='secondary' color='secondary' variant='solid' rounded={false} />
+        <Badge content='success' color='success' variant='solid' rounded={false} />
+        <Badge content='warning' color='warning' variant='solid' rounded={false} />
+        <Badge content='danger' color='danger' variant='solid' rounded={false} />
+      </div>
+      <div className='flex flex-wrap items-center gap-2'>
+        <Badge content='primary' color='primary' variant='flat' rounded={false} />
+        <Badge content='secondary' color='secondary' variant='flat' rounded={false} />
+        <Badge content='success' color='success' variant='flat' rounded={false} />
+        <Badge content='warning' color='warning' variant='flat' rounded={false} />
+        <Badge content='danger' color='danger' variant='flat' rounded={false} />
+      </div>
+      <div className='flex flex-wrap items-center gap-2'>
+        <Badge content='primary' color='primary' variant='subtle' rounded={false} />
+        <Badge content='secondary' color='secondary' variant='subtle' rounded={false} />
+        <Badge content='success' color='success' variant='subtle' rounded={false} />
+        <Badge content='warning' color='warning' variant='subtle' rounded={false} />
+        <Badge content='danger' color='danger' variant='subtle' rounded={false} />
+      </div>
     </div>
   )
 };
@@ -110,16 +128,38 @@ export const Variant: Story = {
 export const Placement: Story = {
   render: () => (
     <div className='flex items-center gap-5'>
-      {placements.map((placement, index) => (
-        <Badge key={placement} content={index + 1} placement={placement} ariaLabel={`${placement} badge`}>
-          <Avatar
-            src={`https://i.pravatar.cc/300?u=badge-placement-${placement}`}
-            alt={`${placement} avatar`}
-            rounded='full'
-            size='lg'
-          />
-        </Badge>
-      ))}
+      <Badge content={1} placement='top-right' ariaLabel='Top-right badge'>
+        <Avatar
+          src='https://i.pravatar.cc/300?u=badge-placement-top-right'
+          alt='Top-right avatar'
+          rounded='full'
+          size='lg'
+        />
+      </Badge>
+      <Badge content={2} placement='bottom-right' ariaLabel='Bottom-right badge'>
+        <Avatar
+          src='https://i.pravatar.cc/300?u=badge-placement-bottom-right'
+          alt='Bottom-right avatar'
+          rounded='full'
+          size='lg'
+        />
+      </Badge>
+      <Badge content={3} placement='top-left' ariaLabel='Top-left badge'>
+        <Avatar
+          src='https://i.pravatar.cc/300?u=badge-placement-top-left'
+          alt='Top-left avatar'
+          rounded='full'
+          size='lg'
+        />
+      </Badge>
+      <Badge content={4} placement='bottom-left' ariaLabel='Bottom-left badge'>
+        <Avatar
+          src='https://i.pravatar.cc/300?u=badge-placement-bottom-left'
+          alt='Bottom-left avatar'
+          rounded='full'
+          size='lg'
+        />
+      </Badge>
     </div>
   )
 };
@@ -203,23 +243,62 @@ export const BadgeVisibility: Story = {
 export const Animation: Story = {
   render: () => (
     <div className='flex items-center gap-6'>
-      {(['default', 'pulse', 'bounce', 'ping'] as const).map((animation) => (
-        <Badge
-          key={animation}
-          content={<Icon name='bell-dot' size={12} color='text-white' />}
-          color='primary'
-          size='sm'
-          animation={animation}
-          ariaLabel={`${animation} notification animation`}
-        >
-          <Avatar
-            src={`https://i.pravatar.cc/300?u=badge-animation-${animation}`}
-            alt={`${animation} animation avatar`}
-            rounded='full'
-            size='lg'
-          />
-        </Badge>
-      ))}
+      <Badge
+        content={<Icon name='bell-dot' size={12} color='text-white' />}
+        color='primary'
+        size='sm'
+        animation='default'
+        ariaLabel='Default notification animation'
+      >
+        <Avatar
+          src='https://i.pravatar.cc/300?u=badge-animation-default'
+          alt='Default animation avatar'
+          rounded='full'
+          size='lg'
+        />
+      </Badge>
+      <Badge
+        content={<Icon name='bell-dot' size={12} color='text-white' />}
+        color='primary'
+        size='sm'
+        animation='pulse'
+        ariaLabel='Pulse notification animation'
+      >
+        <Avatar
+          src='https://i.pravatar.cc/300?u=badge-animation-pulse'
+          alt='Pulse animation avatar'
+          rounded='full'
+          size='lg'
+        />
+      </Badge>
+      <Badge
+        content={<Icon name='bell-dot' size={12} color='text-white' />}
+        color='primary'
+        size='sm'
+        animation='bounce'
+        ariaLabel='Bounce notification animation'
+      >
+        <Avatar
+          src='https://i.pravatar.cc/300?u=badge-animation-bounce'
+          alt='Bounce animation avatar'
+          rounded='full'
+          size='lg'
+        />
+      </Badge>
+      <Badge
+        content={<Icon name='bell-dot' size={12} color='text-white' />}
+        color='primary'
+        size='sm'
+        animation='ping'
+        ariaLabel='Ping notification animation'
+      >
+        <Avatar
+          src='https://i.pravatar.cc/300?u=badge-animation-ping'
+          alt='Ping animation avatar'
+          rounded='full'
+          size='lg'
+        />
+      </Badge>
     </div>
   )
 };

--- a/src/components/atoms/badge/Badge.stories.tsx
+++ b/src/components/atoms/badge/Badge.stories.tsx
@@ -1,22 +1,27 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, within } from '@storybook/test';
 import { useState } from 'react';
 import { Avatar } from '../avatar/Avatar';
 import { Button } from '../button';
 import Icon from '../icon/Icon';
 import { Badge } from './Badge';
 
-/**
- * ## DESCRIPTION
- * A Badge is a small indicator used to convey numerical values, statuses, or labels.
- *
- * They are commonly used to represent notifications, messages, counts, or statuses on top of icons or avatars.
- *
- * - Customizable in color, size, variant, position and animation.
- * - Can be combined with icons, avatars or any other component.
- * - Accessible via the `ariaLabel` prop.
- */
+const colors = ['primary', 'secondary', 'success', 'warning', 'danger'] as const;
+const sizes = ['sm', 'md', 'lg'] as const;
+const variants = ['solid', 'flat', 'subtle'] as const;
+const placements = ['top-right', 'bottom-right', 'top-left', 'bottom-left'] as const;
 
+/**
+ * ## Description
+ * A small status, count, or label indicator for notification counts, presence dots, and compact metadata.
+ * Badge can render standalone or position itself over child content such as avatars, icons, or buttons.
+ *
+ * ## Dependencies
+ * Uses `Avatar`, `Button`, and `Icon` in examples to demonstrate common composition patterns.
+ *
+ * ## Usage Guide
+ * Provide `ariaLabel` for icon-only and dot badges, and for dynamic counts whose visible text needs more context.
+ * Hidden badges are removed from the accessibility tree when `visibility` is `false`.
+ */
 const meta: Meta<typeof Badge> = {
   title: 'Atoms/Badge',
   component: Badge,
@@ -31,277 +36,158 @@ export default meta;
 
 type Story = StoryObj<typeof Badge>;
 
+/**
+ * Shows the default badge variants positioned over a child avatar.
+ */
 export const Default: Story = {
   args: {
-    color: 'primary',
     content: '1',
-    variant: 'solid',
-    placement: 'top-right',
-    size: 'sm',
-    rounded: true,
-    visibility: true,
-    animation: 'default',
-    ariaLabel: '',
-    ariaLive: 'off',
-    role: 'status',
-    children: <Avatar src='https://i.pravatar.cc/300?u=a042581f4e29026709d' alt='Avatar' rounded='full' size='lg' />
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Verify badge renders with correct role
-    const badge = canvas.getByRole('status');
-    await expect(badge).toBeInTheDocument();
-
-    // Verify badge content is correct
-    await expect(badge).toHaveTextContent('1');
+    ariaLabel: '1 notification',
+    children: <Avatar src='https://i.pravatar.cc/300?u=badge-default' alt='Avatar' rounded='full' size='lg' />
   }
 };
 
 /**
- * The `size` prop defines the height, padding and font-size of the badge.
- *
- * Available options:
- * - `sm` → Small
- * - `md` → Medium (default)
- * - `lg` → Large
- *
- * Use it to control the visual weight of the badge based on the element it accompanies.
+ * Compares the available badge sizes while preserving the same content and placement.
  */
 export const Size: Story = {
   render: () => (
-    <div className='flex gap-4 items-center'>
-      <Badge content={'1'} size='sm'>
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e29026704d' alt='Avatar' rounded='full' size='lg' />
-      </Badge>
-      <Badge content={'1'} size='md'>
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e2902asd4d' alt='Avatar' rounded='full' size='lg' />
-      </Badge>
-      <Badge content={'1'} size='lg'>
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e290267012' alt='Avatar' rounded='full' size='lg' />
-      </Badge>
+    <div className='flex items-center gap-4'>
+      {sizes.map((size) => (
+        <Badge key={size} content='1' size={size} ariaLabel={`${size} notification badge`}>
+          <Avatar
+            src={`https://i.pravatar.cc/300?u=badge-size-${size}`}
+            alt={`${size} avatar`}
+            rounded='full'
+            size='lg'
+          />
+        </Badge>
+      ))}
     </div>
-  ),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Verify all three badge sizes render
-    const badges = canvas.getAllByRole('status');
-    await expect(badges).toHaveLength(3);
-
-    // Verify each badge has the correct content
-    for (const badge of badges) {
-      await expect(badge).toHaveTextContent('1');
-    }
-  }
+  )
 };
 
 /**
- * The `color` prop sets the background and text color of the badge.
- *
- * Available options:
- * - `primary`
- * - `secondary`
- * - `success`
- * - `warning`
- * - `danger`
- *
- * Useful for conveying the meaning or status of the content (e.g. green for success, red for error).
+ * Shows each semantic color as a positioned notification count.
  */
 export const Color: Story = {
   render: () => (
-    <div className='flex gap-4 items-center'>
-      <Badge content={'1'} color={'primary'}>
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e290267100' alt='Avatar' rounded='full' size='lg' />
-      </Badge>
-      <Badge content={'2'} color={'secondary'}>
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e290267200' alt='Avatar' rounded='full' size='lg' />
-      </Badge>
-      <Badge content={'3'} color={'success'}>
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e290267300' alt='Avatar' rounded='full' size='lg' />
-      </Badge>
-      <Badge content={'4'} color={'warning'}>
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e290267400' alt='Avatar' rounded='full' size='lg' />
-      </Badge>
-      <Badge content={'5'} color={'danger'}>
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e290267500' alt='Avatar' rounded='full' size='lg' />
-      </Badge>
+    <div className='flex items-center gap-4'>
+      {colors.map((color, index) => (
+        <Badge key={color} content={index + 1} color={color} ariaLabel={`${color} badge`}>
+          <Avatar
+            src={`https://i.pravatar.cc/300?u=badge-color-${color}`}
+            alt={`${color} avatar`}
+            rounded='full'
+            size='lg'
+          />
+        </Badge>
+      ))}
     </div>
-  ),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Verify all five color variants render
-    const badges = canvas.getAllByRole('status');
-    await expect(badges).toHaveLength(5);
-
-    // Verify each badge has the correct content
-    await expect(badges[0]).toHaveTextContent('1');
-    await expect(badges[1]).toHaveTextContent('2');
-    await expect(badges[2]).toHaveTextContent('3');
-    await expect(badges[3]).toHaveTextContent('4');
-    await expect(badges[4]).toHaveTextContent('5');
-  }
+  )
 };
 
 /**
- * The `variant` prop defines visual style modifications for the badge.
- *
- * Available options:
- * - `solid` → Maximum prominence with full background color.
- * - `flat` → Medium prominence with opaque tinted background and border.
- * - `subtle` → Minimum prominence with very soft background, no border.
- *
- * Use variants to establish a clear visual hierarchy based on importance.
+ * Compares solid, flat, and subtle visual treatments across semantic colors.
  */
 export const Variant: Story = {
   render: () => (
-    <div className='flex gap-4 items-center'>
-      <Badge content={'5'} variant={'solid'}>
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e290267600' alt='Avatar' rounded='full' size='lg' />
-      </Badge>
-      <Badge content={'5'} variant={'flat'}>
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e290267700' alt='Avatar' rounded='full' size='lg' />
-      </Badge>
-      <Badge content={'5'} variant={'subtle'}>
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e290267800' alt='Avatar' rounded='full' size='lg' />
-      </Badge>
+    <div className='grid gap-3'>
+      {variants.map((variant) => (
+        <div key={variant} className='flex flex-wrap items-center gap-2'>
+          {colors.map((color) => (
+            <Badge key={`${variant}-${color}`} content={color} color={color} variant={variant} rounded={false} />
+          ))}
+        </div>
+      ))}
     </div>
-  ),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Verify all three variants render
-    const badges = canvas.getAllByRole('status');
-    await expect(badges).toHaveLength(3);
-
-    // Verify all have same content
-    for (const badge of badges) {
-      await expect(badge).toHaveTextContent('5');
-    }
-  }
+  )
 };
 
 /**
- * The `placement` prop determines the position of the badge relative to its child element.
- *
- * **Important:** `placement` only works when the Badge has `children` (e.g., an Avatar or Icon).
- * For standalone badges, the prop is ignored and the badge renders as an inline element.
- *
- * Available options:
- * - `top-right` (default)
- * - `bottom-right`
- * - `top-left`
- * - `bottom-left`
- *
- * Use this to position notification badges over avatars, icons, or buttons.
+ * Demonstrates how placement changes when the badge is composed with child content.
  */
 export const Placement: Story = {
   render: () => (
-    <div className='flex gap-4 items-center'>
-      <Badge content={'1'} placement={'top-right'}>
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e290267900' alt='Avatar' rounded='full' size='lg' />
-      </Badge>
-      <Badge content={'2'} placement={'bottom-right'}>
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e290267000' alt='Avatar' rounded='full' size='lg' />
-      </Badge>
-      <Badge content={'3'} placement={'top-left'}>
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e290266800' alt='Avatar' rounded='full' size='lg' />
-      </Badge>
-      <Badge content={'4'} placement={'bottom-left'}>
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e290262800' alt='Avatar' rounded='full' size='lg' />
-      </Badge>
+    <div className='flex items-center gap-5'>
+      {placements.map((placement, index) => (
+        <Badge key={placement} content={index + 1} placement={placement} ariaLabel={`${placement} badge`}>
+          <Avatar
+            src={`https://i.pravatar.cc/300?u=badge-placement-${placement}`}
+            alt={`${placement} avatar`}
+            rounded='full'
+            size='lg'
+          />
+        </Badge>
+      ))}
     </div>
   )
 };
 
 /**
- * When used without `children`, the badge renders as a standalone inline element.
- * The `placement` prop is ignored in this mode.
- *
- * Use standalone badges for labels, tags, and status indicators.
+ * Shows standalone badges for labels and compact metadata; placement is ignored without children.
  */
 export const Standalone: Story = {
   render: () => (
-    <div className='flex gap-2 flex-wrap'>
-      <Badge content={'New'} color={'primary'} variant={'subtle'} size={'sm'} rounded={false} />
-      <Badge content={'Pro'} color={'warning'} variant={'flat'} size={'sm'} rounded={false} />
-      <Badge content={'Beta'} color={'secondary'} variant={'flat'} size={'sm'} rounded={false} />
-      <Badge content={'5'} color={'primary'} variant={'solid'} size={'sm'} />
-      <Badge content={'React'} color={'success'} variant={'subtle'} size={'sm'} rounded={false} />
-      <Badge content={'TypeScript'} color={'secondary'} variant={'subtle'} size={'sm'} rounded={false} />
+    <div className='flex flex-wrap gap-2'>
+      <Badge content='New' color='primary' variant='subtle' size='sm' rounded={false} />
+      <Badge content='Pro' color='warning' variant='flat' size='sm' rounded={false} />
+      <Badge content='Beta' color='secondary' variant='flat' size='sm' rounded={false} />
+      <Badge content='5' color='primary' variant='solid' size='sm' ariaLabel='5 notifications' />
+      <Badge content='React' color='success' variant='subtle' size='sm' rounded={false} />
+      <Badge content='TypeScript' color='secondary' variant='subtle' size='sm' rounded={false} />
     </div>
-  ),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Verify all standalone badges render
-    const badges = canvas.getAllByRole('status');
-    await expect(badges).toHaveLength(6);
-
-    // Verify specific badge content
-    await expect(canvas.getByText('New')).toBeInTheDocument();
-    await expect(canvas.getByText('Pro')).toBeInTheDocument();
-    await expect(canvas.getByText('Beta')).toBeInTheDocument();
-    await expect(canvas.getByText('React')).toBeInTheDocument();
-    await expect(canvas.getByText('TypeScript')).toBeInTheDocument();
-  }
+  )
 };
 
 /**
- * The `content` prop accepts four types of values:
- *
- * - **Number** → for unread counts or notifications
- * - **Text** → for short labels like "New" or "Beta"
- * - **Icon** → for status indicators
- * - **Empty string** → renders as a dot, useful for presence or activity indicators
+ * Shows number, text, icon, and dot content patterns.
  */
 export const ContentExamples: Story = {
   render: () => (
-    <div className='flex gap-4 items-center'>
-      {/* Number */}
-      <Badge content={3} color={'primary'}>
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e291262800' alt='Avatar' rounded='full' size='lg' />
+    <div className='flex items-center gap-4'>
+      <Badge content={3} color='primary' ariaLabel='3 notifications'>
+        <Avatar
+          src='https://i.pravatar.cc/300?u=badge-content-number'
+          alt='Number badge avatar'
+          rounded='full'
+          size='lg'
+        />
       </Badge>
-      {/* Text */}
-      <Badge content={'New'} color={'primary'}>
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e295262800' alt='Avatar' rounded='full' size='lg' />
+      <Badge content='New' color='primary'>
+        <Avatar src='https://i.pravatar.cc/300?u=badge-content-text' alt='Text badge avatar' rounded='full' size='lg' />
       </Badge>
-      {/* Icon */}
       <Badge
         content={<Icon name='check' size={10} color='text-white' />}
-        color={'success'}
-        size={'sm'}
-        placement={'bottom-right'}
+        color='success'
+        size='sm'
+        placement='bottom-right'
+        ariaLabel='Verified'
       >
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e296262800' alt='Avatar' rounded='full' size='lg' />
+        <Avatar src='https://i.pravatar.cc/300?u=badge-content-icon' alt='Icon badge avatar' rounded='full' size='lg' />
       </Badge>
-      {/* Empty → dot */}
-      <Badge content={''} color={'success'} size={'sm'} placement={'bottom-right'}>
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e293262800' alt='Avatar' rounded='full' size='lg' />
+      <Badge content='' color='success' size='sm' placement='bottom-right' ariaLabel='Online'>
+        <Avatar src='https://i.pravatar.cc/300?u=badge-content-dot' alt='Dot badge avatar' rounded='full' size='lg' />
       </Badge>
     </div>
   )
 };
+
 /**
- * The `visibility` prop toggles whether the badge is shown.
- *
- * It accepts a boolean (`true` or `false`) and can be dynamically controlled.
- *
- * Useful for conditionally hiding or showing badges based on user interaction or state.
+ * Toggles `visibility`; hidden badges are removed while the child trigger remains visible.
  */
 export const BadgeVisibility: Story = {
   render: () => {
     const [visible, setVisible] = useState(true);
 
     return (
-      <div className='flex gap-6 items-center'>
-        <Badge content='5' color={'danger'} visibility={visible}>
+      <div className='flex items-center gap-6'>
+        <Badge content='5' color='danger' visibility={visible} ariaLabel='5 alerts'>
           <Icon name='bell-ring' size={28} colorDark='dark:text-white' />
         </Badge>
         <Button
           onClick={() => setVisible((prev) => !prev)}
-          variant={'outlined'}
+          variant='outlined'
           text={visible ? 'Hide' : 'Show'}
           size='sm'
           className='w-20'
@@ -310,92 +196,43 @@ export const BadgeVisibility: Story = {
     );
   }
 };
+
 /**
- * The `animation` prop allows you to apply movement or visual feedback to the badge.
- *
- * Available options:
- * - `default` → No animation
- * - `pulse` → Smooth fading in and out
- * - `bounce` → Subtle bounce
- * - `ping` → Expanding ripple effect
- * - `rotation` → Continuous rotation
- *
- * Use animations to draw attention to updates or notifications.
+ * Shows the supported decorative animation values with reduced-motion-safe CSS classes.
  */
 export const Animation: Story = {
   render: () => (
-    <div className='flex gap-6 items-center'>
-      <Badge
-        content={<Icon name='bell-dot' size={12} color='text-white' />}
-        color={'primary'}
-        size={'sm'}
-        animation={'default'}
-      >
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e196262800' alt='Avatar' rounded='full' size='lg' />
-      </Badge>
-      <Badge
-        content={<Icon name='bell-dot' size={12} color='text-white' />}
-        color={'primary'}
-        size={'sm'}
-        animation={'pulse'}
-      >
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e296262800' alt='Avatar' rounded='full' size='lg' />
-      </Badge>
-      <Badge
-        content={<Icon name='bell-dot' size={12} color='text-white' />}
-        color={'primary'}
-        size={'sm'}
-        animation={'bounce'}
-      >
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e396262800' alt='Avatar' rounded='full' size='lg' />
-      </Badge>
-      <Badge
-        content={<Icon name='bell-dot' size={12} color='text-white' />}
-        color={'primary'}
-        size={'sm'}
-        animation={'ping'}
-      >
-        <Avatar src='https://i.pravatar.cc/300?u=a042581f4e496262800' alt='Avatar' rounded='full' size='lg' />
-      </Badge>
+    <div className='flex items-center gap-6'>
+      {(['default', 'pulse', 'bounce', 'ping'] as const).map((animation) => (
+        <Badge
+          key={animation}
+          content={<Icon name='bell-dot' size={12} color='text-white' />}
+          color='primary'
+          size='sm'
+          animation={animation}
+          ariaLabel={`${animation} notification animation`}
+        >
+          <Avatar
+            src={`https://i.pravatar.cc/300?u=badge-animation-${animation}`}
+            alt={`${animation} animation avatar`}
+            rounded='full'
+            size='lg'
+          />
+        </Badge>
+      ))}
     </div>
   )
 };
+
 /**
- * The `ariaLabel`, `ariaLive`, and `role` props improve screen reader accessibility for badges.
- *
- * - `ariaLabel` provides a descriptive text alternative, useful for dynamic or icon-only content.
- * - `ariaLive` tells assistive technologies how urgently to announce updates to the badge. (e.g. `"polite"` or `"assertive"`).
- * - `role` defines the semantic meaning of the badge. Common value: `"status"` for dynamic content.
- *
- * ### Examples:
- * - `ariaLabel="5 unread notifications"`
- * - `ariaLive="assertive"`
- * - `role="status"`
- *
- * These props are especially helpful when the badge communicates real-time updates.
+ * Documents the accessibility props for dynamic and icon-only badge content.
  */
 export const Accessibility: Story = {
   render: () => (
-    <div className='flex gap-4 items-center'>
-      <Badge content={'+99'} color={'danger'} ariaLabel='more than 99 notifications' role='status' ariaLive='assertive'>
+    <div className='flex items-center gap-4'>
+      <Badge content='+99' color='danger' ariaLabel='More than 99 notifications' role='status' ariaLive='assertive'>
         <Icon name='bell-ring' size={34} colorDark='dark:text-white' />
       </Badge>
     </div>
-  ),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Verify badge renders with correct accessibility attributes
-    const badge = canvas.getByRole('status');
-    await expect(badge).toBeInTheDocument();
-
-    // Verify aria-label is present
-    await expect(badge).toHaveAttribute('aria-label', 'more than 99 notifications');
-
-    // Verify aria-live is assertive
-    await expect(badge).toHaveAttribute('aria-live', 'assertive');
-
-    // Verify badge content
-    await expect(badge).toHaveTextContent('+99');
-  }
+  )
 };

--- a/src/components/atoms/badge/Badge.test.tsx
+++ b/src/components/atoms/badge/Badge.test.tsx
@@ -1,0 +1,149 @@
+import { render, renderHook, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Badge } from './Badge';
+import { useBadge } from './useBadge';
+
+describe('useBadge — logic', () => {
+  it('returns accessible defaults for a standalone dot badge', () => {
+    const { result } = renderHook(() => useBadge({}));
+
+    expect(result.current.content).toBe('');
+    expect(result.current.hasChildren).toBe(false);
+    expect(result.current.isDot).toBe(true);
+    expect(result.current.isSquare).toBe(true);
+    expect(result.current.shouldRenderBadge).toBe(true);
+    expect(result.current.badgeProps.role).toBe('status');
+    expect(result.current.badgeProps['aria-live']).toBe('off');
+  });
+
+  it('ignores placement for standalone badges and keeps positioned badges wrapped with children', () => {
+    const { result: standaloneResult } = renderHook(() => useBadge({ content: 'New', placement: 'bottom-left' }));
+    const { result: positionedResult } = renderHook(() =>
+      useBadge({
+        content: '3',
+        placement: 'bottom-left',
+        children: <span>Inbox</span>
+      })
+    );
+
+    expect(standaloneResult.current.hasChildren).toBe(false);
+    expect(standaloneResult.current.badgeProps.className).not.toContain('absolute');
+    expect(standaloneResult.current.badgeProps.className).not.toContain('translate');
+    expect(positionedResult.current.hasChildren).toBe(true);
+    expect(positionedResult.current.children).toBeTruthy();
+    expect(positionedResult.current.badgeProps.className).toContain('bottom-0');
+    expect(positionedResult.current.badgeProps.className).toContain('-translate-x-1/3');
+  });
+
+  it('defaults positioned badges to top-right without applying placement to standalone badges', () => {
+    const { result: standaloneResult } = renderHook(() => useBadge({ content: 'New' }));
+    const { result: positionedResult } = renderHook(() =>
+      useBadge({
+        content: '3',
+        children: <span>Inbox</span>
+      })
+    );
+
+    expect(standaloneResult.current.badgeProps.className).not.toContain('top-0');
+    expect(standaloneResult.current.badgeProps.className).not.toContain('right-0');
+    expect(positionedResult.current.badgeProps.className).toContain('top-0');
+    expect(positionedResult.current.badgeProps.className).toContain('right-0');
+    expect(positionedResult.current.badgeProps.className).toContain('translate-x-1/3');
+    expect(positionedResult.current.badgeProps.className).toContain('-translate-y-1/3');
+  });
+
+  it('marks icon and dot content as square badges', () => {
+    const { result: iconResult } = renderHook(() => useBadge({ content: <span aria-hidden='true'>✓</span> }));
+    const { result: dotResult } = renderHook(() => useBadge({ content: '' }));
+
+    expect(iconResult.current.isSquare).toBe(true);
+    expect(dotResult.current.isSquare).toBe(true);
+  });
+
+  it('does not render hidden badges', () => {
+    const { result } = renderHook(() => useBadge({ content: '5', visibility: false }));
+
+    expect(result.current.shouldRenderBadge).toBe(false);
+  });
+
+  it('keeps entrance animation separate from decorative animation', () => {
+    const { result: defaultResult } = renderHook(() => useBadge({ content: '5' }));
+    const { result: pulseResult } = renderHook(() => useBadge({ content: '5', animation: 'pulse' }));
+
+    expect(defaultResult.current.badgeProps.className).toContain('motion-safe:animate-badgeIn');
+    expect(pulseResult.current.badgeProps.className).toContain('motion-safe:animate-pulse');
+    expect(pulseResult.current.badgeProps.className).not.toContain('motion-safe:animate-badgeIn');
+  });
+});
+
+describe('Badge — component behavior', () => {
+  it('renders standalone badges without a positioning wrapper', () => {
+    const { container } = render(<Badge content='New' ariaLabel='New feature' />);
+
+    expect(container.firstElementChild?.tagName).toBe('SPAN');
+    const badge = screen.getByRole('status');
+
+    expect(badge).toHaveTextContent('New');
+    expect(badge).toHaveAttribute('aria-label', 'New feature');
+    expect(badge).not.toHaveClass('absolute');
+  });
+
+  it('renders positioned badges with their child content', () => {
+    const { container } = render(
+      <Badge content='4' ariaLabel='4 unread messages'>
+        <button type='button'>Inbox</button>
+      </Badge>
+    );
+
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+    expect(screen.getByRole('button', { name: 'Inbox' })).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('4');
+  });
+
+  it('applies aria label, role, and live region attributes', () => {
+    render(<Badge content='+99' ariaLabel='More than 99 notifications' ariaLive='assertive' role='status' />);
+
+    const badge = screen.getByRole('status');
+
+    expect(badge).toHaveAttribute('aria-label', 'More than 99 notifications');
+    expect(badge).toHaveAttribute('aria-live', 'assertive');
+  });
+
+  it('renders icon content with an accessible label', () => {
+    render(
+      <Badge content={<span aria-hidden='true'>✓</span>} ariaLabel='Verified account' color='success' size='sm' />
+    );
+
+    const badge = screen.getByRole('status');
+
+    expect(badge).toHaveAttribute('aria-label', 'Verified account');
+    expect(badge).toHaveTextContent('✓');
+  });
+
+  it('renders dot badges with an accessible label', () => {
+    render(<Badge content='' ariaLabel='Online' color='success' size='sm' />);
+
+    const badge = screen.getByRole('status');
+
+    expect(badge).toHaveAttribute('aria-label', 'Online');
+    expect(badge).toHaveTextContent('');
+  });
+
+  it('does not expose hidden standalone badges to assistive technology or layout', () => {
+    const { container } = render(<Badge content='7' ariaLabel='7 notifications' visibility={false} />);
+
+    expect(container.firstElementChild).toBeNull();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('keeps children visible but removes the hidden positioned badge', () => {
+    render(
+      <Badge content='7' ariaLabel='7 notifications' visibility={false}>
+        <button type='button'>Notifications</button>
+      </Badge>
+    );
+
+    expect(screen.getByRole('button', { name: 'Notifications' })).toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/atoms/badge/Badge.test.tsx
+++ b/src/components/atoms/badge/Badge.test.tsx
@@ -27,12 +27,10 @@ describe('useBadge — logic', () => {
     );
 
     expect(standaloneResult.current.hasChildren).toBe(false);
-    expect(standaloneResult.current.badgeProps.className).not.toContain('absolute');
-    expect(standaloneResult.current.badgeProps.className).not.toContain('translate');
+    expect(standaloneResult.current.resolvedPlacement).toBeUndefined();
     expect(positionedResult.current.hasChildren).toBe(true);
     expect(positionedResult.current.children).toBeTruthy();
-    expect(positionedResult.current.badgeProps.className).toContain('bottom-0');
-    expect(positionedResult.current.badgeProps.className).toContain('-translate-x-1/3');
+    expect(positionedResult.current.resolvedPlacement).toBe('bottom-left');
   });
 
   it('defaults positioned badges to top-right without applying placement to standalone badges', () => {
@@ -44,12 +42,8 @@ describe('useBadge — logic', () => {
       })
     );
 
-    expect(standaloneResult.current.badgeProps.className).not.toContain('top-0');
-    expect(standaloneResult.current.badgeProps.className).not.toContain('right-0');
-    expect(positionedResult.current.badgeProps.className).toContain('top-0');
-    expect(positionedResult.current.badgeProps.className).toContain('right-0');
-    expect(positionedResult.current.badgeProps.className).toContain('translate-x-1/3');
-    expect(positionedResult.current.badgeProps.className).toContain('-translate-y-1/3');
+    expect(standaloneResult.current.resolvedPlacement).toBeUndefined();
+    expect(positionedResult.current.resolvedPlacement).toBe('top-right');
   });
 
   it('marks icon and dot content as square badges', () => {
@@ -70,9 +64,8 @@ describe('useBadge — logic', () => {
     const { result: defaultResult } = renderHook(() => useBadge({ content: '5' }));
     const { result: pulseResult } = renderHook(() => useBadge({ content: '5', animation: 'pulse' }));
 
-    expect(defaultResult.current.badgeProps.className).toContain('motion-safe:animate-badgeIn');
-    expect(pulseResult.current.badgeProps.className).toContain('motion-safe:animate-pulse');
-    expect(pulseResult.current.badgeProps.className).not.toContain('motion-safe:animate-badgeIn');
+    expect(defaultResult.current.shouldAnimateIn).toBe(true);
+    expect(pulseResult.current.shouldAnimateIn).toBe(false);
   });
 });
 
@@ -85,7 +78,6 @@ describe('Badge — component behavior', () => {
 
     expect(badge).toHaveTextContent('New');
     expect(badge).toHaveAttribute('aria-label', 'New feature');
-    expect(badge).not.toHaveClass('absolute');
   });
 
   it('renders positioned badges with their child content', () => {

--- a/src/components/atoms/badge/Badge.tsx
+++ b/src/components/atoms/badge/Badge.tsx
@@ -1,52 +1,18 @@
 import type { FC } from 'react';
-import { cn } from '@/lib/utils';
 import type { BadgeProps } from './types';
 import { useBadge } from './useBadge';
 
 export const Badge: FC<BadgeProps> = ({ ...props }) => {
-  const {
-    content,
-    className,
-    visibility,
-    ariaLabel,
-    children,
-    badgeClass,
-    showRenderBadge,
-    role,
-    ariaLive,
-    hasChildren,
-    isSquare
-  } = useBadge({ ...props });
+  const { content, children, badgeProps, hasChildren, shouldRenderBadge } = useBadge({ ...props });
 
-  // Square size map — matches h- values defined per size in badgeVariants
-  const squareSizeMap = { sm: '!w-[18px]', md: '!w-[24px]', lg: '!w-[28px]' } as const;
-
-  const spanClass = cn(
-    badgeClass,
-    // Icon or empty content: remove horizontal padding so the badge stays square
-    isSquare && `!px-0 ${squareSizeMap[props.size ?? 'md']}`,
-    visibility ? 'animate-badgeIn' : 'animate-badgeOut pointer-events-none',
-    className
-  );
-
-  // If there are no children, render badge standalone (inline)
   if (!hasChildren) {
-    return showRenderBadge ? (
-      <span className={spanClass} aria-label={ariaLabel} role={role} aria-live={ariaLive}>
-        {content}
-      </span>
-    ) : null;
+    return shouldRenderBadge ? <span {...badgeProps}>{content}</span> : null;
   }
 
-  // If there are children, render badge positioned relative to children
   return (
     <div className='relative inline-flex items-center justify-center'>
       {children}
-      {showRenderBadge && (
-        <span className={spanClass} aria-label={ariaLabel} role={role} aria-live={ariaLive}>
-          {content}
-        </span>
-      )}
+      {shouldRenderBadge && <span {...badgeProps}>{content}</span>}
     </div>
   );
 };

--- a/src/components/atoms/badge/types.ts
+++ b/src/components/atoms/badge/types.ts
@@ -1,5 +1,5 @@
-import { cva } from 'class-variance-authority';
-import type { ReactNode } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { AriaRole, ReactNode } from 'react';
 
 export const badgeVariants = cva(
   [
@@ -31,16 +31,16 @@ export const badgeVariants = cva(
         subtle: ''
       },
       placement: {
-        'top-right': 'absolute top-0 right-0 translate-x-1/2 -translate-y-1/2',
-        'bottom-right': 'absolute bottom-0 right-0 translate-x-1/2 translate-y-1/2',
-        'bottom-left': 'absolute bottom-0 left-0 -translate-x-1/2 translate-y-1/2',
-        'top-left': 'absolute top-0 left-0 -translate-x-1/2 -translate-y-1/2'
+        'top-right': 'absolute top-0 right-0 translate-x-1/3 -translate-y-1/3',
+        'bottom-right': 'absolute bottom-0 right-0 translate-x-1/3 translate-y-1/3',
+        'bottom-left': 'absolute bottom-0 left-0 -translate-x-1/3 translate-y-1/3',
+        'top-left': 'absolute top-0 left-0 -translate-x-1/3 -translate-y-1/3'
       },
       animation: {
         default: '',
-        pulse: 'animate-pulse',
-        bounce: 'animate-bounce',
-        ping: 'animate-badgePing'
+        pulse: 'motion-safe:animate-pulse motion-reduce:animate-none',
+        bounce: 'motion-safe:animate-bounce motion-reduce:animate-none',
+        ping: 'motion-safe:animate-badgePing motion-reduce:animate-none'
       }
     },
     compoundVariants: [
@@ -113,24 +113,66 @@ export const badgeVariants = cva(
     defaultVariants: {
       color: 'primary',
       size: 'md',
-      rounded: false,
+      rounded: true,
       variant: 'solid',
-      placement: 'top-right'
+      animation: 'default'
     }
   }
 );
-type BadgeColor = 'primary' | 'secondary' | 'success' | 'warning' | 'danger';
-type BadgeSize = 'sm' | 'md' | 'lg';
-type BadgeRounded = true | false;
-type BadgePlacement = 'top-right' | 'bottom-right' | 'bottom-left' | 'top-left';
-type BadgeAnimation = 'default' | 'pulse' | 'bounce' | 'ping';
-type BadgeVariants = 'solid' | 'flat' | 'subtle';
+
+type BadgeVariantProps = VariantProps<typeof badgeVariants>;
 
 export type BadgeProps = {
+  /**
+   * @control select
+   * @default primary
+   */
+  color?: BadgeVariantProps['color'];
+  /**
+   * @control select
+   * @default md
+   */
+  size?: BadgeVariantProps['size'];
+  /**
+   * @control boolean
+   * @default true
+   */
+  rounded?: BadgeVariantProps['rounded'];
+  /**
+   * @control select
+   * @default solid
+   */
+  variant?: BadgeVariantProps['variant'];
+  /**
+   * @control select
+   * @default top-right
+   */
+  placement?: BadgeVariantProps['placement'];
+  /**
+   * @control select
+   * @default default
+   */
+  animation?: BadgeVariantProps['animation'];
   className?: string;
+  /**
+   * Accessible label for icon-only, dot, or contextual badge content.
+   * @control text
+   */
   ariaLabel?: string;
+  /**
+   * Child element the badge should attach to. Without children, the badge renders inline.
+   */
   children?: ReactNode;
-  role?: string;
+  /**
+   * ARIA role for the badge element.
+   * @default status
+   */
+  role?: AriaRole;
+  /**
+   * Live region politeness for dynamic badge updates.
+   * @control select
+   * @default off
+   */
   ariaLive?: 'off' | 'polite' | 'assertive';
   /**
    * @control text
@@ -138,38 +180,8 @@ export type BadgeProps = {
    */
   content?: string | number | ReactNode;
   /**
-   * @control select
-   * @default primary
-   */
-  color?: BadgeColor;
-  /**
-   * @control select
-   * @default top-right
-   */
-  placement?: BadgePlacement;
-  /**
-   * @control select
-   * @default md
-   */
-  size?: BadgeSize;
-  /**
-   * @control boolean
-   * @default true
-   */
-  rounded?: BadgeRounded;
-  /**
-   * @control select
-   * @default solid
-   */
-  variant?: BadgeVariants;
-  /**
    * @control boolean
    * @default true
    */
   visibility?: boolean;
-  /**
-   * @control select
-   * @default default
-   */
-  animation?: BadgeAnimation;
 };

--- a/src/components/atoms/badge/useBadge.ts
+++ b/src/components/atoms/badge/useBadge.ts
@@ -1,63 +1,85 @@
-import React from 'react';
+import { isValidElement } from 'react';
+import { cn } from '@/lib/utils';
 import type { BadgeProps } from './types';
 import { badgeVariants } from './types';
+
+type BadgeSize = NonNullable<BadgeProps['size']>;
+
+type BadgeElementProps = {
+  className: string;
+  'aria-label'?: string;
+  role: BadgeProps['role'];
+  'aria-live': NonNullable<BadgeProps['ariaLive']>;
+};
+
+export type UseBadgeReturn = {
+  content: BadgeProps['content'];
+  children: BadgeProps['children'];
+  badgeProps: BadgeElementProps;
+  hasChildren: boolean;
+  isDot: boolean;
+  isSquare: boolean;
+  shouldRenderBadge: boolean;
+};
+
+const squareSizeClasses: Record<BadgeSize, string> = {
+  sm: '!w-4-5 !px-0',
+  md: '!w-6 !px-0',
+  lg: '!w-7 !px-0'
+};
+
 export const useBadge = ({
   content = '',
-  className = '',
-  color = 'primary',
-  rounded = true,
-  size = 'md',
-  variant = 'solid',
-  placement = 'top-right',
+  className,
+  color,
+  rounded,
+  size,
+  variant,
+  placement,
   visibility = true,
-  ariaLabel = '',
-  animation = 'default',
+  ariaLabel,
+  animation,
   children = null,
   ariaLive = 'off',
   role = 'status'
-}: BadgeProps) => {
+}: BadgeProps): UseBadgeReturn => {
   const hasChildren = children !== null && children !== undefined;
-
-  // Icon content or empty string → needs square shape (no horizontal padding)
-  const isIconContent = React.isValidElement(content);
+  const isIconContent = isValidElement(content);
   const isDot = content === '' || content === null || content === undefined;
   const isSquare = isIconContent || isDot;
+  const hasValidContent = isDot || typeof content === 'string' || typeof content === 'number' || isIconContent;
+  const shouldRenderBadge = visibility && hasValidContent;
+  const resolvedSize = size ?? 'md';
+  const shouldAnimateIn = animation === undefined || animation === 'default';
 
-  // Only apply placement when there are children (positioned badge)
-  // Otherwise, placement is ignored (standalone badge)
   const badgeClass = badgeVariants({
     color,
     rounded,
     size,
     variant,
-    placement: hasChildren ? placement : undefined,
+    placement: hasChildren ? (placement ?? 'top-right') : undefined,
     animation
   });
 
-  // Render the badge element as long as there is valid content — visibility controls animation only.
-  // We keep the span in the DOM so badgeOut can animate before disappearing.
-  const hasValidContent =
-    isDot || typeof content === 'string' || typeof content === 'number' || React.isValidElement(content);
-  const showRenderBadge = hasValidContent;
+  const badgeClassName = cn(
+    badgeClass,
+    isSquare && squareSizeClasses[resolvedSize],
+    shouldAnimateIn && 'motion-safe:animate-badgeIn motion-reduce:animate-none',
+    className
+  );
 
   return {
     content,
-    className,
-    color,
-    rounded,
-    size,
-    variant,
-    placement,
-    visibility,
-    ariaLabel,
-    animation,
     children,
-    badgeClass,
-    showRenderBadge,
-    ariaLive,
-    role,
+    badgeProps: {
+      className: badgeClassName,
+      'aria-label': ariaLabel || undefined,
+      role,
+      'aria-live': ariaLive
+    },
     hasChildren,
     isDot,
-    isSquare
+    isSquare,
+    shouldRenderBadge
   };
 };

--- a/src/components/atoms/badge/useBadge.ts
+++ b/src/components/atoms/badge/useBadge.ts
@@ -4,6 +4,7 @@ import type { BadgeProps } from './types';
 import { badgeVariants } from './types';
 
 type BadgeSize = NonNullable<BadgeProps['size']>;
+type BadgePlacement = NonNullable<BadgeProps['placement']>;
 
 type BadgeElementProps = {
   className: string;
@@ -20,6 +21,8 @@ export type UseBadgeReturn = {
   isDot: boolean;
   isSquare: boolean;
   shouldRenderBadge: boolean;
+  shouldAnimateIn: boolean;
+  resolvedPlacement?: BadgePlacement;
 };
 
 const squareSizeClasses: Record<BadgeSize, string> = {
@@ -51,13 +54,14 @@ export const useBadge = ({
   const shouldRenderBadge = visibility && hasValidContent;
   const resolvedSize = size ?? 'md';
   const shouldAnimateIn = animation === undefined || animation === 'default';
+  const resolvedPlacement = hasChildren ? (placement ?? 'top-right') : undefined;
 
   const badgeClass = badgeVariants({
     color,
     rounded,
     size,
     variant,
-    placement: hasChildren ? (placement ?? 'top-right') : undefined,
+    placement: resolvedPlacement,
     animation
   });
 
@@ -80,6 +84,8 @@ export const useBadge = ({
     hasChildren,
     isDot,
     isSquare,
-    shouldRenderBadge
+    shouldRenderBadge,
+    shouldAnimateIn,
+    resolvedPlacement
   };
 };

--- a/src/components/atoms/chip/Chip.stories.tsx
+++ b/src/components/atoms/chip/Chip.stories.tsx
@@ -31,9 +31,6 @@ export default meta;
 
 type Story = StoryObj<typeof Chip>;
 
-const visualColors = ['primary', 'secondary', 'success', 'warning', 'danger'] as const;
-const visualVariants = ['solid', 'flat', 'shadow', 'bordered', 'light', 'faded', 'dot'] as const;
-
 export const Default: Story = {
   args: {
     children: 'Chip'
@@ -99,20 +96,160 @@ export const Variant: Story = {
 export const VisualReviewMatrix: Story = {
   render: () => (
     <div className='grid gap-6 rounded-xl bg-background-light p-6 dark:bg-background-dark'>
-      {visualVariants.map((variant) => (
-        <section key={variant} className='grid gap-3'>
-          <h3 className='fs-small font-secondary-bold capitalize text-text-secondary-light dark:text-text-secondary-dark'>
-            {variant}
-          </h3>
-          <div className='flex flex-wrap items-center gap-3'>
-            {visualColors.map((color) => (
-              <Chip key={`${variant}-${color}`} variant={variant} color={color}>
-                {color}
-              </Chip>
-            ))}
-          </div>
-        </section>
-      ))}
+      <section className='grid gap-3'>
+        <h3 className='fs-small font-secondary-bold capitalize text-text-secondary-light dark:text-text-secondary-dark'>
+          Solid
+        </h3>
+        <div className='flex flex-wrap items-center gap-3'>
+          <Chip variant='solid' color='primary'>
+            primary
+          </Chip>
+          <Chip variant='solid' color='secondary'>
+            secondary
+          </Chip>
+          <Chip variant='solid' color='success'>
+            success
+          </Chip>
+          <Chip variant='solid' color='warning'>
+            warning
+          </Chip>
+          <Chip variant='solid' color='danger'>
+            danger
+          </Chip>
+        </div>
+      </section>
+      <section className='grid gap-3'>
+        <h3 className='fs-small font-secondary-bold capitalize text-text-secondary-light dark:text-text-secondary-dark'>
+          Flat
+        </h3>
+        <div className='flex flex-wrap items-center gap-3'>
+          <Chip variant='flat' color='primary'>
+            primary
+          </Chip>
+          <Chip variant='flat' color='secondary'>
+            secondary
+          </Chip>
+          <Chip variant='flat' color='success'>
+            success
+          </Chip>
+          <Chip variant='flat' color='warning'>
+            warning
+          </Chip>
+          <Chip variant='flat' color='danger'>
+            danger
+          </Chip>
+        </div>
+      </section>
+      <section className='grid gap-3'>
+        <h3 className='fs-small font-secondary-bold capitalize text-text-secondary-light dark:text-text-secondary-dark'>
+          Shadow
+        </h3>
+        <div className='flex flex-wrap items-center gap-3'>
+          <Chip variant='shadow' color='primary'>
+            primary
+          </Chip>
+          <Chip variant='shadow' color='secondary'>
+            secondary
+          </Chip>
+          <Chip variant='shadow' color='success'>
+            success
+          </Chip>
+          <Chip variant='shadow' color='warning'>
+            warning
+          </Chip>
+          <Chip variant='shadow' color='danger'>
+            danger
+          </Chip>
+        </div>
+      </section>
+      <section className='grid gap-3'>
+        <h3 className='fs-small font-secondary-bold capitalize text-text-secondary-light dark:text-text-secondary-dark'>
+          Bordered
+        </h3>
+        <div className='flex flex-wrap items-center gap-3'>
+          <Chip variant='bordered' color='primary'>
+            primary
+          </Chip>
+          <Chip variant='bordered' color='secondary'>
+            secondary
+          </Chip>
+          <Chip variant='bordered' color='success'>
+            success
+          </Chip>
+          <Chip variant='bordered' color='warning'>
+            warning
+          </Chip>
+          <Chip variant='bordered' color='danger'>
+            danger
+          </Chip>
+        </div>
+      </section>
+      <section className='grid gap-3'>
+        <h3 className='fs-small font-secondary-bold capitalize text-text-secondary-light dark:text-text-secondary-dark'>
+          Light
+        </h3>
+        <div className='flex flex-wrap items-center gap-3'>
+          <Chip variant='light' color='primary'>
+            primary
+          </Chip>
+          <Chip variant='light' color='secondary'>
+            secondary
+          </Chip>
+          <Chip variant='light' color='success'>
+            success
+          </Chip>
+          <Chip variant='light' color='warning'>
+            warning
+          </Chip>
+          <Chip variant='light' color='danger'>
+            danger
+          </Chip>
+        </div>
+      </section>
+      <section className='grid gap-3'>
+        <h3 className='fs-small font-secondary-bold capitalize text-text-secondary-light dark:text-text-secondary-dark'>
+          Faded
+        </h3>
+        <div className='flex flex-wrap items-center gap-3'>
+          <Chip variant='faded' color='primary'>
+            primary
+          </Chip>
+          <Chip variant='faded' color='secondary'>
+            secondary
+          </Chip>
+          <Chip variant='faded' color='success'>
+            success
+          </Chip>
+          <Chip variant='faded' color='warning'>
+            warning
+          </Chip>
+          <Chip variant='faded' color='danger'>
+            danger
+          </Chip>
+        </div>
+      </section>
+      <section className='grid gap-3'>
+        <h3 className='fs-small font-secondary-bold capitalize text-text-secondary-light dark:text-text-secondary-dark'>
+          Dot
+        </h3>
+        <div className='flex flex-wrap items-center gap-3'>
+          <Chip variant='dot' color='primary'>
+            primary
+          </Chip>
+          <Chip variant='dot' color='secondary'>
+            secondary
+          </Chip>
+          <Chip variant='dot' color='success'>
+            success
+          </Chip>
+          <Chip variant='dot' color='warning'>
+            warning
+          </Chip>
+          <Chip variant='dot' color='danger'>
+            danger
+          </Chip>
+        </div>
+      </section>
     </div>
   )
 };

--- a/src/components/atoms/header/Header.stories.tsx
+++ b/src/components/atoms/header/Header.stories.tsx
@@ -1,10 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Header } from './Header';
-import type { HeaderVariant } from './types';
 
 const stackClass =
   'flex flex-col gap-4 rounded-md border border-border-light bg-surface-light p-4 dark:border-border-dark dark:bg-surface-dark';
-const headingTags: HeaderVariant[] = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
 
 /**
  * ## Description
@@ -44,11 +42,12 @@ export const Default: Story = {
 export const SemanticTags: Story = {
   render: () => (
     <div className={stackClass}>
-      {headingTags.map((tag) => (
-        <Header key={tag} tag={tag}>
-          {tag.toUpperCase()} semantic heading
-        </Header>
-      ))}
+      <Header tag='h1'>H1 semantic heading</Header>
+      <Header tag='h2'>H2 semantic heading</Header>
+      <Header tag='h3'>H3 semantic heading</Header>
+      <Header tag='h4'>H4 semantic heading</Header>
+      <Header tag='h5'>H5 semantic heading</Header>
+      <Header tag='h6'>H6 semantic heading</Header>
     </div>
   )
 };
@@ -57,11 +56,24 @@ export const SemanticTags: Story = {
 export const VisualSizes: Story = {
   render: () => (
     <div className={stackClass}>
-      {headingTags.map((size) => (
-        <Header key={size} tag='h2' size={size}>
-          h2 rendered with {size.toUpperCase()} visual scale
-        </Header>
-      ))}
+      <Header tag='h2' size='h1'>
+        h2 rendered with H1 visual scale
+      </Header>
+      <Header tag='h2' size='h2'>
+        h2 rendered with H2 visual scale
+      </Header>
+      <Header tag='h2' size='h3'>
+        h2 rendered with H3 visual scale
+      </Header>
+      <Header tag='h2' size='h4'>
+        h2 rendered with H4 visual scale
+      </Header>
+      <Header tag='h2' size='h5'>
+        h2 rendered with H5 visual scale
+      </Header>
+      <Header tag='h2' size='h6'>
+        h2 rendered with H6 visual scale
+      </Header>
     </div>
   )
 };

--- a/src/components/molecules/accordion/Accordion.stories.tsx
+++ b/src/components/molecules/accordion/Accordion.stories.tsx
@@ -205,10 +205,27 @@ export const WithoutSeparator: Story = {
 export const CustomIndicator: Story = {
   args: {
     ...Default.args,
-    items: baseItems.map((item) => ({
-      ...item,
-      indicator: <Icon name='plus' size={18} color='text-color-brand-light' colorDark='dark:text-color-brand-dark' />
-    }))
+    items: [
+      {
+        id: 'overview',
+        title: 'What is Stack-and-Flow?',
+        content: 'Stack-and-Flow is a React design system focused on accessible, token-driven components.',
+        indicator: <Icon name='plus' size={18} color='text-color-brand-light' colorDark='dark:text-color-brand-dark' />
+      },
+      {
+        id: 'usage',
+        title: 'When should I use Accordion?',
+        content: 'Use Accordion to organize related content sections when users only need to inspect some of them.',
+        indicator: <Icon name='plus' size={18} color='text-color-brand-light' colorDark='dark:text-color-brand-dark' />
+      },
+      {
+        id: 'accessibility',
+        title: 'How does keyboard navigation work?',
+        content:
+          'Use Tab to enter the accordion, arrow keys to move between triggers, and Enter or Space to toggle a panel.',
+        indicator: <Icon name='plus' size={18} color='text-color-brand-light' colorDark='dark:text-color-brand-dark' />
+      }
+    ]
   }
 };
 

--- a/src/storybook-explicit-examples.test.ts
+++ b/src/storybook-explicit-examples.test.ts
@@ -1,0 +1,74 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import * as ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const storyFilePattern = /\.stories\.(ts|tsx|js|jsx)$/;
+const root = process.cwd();
+const srcDir = join(root, 'src');
+
+type StoryMapViolation = {
+  file: string;
+  line: number;
+  column: number;
+};
+
+const getStoryFiles = (directory: string): string[] =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      return getStoryFiles(fullPath);
+    }
+
+    if (entry.isFile() && storyFilePattern.test(entry.name)) {
+      return [fullPath];
+    }
+
+    return [];
+  });
+
+const getScriptKind = (filePath: string) => (filePath.endsWith('x') ? ts.ScriptKind.TSX : ts.ScriptKind.TS);
+
+const findStoryMapViolations = (): StoryMapViolation[] =>
+  getStoryFiles(srcDir).flatMap((filePath) => {
+    const sourceText = readFileSync(filePath, 'utf8');
+    const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true, getScriptKind(filePath));
+    const violations: StoryMapViolation[] = [];
+
+    const visit = (node: ts.Node) => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        node.expression.name.text === 'map'
+      ) {
+        const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.expression.name.getStart(sourceFile));
+        violations.push({
+          file: relative(root, sourceFile.fileName),
+          line: line + 1,
+          column: character + 1
+        });
+      }
+
+      ts.forEachChild(node, visit);
+    };
+
+    visit(sourceFile);
+    return violations;
+  });
+
+describe('Storybook explicit examples', () => {
+  it('does not use .map() in story files', () => {
+    const violations = findStoryMapViolations();
+
+    expect(
+      violations,
+      [
+        'Do not use `.map()` in *.stories.* files.',
+        'Storybook code panels must show explicit, copyable component examples.',
+        'Use containers to group examples, but write each component invocation with its props inline.',
+        ...violations.map(({ file, line, column }) => `- ${file}:${line}:${column}`)
+      ].join('\n')
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Storybook documentation harness that forbids `.map()` in story files, then rewrites existing mapped examples as explicit component invocations so code panels stay copyable.

Closes #178

## Type of change

- [ ] 🧩 New component
- [x] 🐛 Bug fix
- [ ] 🎨 Design tokens
- [ ] ♿ Accessibility
- [ ] 🏗️ Infrastructure
- [ ] 📚 Documentation

## Component checklist (skip if not applicable)

- [x] Follows the 5-file structure (`types.ts`, `use*.ts`, `Component.tsx`, `index.ts`, `*.stories.tsx`)
- [x] CVA variants defined in `types.ts`, not inline
- [x] No hardcoded colors — uses tokens from `theme.css`
- [x] No `any` types — TypeScript strict
- [x] ARIA attributes present and correct
- [x] Keyboard navigable (Tab, Enter, Escape where applicable)
- [x] Dark mode works correctly
- [x] Storybook stories cover: default, variants, states (hover, focus, disabled)
- [x] Tests added or updated

## How to test

1. `rg -n "\\.map\\(" src --glob "*.stories.*"`
2. `./node_modules/.bin/vitest run src/storybook-explicit-examples.test.ts`
3. `pnpm test`
4. `./node_modules/.bin/tsc --noEmit --pretty false`
5. `pnpm run storybook-build`

## Screenshots / recordings (if applicable)

Not applicable — this is a documentation-source harness and story source cleanup.

## Notes for reviewer

- The harness intentionally rejects any `.map()` in `src/**/*.stories.*` files. This is stricter than only detecting JSX-render maps, but it keeps the rule simple and aligned with the docs convention: story code should be explicit and copyable.
- Existing mapped examples were expanded in Badge, Header, Chip, and Accordion stories.
