### PR TITLE
docs(ai): align skill harness commit conventions

### DIFF
--- a/.atl/AGENTS.md
+++ b/.atl/AGENTS.md
@@ -58,7 +58,7 @@ Components live in `src/components/{atoms|molecules|organisms}/{kebab-name}/` wi
 - Never modify `theme.css` without explicit user confirmation
 - Never add dependencies without explicit user confirmation
 - English only — code, comments, stories
-- Commit and PR titles must follow the commitlint-enforced Conventional Commit format: `<type>(<optional scope>): <description>`. Allowed types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`. Use scopes for domains such as `a11y`, `tokens`, or `infra` instead of inventing custom types.
+- Commit messages must follow the commitlint-enforced Conventional Commit format: `<type>(<optional scope>): <description>`. PR titles should follow the same format for review consistency. Allowed types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`. Use scopes for domains such as `a11y`, `tokens`, or `infra` instead of inventing custom types.
 
 ---
 

--- a/.atl/AGENTS.md
+++ b/.atl/AGENTS.md
@@ -58,7 +58,7 @@ Components live in `src/components/{atoms|molecules|organisms}/{kebab-name}/` wi
 - Never modify `theme.css` without explicit user confirmation
 - Never add dependencies without explicit user confirmation
 - English only — code, comments, stories
-- Conventional commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`
+- Commit and PR titles must follow the commitlint-enforced Conventional Commit format: `<type>(<optional scope>): <description>`. Allowed types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`. Use scopes for domains such as `a11y`, `tokens`, or `infra` instead of inventing custom types.
 
 ---
 

--- a/.atl/skills/component-contributor/references/git-workflow.md
+++ b/.atl/skills/component-contributor/references/git-workflow.md
@@ -36,7 +36,7 @@ Rules:
 
 ## Conventional Commits
 
-Commit messages and PR titles must follow the commitlint-enforced Conventional Commit format:
+Commit messages must follow the commitlint-enforced Conventional Commit format. PR titles should follow the same format for review consistency:
 
 ```text
 <type>(<optional scope>): <description>

--- a/.atl/skills/component-contributor/references/git-workflow.md
+++ b/.atl/skills/component-contributor/references/git-workflow.md
@@ -36,33 +36,51 @@ Rules:
 
 ## Conventional Commits
 
-Format: `<type>: <description>`
+Commit messages and PR titles must follow the commitlint-enforced Conventional Commit format:
 
-All lowercase. No period at the end. Present tense.
+```text
+<type>(<optional scope>): <description>
+```
+
+This repo uses `@commitlint/config-conventional` via the `commit-msg` hook. Use lowercase type, optional lowercase scope, present-tense description, and no period at the end.
 
 | Type        | When to use                              |
 | ----------- | ---------------------------------------- |
+| `build:`    | Build system or packaging changes        |
+| `chore:`    | Dependencies, tooling, config            |
+| `ci:`       | CI workflow changes                      |
+| `docs:`     | Documentation only                       |
 | `feat:`     | New component, new feature, new prop     |
 | `fix:`      | Bug fix                                  |
-| `chore:`    | Dependencies, tooling, config            |
-| `docs:`     | Documentation only                       |
+| `perf:`     | Performance improvement                  |
 | `refactor:` | Code change — no bug fix, no new feature |
+| `revert:`   | Revert a previous commit                 |
 | `style:`    | Formatting, whitespace, semicolons       |
 | `test:`     | Adding or fixing tests                   |
 
+Use scopes for domains such as `a11y`, `tokens`, or `infra` instead of inventing custom types.
+
 ```bash
 # ✅ CORRECT
-git commit -m "feat: add Avatar component with size and shape variants"
-git commit -m "fix: prevent button onClick when isLoading is true"
-git commit -m "chore: update biome to 2.4.12"
-git commit -m "docs: add forwardRef usage to GUIDELINES"
-git commit -m "test: add renderHook tests for useInput"
+git commit -m "feat(avatar): add size and shape variants"
+git commit -m "fix(button): prevent onClick when loading"
+git commit -m "fix(a11y): improve input focus ring visibility"
+git commit -m "chore(tokens): update spacing token docs"
+git commit -m "docs: add forwardRef usage to guidelines"
+git commit -m "test(input): add renderHook coverage"
 
 # ❌ WRONG
