### PR TITLE
test(storybook): require explicit story examples

### DIFF
--- a/src/components/atoms/badge/Badge.stories.tsx
+++ b/src/components/atoms/badge/Badge.stories.tsx
@@ -5,11 +5,6 @@ import { Button } from '../button';
 import Icon from '../icon/Icon';
 import { Badge } from './Badge';
 
-const colors = ['primary', 'secondary', 'success', 'warning', 'danger'] as const;
-const sizes = ['sm', 'md', 'lg'] as const;
-const variants = ['solid', 'flat', 'subtle'] as const;
-const placements = ['top-right', 'bottom-right', 'top-left', 'bottom-left'] as const;
-
 /**
  * ## Description
  * A small status, count, or label indicator for notification counts, presence dots, and compact metadata.
@@ -53,16 +48,15 @@ export const Default: Story = {
 export const Size: Story = {
   render: () => (
     <div className='flex items-center gap-4'>
-      {sizes.map((size) => (
-        <Badge key={size} content='1' size={size} ariaLabel={`${size} notification badge`}>
-          <Avatar
-            src={`https://i.pravatar.cc/300?u=badge-size-${size}`}
-            alt={`${size} avatar`}
-            rounded='full'
-            size='lg'
-          />
-        </Badge>
-      ))}
+      <Badge content='1' size='sm' ariaLabel='Small notification badge'>
+        <Avatar src='https://i.pravatar.cc/300?u=badge-size-sm' alt='Small avatar' rounded='full' size='lg' />
+      </Badge>
+      <Badge content='1' size='md' ariaLabel='Medium notification badge'>
+        <Avatar src='https://i.pravatar.cc/300?u=badge-size-md' alt='Medium avatar' rounded='full' size='lg' />
+      </Badge>
+      <Badge content='1' size='lg' ariaLabel='Large notification badge'>
+        <Avatar src='https://i.pravatar.cc/300?u=badge-size-lg' alt='Large avatar' rounded='full' size='lg' />
+      </Badge>
     </div>
   )
 };
@@ -73,16 +67,26 @@ export const Size: Story = {
 export const Color: Story = {
   render: () => (
     <div className='flex items-center gap-4'>
-      {colors.map((color, index) => (
-        <Badge key={color} content={index + 1} color={color} ariaLabel={`${color} badge`}>
-          <Avatar
-            src={`https://i.pravatar.cc/300?u=badge-color-${color}`}
-            alt={`${color} avatar`}
-            rounded='full'
-            size='lg'
-          />
-        </Badge>
-      ))}
+      <Badge content={1} color='primary' ariaLabel='Primary badge'>
+        <Avatar src='https://i.pravatar.cc/300?u=badge-color-primary' alt='Primary avatar' rounded='full' size='lg' />
+      </Badge>
+      <Badge content={2} color='secondary' ariaLabel='Secondary badge'>
+        <Avatar
+          src='https://i.pravatar.cc/300?u=badge-color-secondary'
+          alt='Secondary avatar'
+          rounded='full'
+          size='lg'
+        />
+      </Badge>
+      <Badge content={3} color='success' ariaLabel='Success badge'>
+        <Avatar src='https://i.pravatar.cc/300?u=badge-color-success' alt='Success avatar' rounded='full' size='lg' />
+      </Badge>
+      <Badge content={4} color='warning' ariaLabel='Warning badge'>
+        <Avatar src='https://i.pravatar.cc/300?u=badge-color-warning' alt='Warning avatar' rounded='full' size='lg' />
+      </Badge>
+      <Badge content={5} color='danger' ariaLabel='Danger badge'>
+        <Avatar src='https://i.pravatar.cc/300?u=badge-color-danger' alt='Danger avatar' rounded='full' size='lg' />
+      </Badge>
     </div>
   )
 };
@@ -93,13 +97,27 @@ export const Color: Story = {
 export const Variant: Story = {
   render: () => (
     <div className='grid gap-3'>
-      {variants.map((variant) => (
-        <div key={variant} className='flex flex-wrap items-center gap-2'>
-          {colors.map((color) => (
-            <Badge key={`${variant}-${color}`} content={color} color={color} variant={variant} rounded={false} />
-          ))}
-        </div>
-      ))}
+      <div className='flex flex-wrap items-center gap-2'>
+        <Badge content='primary' color='primary' variant='solid' rounded={false} />
+        <Badge content='secondary' color='secondary' variant='solid' rounded={false} />
+        <Badge content='success' color='success' variant='solid' rounded={false} />
+        <Badge content='warning' color='warning' variant='solid' rounded={false} />
+        <Badge content='danger' color='danger' variant='solid' rounded={false} />
+      </div>
+      <div className='flex flex-wrap items-center gap-2'>
+        <Badge content='primary' color='primary' variant='flat' rounded={false} />
+        <Badge content='secondary' color='secondary' variant='flat' rounded={false} />
+        <Badge content='success' color='success' variant='flat' rounded={false} />
+        <Badge content='warning' color='warning' variant='flat' rounded={false} />
+        <Badge content='danger' color='danger' variant='flat' rounded={false} />
+      </div>
+      <div className='flex flex-wrap items-center gap-2'>
+        <Badge content='primary' color='primary' variant='subtle' rounded={false} />
+        <Badge content='secondary' color='secondary' variant='subtle' rounded={false} />
+        <Badge content='success' color='success' variant='subtle' rounded={false} />
+        <Badge content='warning' color='warning' variant='subtle' rounded={false} />
+        <Badge content='danger' color='danger' variant='subtle' rounded={false} />
+      </div>
     </div>
   )
 };
@@ -110,16 +128,38 @@ export const Variant: Story = {
 export const Placement: Story = {
   render: () => (
     <div className='flex items-center gap-5'>
-      {placements.map((placement, index) => (
-        <Badge key={placement} content={index + 1} placement={placement} ariaLabel={`${placement} badge`}>
-          <Avatar
-            src={`https://i.pravatar.cc/300?u=badge-placement-${placement}`}
-            alt={`${placement} avatar`}
-            rounded='full'
-            size='lg'
-          />
-        </Badge>
-      ))}
+      <Badge content={1} placement='top-right' ariaLabel='Top-right badge'>
+        <Avatar
+          src='https://i.pravatar.cc/300?u=badge-placement-top-right'
+          alt='Top-right avatar'
+          rounded='full'
+          size='lg'
+        />
+      </Badge>
+      <Badge content={2} placement='bottom-right' ariaLabel='Bottom-right badge'>
+        <Avatar
+          src='https://i.pravatar.cc/300?u=badge-placement-bottom-right'
+          alt='Bottom-right avatar'
+          rounded='full'
+          size='lg'
+        />
+      </Badge>
+      <Badge content={3} placement='top-left' ariaLabel='Top-left badge'>
+        <Avatar
+          src='https://i.pravatar.cc/300?u=badge-placement-top-left'
+          alt='Top-left avatar'
+          rounded='full'
+          size='lg'
+        />
+      </Badge>
+      <Badge content={4} placement='bottom-left' ariaLabel='Bottom-left badge'>
+        <Avatar
+          src='https://i.pravatar.cc/300?u=badge-placement-bottom-left'
+          alt='Bottom-left avatar'
+          rounded='full'
+          size='lg'
+        />
+      </Badge>
     </div>
   )
 };
@@ -203,23 +243,62 @@ export const BadgeVisibility: Story = {
 export const Animation: Story = {
   render: () => (
     <div className='flex items-center gap-6'>
-      {(['default', 'pulse', 'bounce', 'ping'] as const).map((animation) => (
-        <Badge
-          key={animation}
-          content={<Icon name='bell-dot' size={12} color='text-white' />}
-          color='primary'
-          size='sm'
-          animation={animation}
-          ariaLabel={`${animation} notification animation`}
-        >
-          <Avatar
-            src={`https://i.pravatar.cc/300?u=badge-animation-${animation}`}
-            alt={`${animation} animation avatar`}
-            rounded='full'
-            size='lg'
-          />
-        </Badge>
-      ))}
+      <Badge
+        content={<Icon name='bell-dot' size={12} color='text-white' />}
+        color='primary'
+        size='sm'
+        animation='default'
+        ariaLabel='Default notification animation'
+      >
+        <Avatar
+          src='https://i.pravatar.cc/300?u=badge-animation-default'
+          alt='Default animation avatar'
+          rounded='full'
+          size='lg'
+        />
+      </Badge>
+      <Badge
+        content={<Icon name='bell-dot' size={12} color='text-white' />}
+        color='primary'
+        size='sm'
+        animation='pulse'
+        ariaLabel='Pulse notification animation'
+      >
+        <Avatar
+          src='https://i.pravatar.cc/300?u=badge-animation-pulse'
+          alt='Pulse animation avatar'
+          rounded='full'
+          size='lg'
+        />
+      </Badge>
+      <Badge
+        content={<Icon name='bell-dot' size={12} color='text-white' />}
+        color='primary'
+        size='sm'
+        animation='bounce'
+        ariaLabel='Bounce notification animation'
+      >
+        <Avatar
+          src='https://i.pravatar.cc/300?u=badge-animation-bounce'
+          alt='Bounce animation avatar'
+          rounded='full'
+          size='lg'
+        />
+      </Badge>
+      <Badge
+        content={<Icon name='bell-dot' size={12} color='text-white' />}
+        color='primary'
+        size='sm'
+        animation='ping'
+        ariaLabel='Ping notification animation'
+      >
+        <Avatar
+          src='https://i.pravatar.cc/300?u=badge-animation-ping'
+          alt='Ping animation avatar'
+          rounded='full'
+          size='lg'
+        />
+      </Badge>
     </div>
   )
 };

--- a/src/components/atoms/chip/Chip.stories.tsx
+++ b/src/components/atoms/chip/Chip.stories.tsx
@@ -31,9 +31,6 @@ export default meta;
 
 type Story = StoryObj<typeof Chip>;
 
-const visualColors = ['primary', 'secondary', 'success', 'warning', 'danger'] as const;
-const visualVariants = ['solid', 'flat', 'shadow', 'bordered', 'light', 'faded', 'dot'] as const;
-
 export const Default: Story = {
   args: {
     children: 'Chip'
@@ -99,20 +96,160 @@ export const Variant: Story = {
 export const VisualReviewMatrix: Story = {
   render: () => (
     <div className='grid gap-6 rounded-xl bg-background-light p-6 dark:bg-background-dark'>
-      {visualVariants.map((variant) => (
-        <section key={variant} className='grid gap-3'>
-          <h3 className='fs-small font-secondary-bold capitalize text-text-secondary-light dark:text-text-secondary-dark'>
-            {variant}
-          </h3>
-          <div className='flex flex-wrap items-center gap-3'>
-            {visualColors.map((color) => (
-              <Chip key={`${variant}-${color}`} variant={variant} color={color}>
-                {color}
-              </Chip>
-            ))}
-          </div>
-        </section>
-      ))}
+      <section className='grid gap-3'>
+        <h3 className='fs-small font-secondary-bold capitalize text-text-secondary-light dark:text-text-secondary-dark'>
+          Solid
+        </h3>
+        <div className='flex flex-wrap items-center gap-3'>
+          <Chip variant='solid' color='primary'>
+            primary
+          </Chip>
+          <Chip variant='solid' color='secondary'>
+            secondary
+          </Chip>
+          <Chip variant='solid' color='success'>
+            success
+          </Chip>
+          <Chip variant='solid' color='warning'>
+            warning
+          </Chip>
+          <Chip variant='solid' color='danger'>
+            danger
+          </Chip>
+        </div>
+      </section>
+      <section className='grid gap-3'>
+        <h3 className='fs-small font-secondary-bold capitalize text-text-secondary-light dark:text-text-secondary-dark'>
+          Flat
+        </h3>
+        <div className='flex flex-wrap items-center gap-3'>
+          <Chip variant='flat' color='primary'>
+            primary
+          </Chip>
+          <Chip variant='flat' color='secondary'>
+            secondary
+          </Chip>
+          <Chip variant='flat' color='success'>
+            success
+          </Chip>
+          <Chip variant='flat' color='warning'>
+            warning
+          </Chip>
+          <Chip variant='flat' color='danger'>
+            danger
+          </Chip>
+        </div>
+      </section>
+      <section className='grid gap-3'>
+        <h3 className='fs-small font-secondary-bold capitalize text-text-secondary-light dark:text-text-secondary-dark'>
+          Shadow
+        </h3>
+        <div className='flex flex-wrap items-center gap-3'>
+          <Chip variant='shadow' color='primary'>
+            primary
+          </Chip>
+          <Chip variant='shadow' color='secondary'>
+            secondary
+          </Chip>
+          <Chip variant='shadow' color='success'>
+            success
+          </Chip>
+          <Chip variant='shadow' color='warning'>
+            warning
+          </Chip>
+          <Chip variant='shadow' color='danger'>
+            danger
+          </Chip>
+        </div>
+      </section>
+      <section className='grid gap-3'>
+        <h3 className='fs-small font-secondary-bold capitalize text-text-secondary-light dark:text-text-secondary-dark'>
+          Bordered
+        </h3>
+        <div className='flex flex-wrap items-center gap-3'>
+          <Chip variant='bordered' color='primary'>
+            primary
+          </Chip>
+          <Chip variant='bordered' color='secondary'>
+            secondary
+          </Chip>
+          <Chip variant='bordered' color='success'>
+            success
+          </Chip>
+          <Chip variant='bordered' color='warning'>
+            warning
+          </Chip>
+          <Chip variant='bordered' color='danger'>
+            danger
+          </Chip>
+        </div>
+      </section>
+      <section className='grid gap-3'>
+        <h3 className='fs-small font-secondary-bold capitalize text-text-secondary-light dark:text-text-secondary-dark'>
+          Light
+        </h3>
+        <div className='flex flex-wrap items-center gap-3'>
+          <Chip variant='light' color='primary'>
+            primary
+          </Chip>
+          <Chip variant='light' color='secondary'>
+            secondary
+          </Chip>
+          <Chip variant='light' color='success'>
+            success
+          </Chip>
+          <Chip variant='light' color='warning'>
+            warning
+          </Chip>
+          <Chip variant='light' color='danger'>
+            danger
+          </Chip>
+        </div>
+      </section>
+      <section className='grid gap-3'>
+        <h3 className='fs-small font-secondary-bold capitalize text-text-secondary-light dark:text-text-secondary-dark'>
+          Faded
+        </h3>
+        <div className='flex flex-wrap items-center gap-3'>
+          <Chip variant='faded' color='primary'>
+            primary
+          </Chip>
+          <Chip variant='faded' color='secondary'>
+            secondary
+          </Chip>
+          <Chip variant='faded' color='success'>
+            success
+          </Chip>
+          <Chip variant='faded' color='warning'>
+            warning
+          </Chip>
+          <Chip variant='faded' color='danger'>
+            danger
+          </Chip>
+        </div>
+      </section>
+      <section className='grid gap-3'>
+        <h3 className='fs-small font-secondary-bold capitalize text-text-secondary-light dark:text-text-secondary-dark'>
+          Dot
+        </h3>
+        <div className='flex flex-wrap items-center gap-3'>
+          <Chip variant='dot' color='primary'>
+            primary
+          </Chip>
+          <Chip variant='dot' color='secondary'>
+            secondary
+          </Chip>
+          <Chip variant='dot' color='success'>
+            success
+          </Chip>
+          <Chip variant='dot' color='warning'>
+            warning
+          </Chip>
+          <Chip variant='dot' color='danger'>
+            danger
+          </Chip>
+        </div>
+      </section>
     </div>
   )
 };

--- a/src/components/atoms/header/Header.stories.tsx
+++ b/src/components/atoms/header/Header.stories.tsx
@@ -1,10 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Header } from './Header';
-import type { HeaderVariant } from './types';
 
 const stackClass =
   'flex flex-col gap-4 rounded-md border border-border-light bg-surface-light p-4 dark:border-border-dark dark:bg-surface-dark';
-const headingTags: HeaderVariant[] = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
 
 /**
  * ## Description
@@ -44,11 +42,12 @@ export const Default: Story = {
 export const SemanticTags: Story = {
   render: () => (
     <div className={stackClass}>
-      {headingTags.map((tag) => (
-        <Header key={tag} tag={tag}>
-          {tag.toUpperCase()} semantic heading
-        </Header>
-      ))}
+      <Header tag='h1'>H1 semantic heading</Header>
+      <Header tag='h2'>H2 semantic heading</Header>
+      <Header tag='h3'>H3 semantic heading</Header>
+      <Header tag='h4'>H4 semantic heading</Header>
+      <Header tag='h5'>H5 semantic heading</Header>
+      <Header tag='h6'>H6 semantic heading</Header>
     </div>
   )
 };
@@ -57,11 +56,24 @@ export const SemanticTags: Story = {
 export const VisualSizes: Story = {
   render: () => (
     <div className={stackClass}>
-      {headingTags.map((size) => (
-        <Header key={size} tag='h2' size={size}>
-          h2 rendered with {size.toUpperCase()} visual scale
-        </Header>
-      ))}
+      <Header tag='h2' size='h1'>
+        h2 rendered with H1 visual scale
+      </Header>
+      <Header tag='h2' size='h2'>
+        h2 rendered with H2 visual scale
+      </Header>
+      <Header tag='h2' size='h3'>
+        h2 rendered with H3 visual scale
+      </Header>
+      <Header tag='h2' size='h4'>
+        h2 rendered with H4 visual scale
+      </Header>
+      <Header tag='h2' size='h5'>
+        h2 rendered with H5 visual scale
+      </Header>
+      <Header tag='h2' size='h6'>
+        h2 rendered with H6 visual scale
+      </Header>
     </div>
   )
 };

--- a/src/components/molecules/accordion/Accordion.stories.tsx
+++ b/src/components/molecules/accordion/Accordion.stories.tsx
@@ -205,10 +205,27 @@ export const WithoutSeparator: Story = {
 export const CustomIndicator: Story = {
   args: {
     ...Default.args,
-    items: baseItems.map((item) => ({
-      ...item,
-      indicator: <Icon name='plus' size={18} color='text-color-brand-light' colorDark='dark:text-color-brand-dark' />
-    }))
+    items: [
+      {
+        id: 'overview',
+        title: 'What is Stack-and-Flow?',
+        content: 'Stack-and-Flow is a React design system focused on accessible, token-driven components.',
+        indicator: <Icon name='plus' size={18} color='text-color-brand-light' colorDark='dark:text-color-brand-dark' />
+      },
+      {
+        id: 'usage',
+        title: 'When should I use Accordion?',
+        content: 'Use Accordion to organize related content sections when users only need to inspect some of them.',
+        indicator: <Icon name='plus' size={18} color='text-color-brand-light' colorDark='dark:text-color-brand-dark' />
+      },
+      {
+        id: 'accessibility',
+        title: 'How does keyboard navigation work?',
+        content:
+          'Use Tab to enter the accordion, arrow keys to move between triggers, and Enter or Space to toggle a panel.',
+        indicator: <Icon name='plus' size={18} color='text-color-brand-light' colorDark='dark:text-color-brand-dark' />
+      }
+    ]
   }
 };
 

--- a/src/components/molecules/accordion/Accordion.stories.tsx
+++ b/src/components/molecules/accordion/Accordion.stories.tsx
@@ -207,22 +207,15 @@ export const CustomIndicator: Story = {
     ...Default.args,
     items: [
       {
-        id: 'overview',
-        title: 'What is Stack-and-Flow?',
-        content: 'Stack-and-Flow is a React design system focused on accessible, token-driven components.',
+        ...baseItems[0],
         indicator: <Icon name='plus' size={18} color='text-color-brand-light' colorDark='dark:text-color-brand-dark' />
       },
       {
-        id: 'usage',
-        title: 'When should I use Accordion?',
-        content: 'Use Accordion to organize related content sections when users only need to inspect some of them.',
+        ...baseItems[1],
         indicator: <Icon name='plus' size={18} color='text-color-brand-light' colorDark='dark:text-color-brand-dark' />
       },
       {
-        id: 'accessibility',
-        title: 'How does keyboard navigation work?',
-        content:
-          'Use Tab to enter the accordion, arrow keys to move between triggers, and Enter or Space to toggle a panel.',
+        ...baseItems[2],
         indicator: <Icon name='plus' size={18} color='text-color-brand-light' colorDark='dark:text-color-brand-dark' />
       }
     ]

--- a/src/storybook-explicit-examples.test.ts
+++ b/src/storybook-explicit-examples.test.ts
@@ -30,32 +30,45 @@ const getStoryFiles = (directory: string): string[] =>
 
 const getScriptKind = (filePath: string) => (filePath.endsWith('x') ? ts.ScriptKind.TSX : ts.ScriptKind.TS);
 
-const findStoryMapViolations = (): StoryMapViolation[] =>
-  getStoryFiles(srcDir).flatMap((filePath) => {
-    const sourceText = readFileSync(filePath, 'utf8');
-    const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true, getScriptKind(filePath));
-    const violations: StoryMapViolation[] = [];
+const getMapPropertyAccessName = (node: ts.Expression) => {
+  if ((ts.isPropertyAccessExpression(node) || ts.isPropertyAccessChain(node)) && node.name.text === 'map') {
+    return node.name;
+  }
 
-    const visit = (node: ts.Node) => {
-      if (
-        ts.isCallExpression(node) &&
-        ts.isPropertyAccessExpression(node.expression) &&
-        node.expression.name.text === 'map'
-      ) {
-        const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.expression.name.getStart(sourceFile));
+  return undefined;
+};
+
+const findMapViolationsInSourceFile = (sourceFile: ts.SourceFile): StoryMapViolation[] => {
+  const violations: StoryMapViolation[] = [];
+
+  const visit = (node: ts.Node) => {
+    if (ts.isCallExpression(node)) {
+      const mapPropertyName = getMapPropertyAccessName(node.expression);
+
+      if (mapPropertyName !== undefined) {
+        const { line, character } = sourceFile.getLineAndCharacterOfPosition(mapPropertyName.getStart(sourceFile));
         violations.push({
           file: relative(root, sourceFile.fileName),
           line: line + 1,
           column: character + 1
         });
       }
+    }
 
-      ts.forEachChild(node, visit);
-    };
+    ts.forEachChild(node, visit);
+  };
 
-    visit(sourceFile);
-    return violations;
-  });
+  visit(sourceFile);
+  return violations;
+};
+
+const findMapViolationsInSourceText = (filePath: string, sourceText: string): StoryMapViolation[] => {
+  const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true, getScriptKind(filePath));
+  return findMapViolationsInSourceFile(sourceFile);
+};
+
+const findStoryMapViolations = (): StoryMapViolation[] =>
+  getStoryFiles(srcDir).flatMap((filePath) => findMapViolationsInSourceText(filePath, readFileSync(filePath, 'utf8')));
 
 describe('Storybook explicit examples', () => {
   it('does not use .map() in story files', () => {
@@ -70,5 +83,24 @@ describe('Storybook explicit examples', () => {
         ...violations.map(({ file, line, column }) => `- ${file}:${line}:${column}`)
       ].join('\n')
     ).toEqual([]);
+  });
+
+  it('detects optional-chained .map() calls', () => {
+    const violations = findMapViolationsInSourceText(
+      join(root, 'src/components/example/Example.stories.tsx'),
+      `
+        export const Example = {
+          render: () => <div>{items?.map((item) => <Component key={item.id} {...item} />)}</div>
+        };
+      `
+    );
+
+    expect(violations).toEqual([
+      {
+        file: 'src/components/example/Example.stories.tsx',
+        line: 3,
+        column: 38
+      }
+    ]);
   });
 });

--- a/src/storybook-explicit-examples.test.ts
+++ b/src/storybook-explicit-examples.test.ts
@@ -1,0 +1,74 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import * as ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const storyFilePattern = /\.stories\.(ts|tsx|js|jsx)$/;
+const root = process.cwd();
+const srcDir = join(root, 'src');
+
+type StoryMapViolation = {
+  file: string;
+  line: number;
+  column: number;
+};
+
+const getStoryFiles = (directory: string): string[] =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      return getStoryFiles(fullPath);
+    }
+
+    if (entry.isFile() && storyFilePattern.test(entry.name)) {
+      return [fullPath];
+    }
+
+    return [];
+  });
+
+const getScriptKind = (filePath: string) => (filePath.endsWith('x') ? ts.ScriptKind.TSX : ts.ScriptKind.TS);
+
+const findStoryMapViolations = (): StoryMapViolation[] =>
+  getStoryFiles(srcDir).flatMap((filePath) => {
+    const sourceText = readFileSync(filePath, 'utf8');
+    const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true, getScriptKind(filePath));
+    const violations: StoryMapViolation[] = [];
+
+    const visit = (node: ts.Node) => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        node.expression.name.text === 'map'
+      ) {
+        const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.expression.name.getStart(sourceFile));
+        violations.push({
+          file: relative(root, sourceFile.fileName),
+          line: line + 1,
+          column: character + 1
+        });
+      }
+
+      ts.forEachChild(node, visit);
+    };
+
+    visit(sourceFile);
+    return violations;
+  });
+
+describe('Storybook explicit examples', () => {
+  it('does not use .map() in story files', () => {
+    const violations = findStoryMapViolations();
+
+    expect(
+      violations,
+      [
+        'Do not use `.map()` in *.stories.* files.',
+        'Storybook code panels must show explicit, copyable component examples.',
+        'Use containers to group examples, but write each component invocation with its props inline.',
+        ...violations.map(({ file, line, column }) => `- ${file}:${line}:${column}`)
+      ].join('\n')
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Storybook documentation harness that forbids `.map()` in story files, then rewrites existing mapped examples as explicit component invocations so code panels stay copyable.

Closes #178

## Type of change

- [ ] 🧩 New component
- [x] 🐛 Bug fix
- [ ] 🎨 Design tokens
- [ ] ♿ Accessibility
- [ ] 🏗️ Infrastructure
- [ ] 📚 Documentation

## Component checklist (skip if not applicable)

- [x] Follows the 5-file structure (`types.ts`, `use*.ts`, `Component.tsx`, `index.ts`, `*.stories.tsx`)
- [x] CVA variants defined in `types.ts`, not inline
- [x] No hardcoded colors — uses tokens from `theme.css`
- [x] No `any` types — TypeScript strict
- [x] ARIA attributes present and correct
- [x] Keyboard navigable (Tab, Enter, Escape where applicable)
- [x] Dark mode works correctly
- [x] Storybook stories cover: default, variants, states (hover, focus, disabled)
- [x] Tests added or updated

## How to test

1. `rg -n "\\.map\\(" src --glob "*.stories.*"`
2. `./node_modules/.bin/vitest run src/storybook-explicit-examples.test.ts`
3. `pnpm test`
4. `./node_modules/.bin/tsc --noEmit --pretty false`
5. `pnpm run storybook-build`

## Screenshots / recordings (if applicable)

Not applicable — this is a documentation-source harness and story source cleanup.

## Notes for reviewer

- Replaces #179, which conflicted with `main` after #177 merged.
- This branch is rebased cleanly on current `main` and contains only the Storybook explicit examples harness/story cleanup commit.
- The harness intentionally rejects any `.map()` in `src/**/*.stories.*` files. This is stricter than only detecting JSX-render maps, but it keeps the rule simple and aligned with the docs convention: story code should be explicit and copyable.
