### PR TITLE
fix(package): make root entry consumable

### DIFF
--- a/docs/GUIDELINES.en.md
+++ b/docs/GUIDELINES.en.md
@@ -219,7 +219,7 @@ Every component test file MUST cover:
 Always mock these two packages — they import CSS animations or dynamic modules that break jsdom:
 
 ```typescript
-vi.mock('lucide-react/dynamic', () => ({
+vi.mock('lucide-react/dynamic.js', () => ({
   DynamicIcon: () => null
 }));
 

--- a/docs/GUIDELINES.md
+++ b/docs/GUIDELINES.md
@@ -245,7 +245,7 @@ Cada archivo de test de componente DEBE cubrir:
 Siempre mockea estos dos paquetes — importan animaciones CSS o módulos dinámicos que rompen jsdom:
 
 ```typescript
-vi.mock("lucide-react/dynamic", () => ({
+vi.mock("lucide-react/dynamic.js", () => ({
   DynamicIcon: () => null,
 }));
 

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     },
     "./styles": "./dist/design-system.css"
   },
@@ -19,6 +19,7 @@
   ],
   "scripts": {
     "build": "vite build && tsc --project tsconfig.build.json",
+    "verify:package": "pnpm run build && node scripts/verify-package-consumption.mjs",
     "clean": "node -e \"['dist','node_modules','pnpm-lock.yaml','package-lock.json'].forEach(p=>require('fs').rmSync(p,{recursive:true,force:true}))\" && npm cache clean --force",
     "reinstall": "pnpm run clean && pnpm install",
     "biome-all": "biome check --write .",

--- a/scripts/verify-package-consumption.mjs
+++ b/scripts/verify-package-consumption.mjs
@@ -1,8 +1,10 @@
 import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Button } from '@stack-and-flow/design-system';
 
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const loadCjs = createRequire(import.meta.url);
 const cjsExports = loadCjs('@stack-and-flow/design-system');
 const stylesPath = loadCjs.resolve('@stack-and-flow/design-system/styles');
@@ -15,7 +17,7 @@ if (typeof cjsExports.Button !== 'function') {
   throw new TypeError(`Expected CJS Button export to be a function, received ${typeof cjsExports.Button}`);
 }
 
-const cssPath = resolve('dist/design-system.css');
+const cssPath = resolve(packageRoot, 'dist/design-system.css');
 if (stylesPath !== cssPath) {
   throw new Error(`Expected styles subpath to resolve to ${cssPath}, received ${stylesPath}`);
 }

--- a/scripts/verify-package-consumption.mjs
+++ b/scripts/verify-package-consumption.mjs
@@ -1,0 +1,27 @@
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+import { Button } from '@stack-and-flow/design-system';
+
+const loadCjs = createRequire(import.meta.url);
+const cjsExports = loadCjs('@stack-and-flow/design-system');
+const stylesPath = loadCjs.resolve('@stack-and-flow/design-system/styles');
+
+if (typeof Button !== 'function') {
+  throw new TypeError(`Expected ESM Button export to be a function, received ${typeof Button}`);
+}
+
+if (typeof cjsExports.Button !== 'function') {
+  throw new TypeError(`Expected CJS Button export to be a function, received ${typeof cjsExports.Button}`);
+}
+
+const cssPath = resolve('dist/design-system.css');
+if (stylesPath !== cssPath) {
+  throw new Error(`Expected styles subpath to resolve to ${cssPath}, received ${stylesPath}`);
+}
+
+if (!existsSync(cssPath)) {
+  throw new Error(`Expected package styles export target to exist: ${cssPath}`);
+}
+
+console.log('Package consumption verified: ESM/CJS root Button imports and styles subpath are available.');

--- a/src/components/atoms/button/Button.test.tsx
+++ b/src/components/atoms/button/Button.test.tsx
@@ -9,7 +9,7 @@
  * WHAT we do NOT test: specific CSS class strings, internal refs, ripple implementation
  *
  * MOCKS:
- * - lucide-react/dynamic → DynamicIcon causes dynamic import issues in jsdom
+ * - lucide-react/dynamic.js → DynamicIcon causes dynamic import issues in jsdom
  * - spinners-react → SpinnerCircular uses CSS animations not available in jsdom
  *   but the import itself still resolves, so we mock the module to avoid CSS parse errors
  */
@@ -20,7 +20,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 // --- Mocks (declared before component import) ---
 