-git commit -m "Added Avatar"           # not conventional
-git commit -m "Feat: Avatar Component" # wrong case
-git commit -m "feat: Avatar."          # has period
-git commit -m "update stuff"           # no type
+git commit -m "Added Avatar"            # not conventional
+git commit -m "Feat: Avatar Component"  # wrong case
+git commit -m "feat: Avatar."           # has period
+git commit -m "a11y: improve focus ring" # unsupported custom type
+git commit -m "update stuff"            # no type
+```
+
+Validate manually before committing when unsure:
+
+```bash
+echo "feat(button): add loading state" | pnpm exec commitlint
 ```
 
 ---
@@ -82,11 +100,11 @@ When creating the issue, use the appropriate template (component, bug, feature).
 git checkout -b feat/my-component
 # ... make changes ...
 git add .
-git commit -m "feat: add MyComponent with variant and size props"
+git commit -m "feat(my-component): add variant and size props"
 git push origin feat/my-component
 ```
 
-Then open the PR via GitHub UI or `gh pr create`.
+Then open the PR via GitHub UI or `gh pr create`. The PR title must also follow the same Conventional Commit format, for example `feat(button): add loading state`.
 
 ### Step 3 — Fill the PR template completely
 
@@ -164,7 +182,8 @@ A PR is ready to merge when:
 - [ ] No hardcoded values — only design tokens
 - [ ] ARIA attributes present and correct
 - [ ] PR template fully filled
-- [ ] Conventional commit message
+- [ ] Conventional Commit messages pass commitlint
+- [ ] PR title follows Conventional Commit format
 - [ ] Linked to an issue with `Closes #NNN`
 
 ---

--- a/.atl/skills/pr-reviewer/SKILL.md
+++ b/.atl/skills/pr-reviewer/SKILL.md
@@ -60,6 +60,7 @@ Report the failing criterion and stop — do not continue with the detailed chec
 |-------|--------------|
 | CI is failing | Look for test, build, or lint failures in the PR |
 | No linked issue | PR description must contain `Closes #NNN` |
+| Invalid PR title | PR title must match commitlint-enforced Conventional Commit format: `<type>(<optional scope>): <description>` |
 | `interface` used | Grep for `interface ` in all `.ts` / `.tsx` files |
 | `any` used explicitly | Grep for `: any` or `as any` in all `.ts` / `.tsx` files |
 | Container/Presentational mixed | Logic (useState, useRef, handlers, CVA calls) found in `.tsx` file |
@@ -162,7 +163,10 @@ Before the Storybook review, read `.atl/skills/component-contributor/references/
 ### 10 — Git hygiene
 
 - [ ] Branch name follows convention: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `test/`
-- [ ] Conventional commit messages — `feat:`, `fix:`, etc.
+- [ ] Commit messages follow the commitlint-enforced Conventional Commit format: `<type>(<optional scope>): <description>`
+- [ ] PR title follows the same Conventional Commit format
+- [ ] Allowed types only: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
+- [ ] Domain terms such as `a11y`, `tokens`, or `infra` are scopes, not custom types
 - [ ] PR description contains `Closes #NNN`
 - [ ] PR template fully filled — no placeholder sections left empty
 - [ ] Branch is up to date with `main`

--- a/.atl/skills/pr-reviewer/SKILL.md
+++ b/.atl/skills/pr-reviewer/SKILL.md
@@ -60,7 +60,7 @@ Report the failing criterion and stop — do not continue with the detailed chec
 |-------|--------------|
 | CI is failing | Look for test, build, or lint failures in the PR |
 | No linked issue | PR description must contain `Closes #NNN` |
-| Invalid PR title | PR title must match commitlint-enforced Conventional Commit format: `<type>(<optional scope>): <description>` |
+| Invalid PR title | PR title must follow Conventional Commit format: `<type>(<optional scope>): <description>` |
 | `interface` used | Grep for `interface ` in all `.ts` / `.tsx` files |
 | `any` used explicitly | Grep for `: any` or `as any` in all `.ts` / `.tsx` files |
 | Container/Presentational mixed | Logic (useState, useRef, handlers, CVA calls) found in `.tsx` file |

