### PR TITLE
fix(divider): complete atom review

### DIFF
--- a/src/components/atoms/divider/Divider.stories.tsx
+++ b/src/components/atoms/divider/Divider.stories.tsx
@@ -54,7 +54,7 @@ export const Default: Story = {
 /** Shows the semantic difference between a default separator and a decorative-only divider. */
 export const Decorative: Story = {
   render: () => (
-    <div className='grid w-168 gap-4 md:grid-cols-2'>
+    <div className='grid gap-4 md:grid-cols-2'>
       <section className={`${surfaceClass} flex flex-col gap-4`}>
         <VariantLabel>Semantic separator</VariantLabel>
         <p className={bodyTextClass}>Assistive technology receives role="separator" and the orientation.</p>
@@ -72,7 +72,7 @@ export const Decorative: Story = {
 /** Shows a divider filling the available inline size, and a vertical divider filling a defined parent height. */
 export const FullSize: Story = {
   render: () => (
-    <div className='grid w-168 gap-4 md:grid-cols-2'>
+    <div className='grid gap-4 md:grid-cols-2'>
       <section className={`${surfaceClass} flex flex-col gap-4`}>
         <VariantLabel>Horizontal full</VariantLabel>
         <p className={bodyTextClass}>Fills the available width of its parent.</p>

--- a/src/components/atoms/divider/Divider.stories.tsx
+++ b/src/components/atoms/divider/Divider.stories.tsx
@@ -1,6 +1,26 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import Divider from './Divider';
+import { Divider } from './Divider';
 
+const surfaceClass =
+  'rounded-md border border-border-light bg-surface-light p-6 dark:border-border-dark dark:bg-surface-dark';
+const compactSurfaceClass = `${surfaceClass} flex w-96 flex-col gap-4`;
+const wideSurfaceClass = `${surfaceClass} flex w-[28rem] flex-col gap-5`;
+const verticalSurfaceClass = `${surfaceClass} flex h-48 w-96 items-end justify-center gap-7`;
+const labelClass = 'text-xs font-medium uppercase tracking-wide text-text-tertiary-light dark:text-text-tertiary-dark';
+const bodyTextClass = 'text-sm text-text-secondary-light dark:text-text-secondary-dark';
+const rowClass = 'flex w-full flex-col gap-2';
+
+const VariantLabel = ({ children }: { children: string }) => <span className={labelClass}>{children}</span>;
+
+/**
+ * ## Description
+ * Divider renders a token-based separator that visually splits related content.
+ * Use the semantic default for section boundaries and the decorative mode when a rule is purely visual.
+ *
+ * ## Usage Guide
+ * Keep Divider visually simple and structural. Prefer orientation, size, thickness, and color tokens instead of
+ * custom inline styles or decorative effects.
+ */
 const meta: Meta<typeof Divider> = {
   title: 'Atoms/Divider',
   component: Divider,
@@ -11,107 +31,208 @@ const meta: Meta<typeof Divider> = {
   },
   tags: ['autodocs']
 };
+
 export default meta;
 
 type Story = StoryObj<typeof Divider>;
 
+/** Shows the divider in a realistic stacked content composition. */
 export const Default: Story = {
-  args: {}
-};
-
-/**
- * In the horizontal orientation, we have 5 sizes: XS, SM, MD, LG, and full.
- */
-
-export const HorizontalSize: Story = {
-  render: () => (
-    <div
-      style={{
-        width: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '1rem',
-        justifyContent: 'center',
-        alignItems: 'center'
-      }}
-    >
-      <Divider orientation='horizontal' size='xs' />
-      <Divider orientation='horizontal' size='sm' />
-      <Divider orientation='horizontal' size='md' />
-      <Divider orientation='horizontal' size='lg' />
-      <Divider orientation='horizontal' size='xl' />
-    </div>
+  args: {},
+  render: (args) => (
+    <section className={compactSurfaceClass}>
+      <div className='flex flex-col gap-1'>
+        <VariantLabel>Account settings</VariantLabel>
+        <p className={bodyTextClass}>Use dividers to create a quiet boundary between related content groups.</p>
+      </div>
+      <Divider {...args} />
+      <p className={bodyTextClass}>The line remains simple, token-based, and structural.</p>
+    </section>
   )
 };
-/**
- * We also offer five sizes in vertical: XS, SM, MD, LG, and full.
- */
-export const VerticalSize: Story = {
+
+/** Shows the semantic difference between a default separator and a decorative-only divider. */
+export const Decorative: Story = {
   render: () => (
-    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '1rem' }}>
-      <Divider orientation='vertical' size='xs' />
-      <Divider orientation='vertical' size='sm' />
-      <Divider orientation='vertical' size='md' />
-      <Divider orientation='vertical' size='lg' />
-      <Divider orientation='vertical' size='xl' />
+    <div className='grid w-168 gap-4 md:grid-cols-2'>
+      <section className={`${surfaceClass} flex flex-col gap-4`}>
+        <VariantLabel>Semantic separator</VariantLabel>
+        <p className={bodyTextClass}>Assistive technology receives role="separator" and the orientation.</p>
+        <Divider size='lg' />
+      </section>
+      <section className={`${surfaceClass} flex flex-col gap-4`}>
+        <VariantLabel>Decorative only</VariantLabel>
+        <p className={bodyTextClass}>Purely visual dividers are removed from the accessibility tree.</p>
+        <Divider decorative={true} size='lg' />
+      </section>
     </div>
   )
 };
 
-/**
- * In both orientations, we have four thicknesses.
- */
-export const ThicknessHorizontal: Story = {
+/** Shows a divider filling the available inline size, and a vertical divider filling a defined parent height. */
+export const FullSize: Story = {
   render: () => (
-    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '1rem' }}>
-      <Divider orientation='horizontal' thickness='xs' />
-      <Divider orientation='horizontal' thickness='sm' />
-      <Divider orientation='horizontal' thickness='md' />
-      <Divider orientation='horizontal' thickness='lg' />
+    <div className='grid w-168 gap-4 md:grid-cols-2'>
+      <section className={`${surfaceClass} flex flex-col gap-4`}>
+        <VariantLabel>Horizontal full</VariantLabel>
+        <p className={bodyTextClass}>Fills the available width of its parent.</p>
+        <Divider size='full' />
+      </section>
+      <section className={`${surfaceClass} flex h-48 items-center justify-center gap-5`}>
+        <div className='flex h-full flex-col justify-between py-2'>
+          <span className={bodyTextClass}>Start</span>
+          <span className={bodyTextClass}>End</span>
+        </div>
+        <Divider orientation='vertical' size='full' />
+        <p className={`${bodyTextClass} max-w-32`}>Vertical full needs a parent with defined height.</p>
+      </section>
     </div>
   )
 };
 
-/**
- * In both orientations, we have four thicknesses.
- */
-export const ThicknessVertical: Story = {
+/** Documents the horizontal size scale from extra-small to full width. */
+export const HorizontalSizes: Story = {
   render: () => (
-    <div style={{ display: 'flex', justifyContent: 'center', gap: '1rem' }}>
-      <Divider orientation='vertical' thickness='xs' />
-      <Divider orientation='vertical' thickness='sm' />
-      <Divider orientation='vertical' thickness='md' />
-      <Divider orientation='vertical' thickness='lg' />
+    <div className={wideSurfaceClass}>
+      <div className={rowClass}>
+        <VariantLabel>XS</VariantLabel>
+        <Divider size='xs' />
+      </div>
+      <div className={rowClass}>
+        <VariantLabel>SM</VariantLabel>
+        <Divider size='sm' />
+      </div>
+      <div className={rowClass}>
+        <VariantLabel>MD</VariantLabel>
+        <Divider size='md' />
+      </div>
+      <div className={rowClass}>
+        <VariantLabel>LG</VariantLabel>
+        <Divider size='lg' />
+      </div>
+      <div className={rowClass}>
+        <VariantLabel>XL</VariantLabel>
+        <Divider size='xl' />
+      </div>
+      <div className={rowClass}>
+        <VariantLabel>Full</VariantLabel>
+        <Divider size='full' />
+      </div>
     </div>
   )
 };
 
-/**
- * You can customise the colour of the line with a class name.
- */
-export const Color: Story = {
+/** Documents the vertical size scale from extra-small to full height. */
+export const VerticalSizes: Story = {
   render: () => (
-    <div style={{ width: '100%', display: 'flex', flexDirection: 'column', gap: '1rem', justifyContent: 'center' }}>
-      <Divider orientation='horizontal' size='md' color='bg-color-primary' />
-      <Divider orientation='horizontal' size='md' color='bg-color-blue' />
-      <Divider orientation='horizontal' size='md' color='bg-color-indigo' />
+    <div className={verticalSurfaceClass}>
+      <div className='flex h-full flex-col items-center justify-end gap-3'>
+        <Divider orientation='vertical' size='xs' />
+        <VariantLabel>XS</VariantLabel>
+      </div>
+      <div className='flex h-full flex-col items-center justify-end gap-3'>
+        <Divider orientation='vertical' size='sm' />
+        <VariantLabel>SM</VariantLabel>
+      </div>
+      <div className='flex h-full flex-col items-center justify-end gap-3'>
+        <Divider orientation='vertical' size='md' />
+        <VariantLabel>MD</VariantLabel>
+      </div>
+      <div className='flex h-full flex-col items-center justify-end gap-3'>
+        <Divider orientation='vertical' size='lg' />
+        <VariantLabel>LG</VariantLabel>
+      </div>
+      <div className='flex h-full flex-col items-center justify-end gap-3'>
+        <Divider orientation='vertical' size='xl' />
+        <VariantLabel>XL</VariantLabel>
+      </div>
+      <div className='flex h-full flex-col items-center justify-end gap-3'>
+        <Divider orientation='vertical' size='full' />
+        <VariantLabel>Full</VariantLabel>
+      </div>
     </div>
   )
 };
 
-/**
- * We can give it more stylish corners
- */
-export const Corner: Story = {
+/** Documents horizontal divider thickness values while keeping the other props stable. */
+export const HorizontalThicknesses: Story = {
   render: () => (
-    <div
-      style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', gap: '1rem' }}
-    >
-      <Divider orientation='horizontal' size='lg' thickness='md' corner='none' />
-      <Divider orientation='horizontal' size='lg' thickness='md' corner='rounded' />
-      <div style={{ display: 'flex', gap: '1rem' }}>
-        <Divider orientation='vertical' size='lg' thickness='lg' corner='none' />
-        <Divider orientation='vertical' size='lg' thickness='lg' corner='rounded' />
+    <div className={wideSurfaceClass}>
+      <div className={rowClass}>
+        <VariantLabel>XS</VariantLabel>
+        <Divider size='xl' thickness='xs' />
+      </div>
+      <div className={rowClass}>
+        <VariantLabel>SM</VariantLabel>
+        <Divider size='xl' thickness='sm' />
+      </div>
+      <div className={rowClass}>
+        <VariantLabel>MD</VariantLabel>
+        <Divider size='xl' thickness='md' />
+      </div>
+      <div className={rowClass}>
+        <VariantLabel>LG</VariantLabel>
+        <Divider size='xl' thickness='lg' />
+      </div>
+    </div>
+  )
+};
+
+/** Documents vertical divider thickness values while keeping the other props stable. */
+export const VerticalThicknesses: Story = {
+  render: () => (
+    <div className={verticalSurfaceClass}>
+      <div className='flex h-full flex-col items-center justify-end gap-3'>
+        <Divider orientation='vertical' size='xl' thickness='xs' />
+        <VariantLabel>XS</VariantLabel>
+      </div>
+      <div className='flex h-full flex-col items-center justify-end gap-3'>
+        <Divider orientation='vertical' size='xl' thickness='sm' />
+        <VariantLabel>SM</VariantLabel>
+      </div>
+      <div className='flex h-full flex-col items-center justify-end gap-3'>
+        <Divider orientation='vertical' size='xl' thickness='md' />
+        <VariantLabel>MD</VariantLabel>
+      </div>
+      <div className='flex h-full flex-col items-center justify-end gap-3'>
+        <Divider orientation='vertical' size='xl' thickness='lg' />
+        <VariantLabel>LG</VariantLabel>
+      </div>
+    </div>
+  )
+};
+
+/** Documents supported token-based divider colors without changing the structural behavior. */
+export const Colors: Story = {
+  render: () => (
+    <div className={wideSurfaceClass}>
+      <div className={rowClass}>
+        <VariantLabel>Primary</VariantLabel>
+        <Divider size='xl' color='bg-primary' />
+      </div>
+      <div className={rowClass}>
+        <VariantLabel>Blue</VariantLabel>
+        <Divider size='xl' color='bg-blue' />
+      </div>
+      <div className={rowClass}>
+        <VariantLabel>Indigo</VariantLabel>
+        <Divider size='xl' color='bg-indigo' />
+      </div>
+    </div>
+  )
+};
+
+/** Documents the corner variants for thicker horizontal dividers. */
+export const Corners: Story = {
+  render: () => (
+    <div className={wideSurfaceClass}>
+      <div className={rowClass}>
+        <VariantLabel>None</VariantLabel>
+        <Divider size='xl' thickness='lg' corner='none' />
+      </div>
+      <div className={rowClass}>
+        <VariantLabel>Rounded</VariantLabel>
+        <Divider size='xl' thickness='lg' corner='rounded' />
       </div>
     </div>
   )

--- a/src/components/atoms/divider/Divider.test.tsx
+++ b/src/components/atoms/divider/Divider.test.tsx
@@ -24,7 +24,8 @@ describe('useDivider — logic', () => {
   it('returns token-backed classes for divider variants and color', () => {
     const { result } = renderHook(() => useDivider({ orientation: 'vertical', size: 'lg', thickness: 'md' }));
 
-    expect(result.current.className).toContain('h-18');
+    expect(result.current.className).toContain('h-20');
+    expect(result.current.className).toContain('w-0-75');
     expect(result.current.className).toContain('bg-primary');
   });
 

--- a/src/components/atoms/divider/Divider.test.tsx
+++ b/src/components/atoms/divider/Divider.test.tsx
@@ -1,0 +1,68 @@
+import { render, renderHook, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Divider } from './Divider';
+import { useDivider } from './useDivider';
+
+describe('useDivider — logic', () => {
+  it('returns semantic separator attributes and full width by default', () => {
+    const { result } = renderHook(() => useDivider({}));
+
+    expect(result.current.dividerProps.role).toBe('separator');
+    expect(result.current.dividerProps['aria-orientation']).toBe('horizontal');
+    expect(result.current.dividerProps['aria-hidden']).toBeUndefined();
+    expect(result.current.className).toContain('w-full');
+  });
+
+  it('returns decorative aria attributes when decorative is true', () => {
+    const { result } = renderHook(() => useDivider({ decorative: true }));
+
+    expect(result.current.dividerProps.role).toBeUndefined();
+    expect(result.current.dividerProps['aria-orientation']).toBeUndefined();
+    expect(result.current.dividerProps['aria-hidden']).toBe(true);
+  });
+
+  it('returns token-backed classes for divider variants and color', () => {
+    const { result } = renderHook(() => useDivider({ orientation: 'vertical', size: 'lg', thickness: 'md' }));
+
+    expect(result.current.className).toContain('h-18');
+    expect(result.current.className).toContain('bg-primary');
+  });
+
+  it('maps full size to the available axis for each orientation', () => {
+    const { result: horizontal } = renderHook(() => useDivider({ size: 'full' }));
+    const { result: vertical } = renderHook(() => useDivider({ orientation: 'vertical', size: 'full' }));
+
+    expect(horizontal.current.className).toContain('w-full');
+    expect(vertical.current.className).toContain('h-full');
+  });
+});
+
+describe('Divider — component behavior', () => {
+  it('renders a semantic separator by default', () => {
+    render(<Divider />);
+
+    expect(screen.getByRole('separator')).toBeInTheDocument();
+  });
+
+  it('applies the correct aria orientation for vertical separators', () => {
+    render(<Divider orientation='vertical' />);
+
+    expect(screen.getByRole('separator')).toHaveAttribute('aria-orientation', 'vertical');
+  });
+
+  it('renders a decorative divider outside the accessibility tree when requested', () => {
+    render(<Divider decorative={true} data-testid='decorative-divider' />);
+
+    expect(screen.getByTestId('decorative-divider')).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.queryByRole('separator')).not.toBeInTheDocument();
+  });
+
+  it('forwards custom className and native div attributes', () => {
+    render(<Divider className='custom-divider' data-testid='divider' id='section-divider' />);
+
+    const divider = screen.getByTestId('divider');
+
+    expect(divider).toHaveClass('custom-divider');
+    expect(divider).toHaveAttribute('id', 'section-divider');
+  });
+});

--- a/src/components/atoms/divider/Divider.tsx
+++ b/src/components/atoms/divider/Divider.tsx
@@ -1,11 +1,9 @@
 import type { FC } from 'react';
-import { cn } from '@/lib/utils';
 import type { DividerProps } from './types';
 import { useDivider } from './useDivider';
 
-const Divider: FC<DividerProps> = ({ ...props }) => {
-  const { dividerClass, color, sizeFinal } = useDivider(props);
-  return <div role='separator' className={cn(dividerClass, color, sizeFinal)}></div>;
-};
+export const Divider: FC<DividerProps> = (props) => {
+  const { className, dividerProps } = useDivider(props);
 
-export default Divider;
+  return <div {...dividerProps} className={className} />;
+};

--- a/src/components/atoms/divider/index.ts
+++ b/src/components/atoms/divider/index.ts
@@ -1,2 +1,2 @@
-export { default as Divider } from './Divider';
+export { Divider } from './Divider';
 export * from './types';

--- a/src/components/atoms/divider/types.ts
+++ b/src/components/atoms/divider/types.ts
@@ -4,8 +4,8 @@ import type { ComponentProps } from 'react';
 export const dividerVariants = cva('shrink-0', {
   variants: {
     orientation: {
-      horizontal: 'h-px',
-      vertical: 'w-px'
+      horizontal: '',
+      vertical: ''
     },
     size: {
       xs: '',
@@ -20,10 +20,10 @@ export const dividerVariants = cva('shrink-0', {
       none: 'rounded-none'
     },
     thickness: {
-      xs: 'p-0',
-      sm: 'p-0.5',
-      md: 'p-0-75',
-      lg: 'p-1-25'
+      xs: '',
+      sm: '',
+      md: '',
+      lg: ''
     }
   },
   compoundVariants: [
@@ -75,7 +75,7 @@ export const dividerVariants = cva('shrink-0', {
     {
       orientation: 'vertical',
       size: 'lg',
-      class: 'h-18'
+      class: 'h-20'
     },
     {
       orientation: 'vertical',
@@ -86,6 +86,46 @@ export const dividerVariants = cva('shrink-0', {
       orientation: 'vertical',
       size: 'full',
       class: 'h-full'
+    },
+    {
+      orientation: 'horizontal',
+      thickness: 'xs',
+      class: 'h-px'
+    },
+    {
+      orientation: 'horizontal',
+      thickness: 'sm',
+      class: 'h-0.5'
+    },
+    {
+      orientation: 'horizontal',
+      thickness: 'md',
+      class: 'h-0-75'
+    },
+    {
+      orientation: 'horizontal',
+      thickness: 'lg',
+      class: 'h-1-25'
+    },
+    {
+      orientation: 'vertical',
+      thickness: 'xs',
+      class: 'w-px'
+    },
+    {
+      orientation: 'vertical',
+      thickness: 'sm',
+      class: 'w-0.5'
+    },
+    {
+      orientation: 'vertical',
+      thickness: 'md',
+      class: 'w-0-75'
+    },
+    {
+      orientation: 'vertical',
+      thickness: 'lg',
+      class: 'w-1-25'
     }
   ],
   defaultVariants: {

--- a/src/components/atoms/divider/types.ts
+++ b/src/components/atoms/divider/types.ts
@@ -1,10 +1,19 @@
-import { cva } from 'class-variance-authority';
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { ComponentProps } from 'react';
 
-export const dividerVariants = cva('', {
+export const dividerVariants = cva('shrink-0', {
   variants: {
     orientation: {
-      horizontal: 'h-px w-1',
-      vertical: 'w-px h-1'
+      horizontal: 'h-px',
+      vertical: 'w-px'
+    },
+    size: {
+      xs: '',
+      sm: '',
+      md: '',
+      lg: '',
+      xl: '',
+      full: ''
     },
     corner: {
       rounded: 'rounded-xs',
@@ -20,51 +29,126 @@ export const dividerVariants = cva('', {
   compoundVariants: [
     {
       orientation: 'horizontal',
-      class: 'h-px'
+      size: 'xs',
+      class: 'w-8'
+    },
+    {
+      orientation: 'horizontal',
+      size: 'sm',
+      class: 'w-16'
+    },
+    {
+      orientation: 'horizontal',
+      size: 'md',
+      class: 'w-32'
+    },
+    {
+      orientation: 'horizontal',
+      size: 'lg',
+      class: 'w-64'
+    },
+    {
+      orientation: 'horizontal',
+      size: 'xl',
+      class: 'w-96'
+    },
+    {
+      orientation: 'horizontal',
+      size: 'full',
+      class: 'w-full'
     },
     {
       orientation: 'vertical',
-      class: 'w-px'
+      size: 'xs',
+      class: 'h-6'
+    },
+    {
+      orientation: 'vertical',
+      size: 'sm',
+      class: 'h-10'
+    },
+    {
+      orientation: 'vertical',
+      size: 'md',
+      class: 'h-14'
+    },
+    {
+      orientation: 'vertical',
+      size: 'lg',
+      class: 'h-18'
+    },
+    {
+      orientation: 'vertical',
+      size: 'xl',
+      class: 'h-24'
+    },
+    {
+      orientation: 'vertical',
+      size: 'full',
+      class: 'h-full'
     }
   ],
   defaultVariants: {
-    orientation: 'horizontal'
+    orientation: 'horizontal',
+    size: 'full',
+    corner: 'none',
+    thickness: 'xs'
   }
 });
 
-type DividerOrientation = 'horizontal' | 'vertical';
-type DividerThickness = 'xs' | 'sm' | 'md' | 'lg';
-type DividerCorner = 'rounded' | 'none';
-export type DividerProps = {
-  /** Props for the Divider component */
+type DividerVariantProps = VariantProps<typeof dividerVariants>;
+export type DividerColor =
+  | 'bg-primary'
+  | 'bg-brand-light'
+  | 'bg-brand-dark'
+  | 'bg-red-500'
+  | 'bg-red-600'
+  | 'bg-blue'
+  | 'bg-indigo'
+  | 'bg-purple'
+  | 'bg-green'
+  | 'bg-teal'
+  | 'bg-yellow'
+  | 'bg-orange'
+  | 'bg-pink'
+  | (string & {});
 
+type NativeDividerProps = Omit<
+  ComponentProps<'div'>,
+  'aria-hidden' | 'aria-orientation' | 'children' | 'className' | 'color' | 'role'
+>;
+
+export type DividerProps = NativeDividerProps & {
   /**
    * @control select
    * @default horizontal
    */
-  orientation?: DividerOrientation;
-
+  orientation?: NonNullable<DividerVariantProps['orientation']>;
   /**
    * @control select
-   * @default bg-color-primary
+   * @default bg-primary
    */
-  color?: string;
-
+  color?: DividerColor;
   /**
    * @control select
-   * @default xs
+   * @default full
    */
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
-
+  size?: NonNullable<DividerVariantProps['size']>;
   /**
    * @control select
-   * @default xs
+   * @default none
    */
-  corner?: DividerCorner;
-
+  corner?: NonNullable<DividerVariantProps['corner']>;
   /**
    * @control select
    * @default xs
    */
-  thickness?: DividerThickness;
+  thickness?: NonNullable<DividerVariantProps['thickness']>;
+  /** @control text */
+  className?: string;
+  /**
+   * @control boolean
+   * @default false
+   */
+  decorative?: boolean;
 };

--- a/src/components/atoms/divider/useDivider.ts
+++ b/src/components/atoms/divider/useDivider.ts
@@ -1,50 +1,41 @@
+import { cn } from '@/lib/utils';
 import { type DividerProps, dividerVariants } from './types';
+
+type DividerOrientation = NonNullable<DividerProps['orientation']>;
+
+type DividerElementProps = Omit<
+  DividerProps,
+  'className' | 'color' | 'corner' | 'decorative' | 'orientation' | 'size' | 'thickness'
+> & {
+  role?: 'separator';
+  'aria-hidden'?: true;
+  'aria-orientation'?: DividerOrientation;
+};
+
+export type UseDividerReturn = {
+  className: string;
+  dividerProps: DividerElementProps;
+};
 
 export const useDivider = ({
   orientation = 'horizontal',
   color = 'bg-primary',
-  size = 'xs',
+  size = 'full',
   corner = 'none',
-  thickness = 'xs'
-}: DividerProps) => {
-  // Additional logic can be added here if needed
-
-  const sizeX = {
-    xs: 'w-8',
-    sm: 'w-16',
-    md: 'w-32',
-    lg: 'w-64',
-    xl: 'w-96'
-  };
-
-  const sizeY = {
-    xs: 'h-6',
-    sm: 'h-10',
-    md: 'h-14',
-    lg: 'h-18',
-    xl: 'h-24'
-  };
-
-  let sizeFinal;
-
-  if (orientation === 'horizontal') {
-    sizeFinal = sizeX[size];
-  } else {
-    sizeFinal = sizeY[size];
-  }
-
-  const dividerClass = dividerVariants({
-    orientation,
-    corner,
-    thickness
-  });
+  thickness = 'xs',
+  className,
+  decorative = false,
+  ...props
+}: DividerProps): UseDividerReturn => {
+  const dividerClassName = cn(dividerVariants({ orientation, size, corner, thickness }), color, className);
 
   return {
-    orientation,
-    color,
-    corner,
-    sizeFinal,
-    dividerClass,
-    thickness
+    className: dividerClassName,
+    dividerProps: {
+      ...props,
+      role: decorative ? undefined : 'separator',
+      'aria-hidden': decorative ? true : undefined,
+      'aria-orientation': decorative ? undefined : orientation
+    }
   };
 };


### PR DESCRIPTION
## Summary

Completes the Divider atom review checklist and validates the component against the design-system standards.

Closes #126

## Type of change

- [ ] 🧩 New component
- [x] 🐛 Bug fix
- [ ] 🎨 Design tokens
- [ ] ♿ Accessibility
- [ ] 🏗️ Infrastructure
- [ ] 📚 Documentation

## Component checklist (skip if not applicable)

- [x] Follows the 5-file structure (`types.ts`, `use*.ts`, `Component.tsx`, `index.ts`, `*.stories.tsx`)
- [x] CVA variants defined in `types.ts`, not inline
- [x] No hardcoded colors — uses tokens from `theme.css`
- [x] No `any` types — TypeScript strict
- [x] ARIA attributes present and correct
- [x] Keyboard navigable (Tab, Enter, Escape where applicable)
- [x] Dark mode works correctly
- [x] Storybook stories cover: default, variants, states (hover, focus, disabled)
- [x] Tests added or updated

## How to test

1. `pnpm exec vitest run src/components/atoms/divider/Divider.test.tsx`
2. `pnpm exec tsc --noEmit --pretty false`
3. `pnpm run storybook-build`
4. `pnpm test`
5. In Storybook, navigate to `Atoms/Divider` and verify Default, Decorative, FullSize, size, thickness, color, and corner stories.

## Screenshots / recordings (if applicable)

N/A

## Notes for reviewer

- `size="full"` is now the default so horizontal dividers fill available width by default.
- Vertical full-size dividers use `h-full`; parent containers need an explicit height.
- `color` keeps backward compatibility with arbitrary class strings while suggesting known token utilities.