-vi.mock('lucide-react/dynamic', () => ({
+vi.mock('lucide-react/dynamic.js', () => ({
   // biome-ignore lint/style/useNamingConvention: must match library export name
   DynamicIcon: () => null
 }));

--- a/src/components/atoms/button/Button.tsx
+++ b/src/components/atoms/button/Button.tsx
@@ -1,4 +1,4 @@
-import { DynamicIcon } from 'lucide-react/dynamic';
+import { DynamicIcon } from 'lucide-react/dynamic.js';
 import type { FC } from 'react';
 import { SpinnerCircular } from 'spinners-react';
 import type { ButtonProps } from './types';

--- a/src/components/atoms/icon-button/IconButton.tsx
+++ b/src/components/atoms/icon-button/IconButton.tsx
@@ -1,5 +1,5 @@
 import type { VariantProps } from 'class-variance-authority';
-import { DynamicIcon } from 'lucide-react/dynamic';
+import { DynamicIcon } from 'lucide-react/dynamic.js';
 import type { ComponentProps, FC } from 'react';
 import { cn } from '@/lib/utils';
 import { type IconButtonProps, iconButtonVariants } from './types';

--- a/src/components/atoms/icon/Icon.tsx
+++ b/src/components/atoms/icon/Icon.tsx
@@ -1,4 +1,4 @@
-import { DynamicIcon } from 'lucide-react/dynamic';
+import { DynamicIcon } from 'lucide-react/dynamic.js';
 import type { FC } from 'react';
 import { cn } from '@/lib/utils';
 import type { IconProps } from './types';

--- a/src/components/atoms/link/Link.stories.tsx
+++ b/src/components/atoms/link/Link.stories.tsx
@@ -16,7 +16,7 @@ const VariantRow = ({ children }: { children: ReactNode }) => (
  * Link renders navigation and action affordances with Stack-and-Flow typography, focus, and token styling.
  *
  * ## Dependencies
- * Uses `lucide-react/dynamic` when the optional `icon` prop is provided.
+ * Uses `lucide-react/dynamic.js` when the optional `icon` prop is provided.
  *
  * ## Usage Guide
  * Use `regular` for inline navigation, `outlined` for secondary call-to-action links, and `button` when a link must visually match a primary action while preserving link semantics when `href` is present. When `href` is omitted, Link behaves as a local action control with button semantics and keyboard activation.

--- a/src/components/atoms/link/Link.test.tsx
+++ b/src/components/atoms/link/Link.test.tsx
@@ -14,7 +14,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 // --- Mocks (declared before component import) ---
 
-vi.mock('lucide-react/dynamic', () => ({
+vi.mock('lucide-react/dynamic.js', () => ({
   // biome-ignore lint/style/useNamingConvention: must match library export name
   DynamicIcon: ({ name }: { name: string }) => <span aria-hidden='true' data-icon={name} data-testid='link-icon' />
 }));

--- a/src/components/atoms/link/Link.tsx
+++ b/src/components/atoms/link/Link.tsx
@@ -1,4 +1,4 @@
-import { DynamicIcon } from 'lucide-react/dynamic';
+import { DynamicIcon } from 'lucide-react/dynamic.js';
 import type { FC } from 'react';
 import type { LinkProps } from './types';
 import { useLink } from './useLink';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import './styles/global.css';
+
 // ─── Atoms ───────────────────────────────────────────────────────────────────
 export { Avatar } from './components/atoms/avatar';
 export { Badge } from './components/atoms/badge';
@@ -24,6 +26,3 @@ export { Snippet } from './components/molecules/snippet';
 export { Footer } from './components/organisms/footer';
 export { NavigationHeader } from './components/organisms/header';
 export { Modal } from './components/organisms/modal';
-
-// ─── Hooks ───────────────────────────────────────────────────────────────────
-export { useRipple } from './hooks/useRipple';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,6 @@
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react-swc';
 import path from 'path';
-import { defineConfig } from 'vite';
-import { defineConfig as defineVitestConfig } from 'vitest/config';
 
 const aliases = {
   '@': path.resolve(__dirname, './src'),
@@ -15,7 +13,7 @@ const aliases = {
   '@utils': path.resolve(__dirname, './src/utils')
 };
 
-export default defineConfig({
+const config: Record<string, unknown> = {
   base: './',
   plugins: [react(), tailwindcss()],
   resolve: {
@@ -26,11 +24,13 @@ export default defineConfig({
       entry: path.resolve(__dirname, 'src/index.ts'),
       name: 'StackAndFlowDesignSystem',
       formats: ['es', 'cjs'],
-      fileName: (format) => `index.${format === 'es' ? 'js' : 'cjs'}`
+      fileName: (format: string) => `index.${format === 'es' ? 'js' : 'cjs'}`
     },
     rollupOptions: {
       external: ['react', 'react-dom', 'react/jsx-runtime', 'lucide-react', /^lucide-react\/.*/],
       output: {
+        assetFileNames: (assetInfo: { name?: string }) =>
+          assetInfo.name?.endsWith('.css') ? 'design-system.css' : 'assets/[name]-[hash][extname]',
         globals: {
           react: 'React',
           'react-dom': 'ReactDOM',
@@ -55,4 +55,6 @@ export default defineConfig({
       exclude: ['src/components/**/*.stories.tsx', 'src/components/**/*.test.*', 'src/components/**/index.ts']
     }
   }
-});
+};
+
+export default config;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react-swc';
 import path from 'path';
+import { defineConfig, type UserConfig } from 'vite';
 
 const aliases = {
   '@': path.resolve(__dirname, './src'),
@@ -13,7 +14,21 @@ const aliases = {
   '@utils': path.resolve(__dirname, './src/utils')
 };
 
-const config: Record<string, unknown> = {
+type TestConfig = {
+  globals: boolean;
+  environment: 'jsdom';
+  setupFiles: string[];
+  css: boolean;
+  alias: typeof aliases;
+  coverage: {
+    provider: 'v8';
+    reporter: string[];
+    include: string[];
+    exclude: string[];
+  };
+};
+
+const config = {
   base: './',
   plugins: [react(), tailwindcss()],
   resolve: {
@@ -55,6 +70,6 @@ const config: Record<string, unknown> = {
       exclude: ['src/components/**/*.stories.tsx', 'src/components/**/*.test.*', 'src/components/**/index.ts']
     }
   }
-};
+} satisfies UserConfig & { test: TestConfig };
 
-export default config;
+export default defineConfig(config);


### PR DESCRIPTION
## Summary

Fixes package root consumption by making the root barrel and build output usable by external consumers.

Closes #110

## Type of change

- [ ] 🧩 New component
- [x] 🐛 Bug fix
- [ ] 🎨 Design tokens
- [ ] ♿ Accessibility
- [ ] 🏗️ Infrastructure
- [ ] 📚 Documentation

## Component checklist (skip if not applicable)

- [ ] Follows the 5-file structure (`types.ts`, `use*.ts`, `Component.tsx`, `index.ts`, `*.stories.tsx`)
- [ ] CVA variants defined in `types.ts`, not inline
- [ ] No hardcoded colors — uses tokens from `theme.css`
- [ ] No `any` types — TypeScript strict
- [ ] ARIA attributes present and correct
- [ ] Keyboard navigable (Tab, Enter, Escape where applicable)
- [ ] Dark mode works correctly
- [ ] Storybook stories cover: default, variants, states (hover, focus, disabled)
- [x] Tests added or updated

## Changes

| File | Change |
|------|--------|
| `src/index.ts` | Imports global styles into the package entry and removes internal `useRipple` from root exports. |
| `package.json` | Orders export conditions correctly and adds `verify:package`. |
| `vite.config.ts` | Emits package CSS as stable `dist/design-system.css`. |
| `scripts/verify-package-consumption.mjs` | Adds ESM, CJS, and styles subpath smoke verification. |
| `src/components/atoms/*` | Uses `lucide-react/dynamic.js` for Node ESM-compatible subpath resolution. |
| `docs/GUIDELINES*.md` | Updates mock guidance to match the runtime import path. |

## How to test

- [x] `pnpm run verify:package`
- [x] `pnpm test`
- [x] Pre-push hook ran `pnpm test`
- [x] Shellcheck not applicable, no shell scripts changed

## Screenshots / recordings (if applicable)

N/A

## Notes for reviewer

The package verification script checks:

- `import { Button } from '@stack-and-flow/design-system'`
- `require('@stack-and-flow/design-system')`
- `@stack-and-flow/design-system/styles` resolving to `dist/design-system.css`

The root barrel intentionally no longer exports `useRipple`, because it is an internal implementation hook.