--- a/.atl/skills/release-changeset/SKILL.md
+++ b/.atl/skills/release-changeset/SKILL.md
@@ -112,19 +112,32 @@ Verify `.gitignore` does NOT exclude it. If it does, remove that line.
 
 Find commits that introduced user-visible changes but have no corresponding changeset entry.
 
+### Conventional Commit contract
+
+Commit messages and PR titles must follow the commitlint-enforced format:
+
+```text
+<type>(<optional scope>): <description>
+```
+
+Allowed types from `@commitlint/config-conventional`: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`.
+
+Use scopes for domains such as `a11y`, `tokens`, `infra`, or component names. Do not treat those domains as custom commit types.
+
 ### What needs a changeset
 
 A commit NEEDS a changeset if it:
-- Adds a new component or feature (`feat:`)
-- Fixes a bug (`fix:`)
-- Makes a breaking change (any type with `BREAKING CHANGE:` in body or `!` after type)
+- Adds a new component or feature (`feat:` / `feat(scope):`)
+- Fixes a consumer-visible bug (`fix:` / `fix(scope):`)
+- Makes a breaking change (any allowed type with `BREAKING CHANGE:` in body or `!` after type)
 - Updates exported types or public API
 
 A commit does NOT need a changeset if it:
 - Only changes docs (`docs:`)
 - Only changes tests (`test:`)
-- Only changes internal tooling/config (`chore:`)
-- Only changes Storybook stories with no component logic change (`style:`)
+- Only changes CI, internal tooling, or config (`ci:`, `chore:`, `build:`)
+- Only changes formatting (`style:`)
+- Only changes Storybook stories with no component logic change (`docs:` or `style:` depending on the change)
 
 ### How to detect
 
@@ -173,9 +186,10 @@ Recommendation: generate {N} changeset file(s) — see Phase 3.
 | Condition | Bump |
 |-----------|------|
 | Any commit with `BREAKING CHANGE:` in body | **major** |
-| Any commit with `!` after type (e.g. `feat!:`) | **major** |
-| Any `feat:` commit | **minor** |
-| Only `fix:` commits | **patch** |
+| Any commit with `!` after type or scope (e.g. `feat!:` or `feat(button)!:`) | **major** |
+| Any consumer-visible `feat` commit | **minor** |
+| Only consumer-visible `fix` commits | **patch** |
+| Other allowed types (`docs`, `test`, `chore`, `ci`, `build`, `style`, `refactor`, `perf`, `revert`) | Usually no changeset unless public behavior/API changes |
 | Multiple types — take the highest | e.g. feat + fix = **minor** |
 
 ### Changeset file format
@@ -259,7 +273,7 @@ pnpm changeset:version
 
 # 2 — Commit the version bump
 git add .
-git commit -m "chore: release v{new-version}"
+git commit -m "chore(release): publish v{new-version}"
 
 # 3 — Tag the release
 git tag "v{new-version}"

--- a/.atl/skills/release-changeset/SKILL.md
+++ b/.atl/skills/release-changeset/SKILL.md
@@ -114,7 +114,7 @@ Find commits that introduced user-visible changes but have no corresponding chan
 
 ### Conventional Commit contract
 
-Commit messages and PR titles must follow the commitlint-enforced format:
+Commit messages must follow the commitlint-enforced format. PR titles should follow the same Conventional Commit format for review consistency:
 
 ```text
 <type>(<optional scope>): <description>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,12 @@ Closes #<!-- issue number -->
 - [ ] 🏗️ Infrastructure
 - [ ] 📚 Documentation
 
+## Repository checklist
+
+- [ ] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`
+- [ ] Commit messages follow the same commitlint-enforced format
+- [ ] PR description links the issue with `Closes #NNN`
+
 ## Component checklist (skip if not applicable)
 
 - [ ] Follows the 5-file structure (`types.ts`, `use*.ts`, `Component.tsx`, `index.ts`, `*.stories.tsx`)

--- a/docs/CONTRIBUTING.en.md
+++ b/docs/CONTRIBUTING.en.md
@@ -131,9 +131,10 @@ echo "feat(button): add loading state" | pnpm exec commitlint
 ### Pull Request Process
 
 1. Push your branch and open a PR against `main`.
-2. You can call automatic review to copilot since it is prepared to human review.
-3. The PR MUST pass all CI checks (Biome formatting/linting, TypeScript strict checks).
-4. The PR MUST be reviewed by at least one core maintainer before merging.
+2. Use a PR title with the same Conventional Commit format, for example `feat(button): add loading state`.
+3. You can call automatic review to copilot since it is prepared to human review.
+4. The PR MUST pass all CI checks (Biome formatting/linting, TypeScript strict checks).
+5. The PR MUST be reviewed by at least one core maintainer before merging.
 
 ### PR Checklist
 
@@ -147,7 +148,7 @@ Before requesting a review, verify:
 - [ ] The pre-PR component review has passed or is documented.
 - [ ] Tokens from `theme.css` are used (no hardcoded colors or spacing).
 - [ ] ARIA attributes are implemented for interactable elements.
-- [ ] Conventional Commits are used.
+- [ ] Conventional Commits are used for commit messages and the PR title.
 
 ---
 

--- a/docs/CONTRIBUTING.en.md
+++ b/docs/CONTRIBUTING.en.md
@@ -132,7 +132,7 @@ echo "feat(button): add loading state" | pnpm exec commitlint
 
 1. Push your branch and open a PR against `main`.
 2. Use a PR title with the same Conventional Commit format, for example `feat(button): add loading state`.
-3. You can call automatic review to copilot since it is prepared to human review.
+3. You can request automated Copilot review until the PR is ready for human review.
 4. The PR MUST pass all CI checks (Biome formatting/linting, TypeScript strict checks).
 5. The PR MUST be reviewed by at least one core maintainer before merging.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -132,7 +132,7 @@ echo "feat(button): add loading state" | pnpm exec commitlint
 
 1. Sube tu rama y abre un PR contra `main`.
 2. Usa un título de PR con el mismo formato Conventional Commit, por ejemplo `feat(button): add loading state`.
-3. Puedes pedir revisión automática a copilot hasta que esté listo para revisión humana.
+3. Puedes pedir revisión automática a Copilot hasta que esté listo para revisión humana.
 4. El PR DEBE pasar todos los checks de CI (formato/linting de Biome, checks de TypeScript estricto).
 5. El PR DEBE ser revisado por al menos un maintainer antes de hacer merge.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -131,9 +131,10 @@ echo "feat(button): add loading state" | pnpm exec commitlint
 ### Proceso de Pull Request
 
 1. Sube tu rama y abre un PR contra `main`.
-2. Puedes pedir revisión automática a copilot hasta que esté listo para revisión humana.
-3. El PR DEBE pasar todos los checks de CI (formato/linting de Biome, checks de TypeScript estricto).
-4. El PR DEBE ser revisado por al menos un maintainer antes de hacer merge.
+2. Usa un título de PR con el mismo formato Conventional Commit, por ejemplo `feat(button): add loading state`.
+3. Puedes pedir revisión automática a copilot hasta que esté listo para revisión humana.
+4. El PR DEBE pasar todos los checks de CI (formato/linting de Biome, checks de TypeScript estricto).
+5. El PR DEBE ser revisado por al menos un maintainer antes de hacer merge.
 
 ### Checklist del PR
 
@@ -147,7 +148,7 @@ Antes de pedir revisión, verifica:
 - [ ] La review pre-PR del componente está pasada o documentada.
 - [ ] Se usan tokens de `theme.css` (sin colores ni espaciados hardcodeados).
 - [ ] Se implementan atributos ARIA en elementos interactivos.
-- [ ] Se usan Conventional Commits.
+- [ ] Se usan Conventional Commits en mensajes de commit y título del PR.
 - [ ] Estados visuales implementados: hover, focus, active/pressed, disabled.
 - [ ] Focus ring via `box-shadow` — nunca `outline` sin alternativa visible.
 - [ ] Disabled via `opacity: 0.4` — sin sustitución de color.

--- a/docs/CONTRIBUTOR-FLOW.md
+++ b/docs/CONTRIBUTOR-FLOW.md
@@ -377,7 +377,8 @@ El PR debe linkear la issue y contener evidencia.
 Checklist mínimo:
 
 - [ ] `Closes #NNN` en la descripción.
-- [ ] Conventional commit.
+- [ ] Título del PR en formato Conventional Commit: `<type>(<scope opcional>): <descripción>`.
+- [ ] Commits en formato Conventional Commit válido para `commitlint`.
 - [ ] Tests relevantes pasan.
 - [ ] Build o checks requeridos pasan.
 - [ ] Pre-PR component review incluido o resumido.

--- a/docs/QUICK_START.en.md
+++ b/docs/QUICK_START.en.md
@@ -107,12 +107,15 @@ We use [Conventional Commits](https://www.conventionalcommits.org/). Git hooks w
 feat(button): add loading state variant
 fix(switch): forward aria-label prop correctly
 docs(modal): add usage examples to Storybook
-a11y(input): improve focus ring visibility
+fix(a11y): improve input focus ring visibility
+chore(tokens): update spacing token docs
 ```
 
 Format: `type(scope): description`
 
-Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `a11y`, `tokens`
+Common types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`.
+
+Use `a11y`, `tokens`, or `infra` as scopes, not as custom types.
 
 ---
 

--- a/docs/QUICK_START.en.md
+++ b/docs/QUICK_START.en.md
@@ -111,7 +111,7 @@ fix(a11y): improve input focus ring visibility
 chore(tokens): update spacing token docs
 ```
 
-Format: `type(scope): description`
+Format: `<type>(<optional scope>): <description>` (`scope` is optional)
 
 Common types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`.
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -113,7 +113,7 @@ fix(a11y): improve input focus ring visibility
 chore(tokens): update spacing token docs
 ```
 
-Formato: `type(scope): description`
+Formato: `<type>(<scope opcional>): <description>` (`scope` es opcional)
 
 Tipos comunes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`.
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -109,12 +109,15 @@ Usamos [Conventional Commits](https://www.conventionalcommits.org/). Los hooks d
 feat(button): add loading state variant
 fix(switch): forward aria-label prop correctly
 docs(modal): add usage examples to Storybook
-a11y(input): improve focus ring visibility
+fix(a11y): improve input focus ring visibility
+chore(tokens): update spacing token docs
 ```
 
 Formato: `type(scope): description`
 
-Tipos comunes: `feat`, `fix`, `docs`, `refactor`, `test`, `a11y`, `tokens`
+Tipos comunes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`.
+
+Usa `a11y`, `tokens` o `infra` como scopes, no como tipos personalizados.
 
 ---
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -113,7 +113,7 @@ fix(a11y): improve input focus ring visibility
 chore(tokens): update spacing token docs
 ```
 
-Formato: `<type>(<scope opcional>): <description>` (`scope` es opcional)
+Formato: `<type>(<scope opcional>): <descripción>` (`scope` es opcional)
 
 Tipos comunes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`.
 


### PR DESCRIPTION
## Summary

- Aligns AI harness/skill guidance with the commitlint-enforced Conventional Commit format.
- Adds PR title and commit message checks to PR/review guidance.
- Replaces invalid custom commit types like `a11y`/`tokens` with valid scoped examples.

Closes #187

## Type of change

- [ ] 🧩 New component
- [ ] 🐛 Bug fix
- [ ] 🎨 Design tokens
- [ ] ♿ Accessibility
- [ ] 🏗️ Infrastructure
- [x] 📚 Documentation

## Repository checklist

- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`
- [x] Commit messages follow the same commitlint-enforced format
- [x] PR description links the issue with `Closes #NNN`

## Component checklist (skip if not applicable)

Skipped: this PR only updates AI harness and contributor documentation.

## How to test

- [x] Fresh reviewer audit passed for issue #187 acceptance criteria
- [x] `npx -y pnpm@10 exec tsc --noEmit --pretty false`
- [x] `printf 'docs(ai): align skill harness commit conventions\n' | npx -y pnpm@10 exec commitlint`
- [x] `feat(button): add loading state` passes commitlint
- [x] `fix(a11y): improve input focus ring visibility` passes commitlint
- [x] `chore(tokens): update spacing token docs` passes commitlint
- [x] `a11y(input): improve focus ring visibility` fails commitlint as expected

## Screenshots / recordings (if applicable)

Not applicable.

## Notes for reviewer

- This is documentation/harness alignment only; it intentionally does not modify `commitlint.config.ts`, `lefthook.yml`, `package.json`, or `pnpm-lock.yaml`.
- Issue #187 was created as a follow-up from #138/#188.
