### PR TITLE
feat(components): add compact action size variants

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.ts whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol
+*.tsx whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -64,8 +64,8 @@ Never use `outline: none` without an alternative visible focus indicator.
 **Rule 9 — Gradient borders use `::before` pseudo-element, never `border-image`.**
 `border-image` does not work with `border-radius` — the gradient clips to a rectangle, destroying the pill shape. The correct technique uses `::before` absolutely positioned with `inset: -1.5px` and `z-index: -1`, with the gradient as its `background` and `border-radius: inherit`.
 
-**Rule 10 — Minimum touch target is 44×44px for all interactive elements.**
-Buttons: default minimum `height: 44px`. Nav links: minimum `44px` high area. Dropdown items: `padding: 7px 12px` minimum with 14px font. Only the explicit `xs` action size may go below this for dense interfaces; use `sm` or above when the 44px target is required.
+**Rule 10 — Default touch target is 44×44px for interactive elements.**
+Buttons and action-style links use a default minimum `height: 44px` from `sm` upward. Nav links: minimum `44px` high area. Dropdown items: `padding: 7px 12px` minimum with 14px font. Only the explicit `xs` action size may go below this for dense interfaces; use `sm` or above when the 44px target is required.
 
 **Action size scale — `xs | sm | md | lg`.**
 For `Button`, `IconButton`, and Link variants used as actions (`button` / `outlined`), `xs` is the dense compact size: reduce typography, icon size, gap, horizontal padding, and height so it is visibly smaller than `sm`. `Link` `regular` remains inline typography-only, while CTA-style `sm` and above keep the 44px target.

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -65,7 +65,10 @@ Never use `outline: none` without an alternative visible focus indicator.
 `border-image` does not work with `border-radius` — the gradient clips to a rectangle, destroying the pill shape. The correct technique uses `::before` absolutely positioned with `inset: -1.5px` and `z-index: -1`, with the gradient as its `background` and `border-radius: inherit`.
 
 **Rule 10 — Minimum touch target is 44×44px for all interactive elements.**
-Buttons: minimum `height: 44px`, `padding: 10px 20px`. Nav links: minimum `44px` high area. Dropdown items: `padding: 7px 12px` minimum with 14px font. This is a hard floor — never reduce below it.
+Buttons: default minimum `height: 44px`. Nav links: minimum `44px` high area. Dropdown items: `padding: 7px 12px` minimum with 14px font. Only the explicit `xs` action size may go below this for dense interfaces; use `sm` or above when the 44px target is required.
+
+**Action size scale — `xs | sm | md | lg`.**
+For `Button`, `IconButton`, and Link variants used as actions (`button` / `outlined`), `xs` is the dense compact size: reduce typography, icon size, gap, horizontal padding, and height so it is visibly smaller than `sm`. `Link` `regular` remains inline typography-only, while CTA-style `sm` and above keep the 44px target.
 
 **Rule 11 — Never animate layout-forcing properties.**
 Do not animate `width`, `height`, `top`, `left`, `margin`, `padding`. These trigger layout reflow on every frame. For position animations use `transform: translateY/translateX`. For size animations use `transform: scale`.
@@ -1004,7 +1007,7 @@ background: linear-gradient(
 - [ ] Primary: white `#ffffff` text over red gradient — contrast passes in both modes
 - [ ] Secondary dark: `color: #ffffff` over `rgba(255,0,54,0.06)` — visually dark background context; border defines the affordance
 - [ ] Secondary light: `color: #cc0030` — NEVER `#ff0036` in light mode (insufficient contrast over white)
-- [ ] Touch target includes padding: `padding: 10px 20px` minimum
+- [ ] Touch target remains at least `44px` for `sm` and above; compact `xs` actions are the documented dense exception with reduced height and padding
 - [ ] `role="button"` if implemented as non-`<button>` element
 
 ### Inputs

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -639,7 +639,9 @@ Todos los valores de texto sobre sus respectivos fondos cumplen WCAG AA (4.5:1) 
 > ⚠️ `#6a6b6c` (disabled/muted) no cumple AA sobre los fondos dark — es correcto: WCAG exime explícitamente los estados `disabled` del requisito de contraste.
 
 ### Targets táctiles
-- Botones pill: altura mínima `44px`, padding `10px 20px`
+- Botones pill: altura mínima por defecto `44px`
+- Escala de acciones `xs | sm | md | lg`: `xs` es la variante compacta densa para `Button`, `IconButton` y `Link` CTA (`button` / `outlined`), con menor altura y padding; usá `sm` o superior cuando necesitás conservar el target de `44px`
+- `Link` `regular` sigue siendo tipográfico e inline; los CTA `sm` y superiores mantienen el área mínima de `44px`
 - Nav links: área mínima `44px` de alto incluyendo padding
 - Elementos de menú: `padding: 7px 12px` mínimo con font 14px
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ allowBuilds:
   '@swc/core': true
   esbuild: true
   lefthook: true
+  unrs-resolver: true
 overrides:
   minimatch@10.2.5>brace-expansion: 5.0.6
   ws: 8.20.1

--- a/src/components/atoms/button/Button.stories.tsx
+++ b/src/components/atoms/button/Button.stories.tsx
@@ -10,7 +10,7 @@ import { Button } from './Button';
  * Uses Lucide icons through the `icon` prop and `spinners-react` for loading feedback.
  *
  * ## Usage Guide
- * Use `primary` for the main action, `secondary` or `outlined` for supporting actions, and `ghost` or `light` for low-emphasis actions. Use `isLoading` while async work is pending so repeated submissions are blocked.
+ * Use `primary` for the main action, `secondary` or `outlined` for supporting actions, and `ghost` or `light` for low-emphasis actions. Use `size='xs'` for dense controls with lower height and tighter padding. Use `isLoading` while async work is pending so repeated submissions are blocked.
  */
 const meta: Meta<typeof Button> = {
   title: 'Atoms/Button',
@@ -52,11 +52,12 @@ export const Variant: Story = {
 };
 
 /**
- * Shows size options while preserving the minimum interactive target.
+ * Shows the full `xs` to `lg` size scale with `xs` visibly shorter than `sm`.
  */
 export const Size: Story = {
   render: () => (
     <div className='flex gap-4 items-center flex-wrap'>
+      <Button text='Extra small' size='xs' onClick={action('xs-click')} />
       <Button text='Small' size='sm' onClick={action('small-click')} />
       <Button text='Medium' size='md' onClick={action('medium-click')} />
       <Button text='Large' size='lg' onClick={action('large-click')} />

--- a/src/components/atoms/button/Button.test.tsx
+++ b/src/components/atoms/button/Button.test.tsx
@@ -63,6 +63,11 @@ describe('useButton — logic', () => {
     expect(result.current.className).toEqual(expect.any(String));
   });
 
+  it('returns correct icon class for size xs', () => {
+    const { result } = renderHook(() => useButton({ text: 'Button', size: 'xs' }));
+    expect(result.current.iconSize).toBe('h-sm w-auto');
+  });
+
   it('returns correct icon class for size sm', () => {
     const { result } = renderHook(() => useButton({ text: 'Button', size: 'sm' }));
     expect(result.current.iconSize).toBe('h-md w-auto');
@@ -86,6 +91,13 @@ describe('useButton — logic', () => {
   it('passes native aria-label correctly to return value', () => {
     const { result } = renderHook(() => useButton({ 'aria-label': 'Submit form' }));
     expect(result.current.ariaLabel).toBe('Submit form');
+  });
+
+  it('derives compact classes from size xs', () => {
+    const { result } = renderHook(() => useButton({ text: 'Button', size: 'xs' }));
+    expect(result.current.className).toContain('h-9');
+    expect(result.current.className).toContain('px-2');
+    expect(result.current.contentClassName).toContain('gap-1');
   });
 
   it('derives content gap from the size prop', () => {

--- a/src/components/atoms/button/types.ts
+++ b/src/components/atoms/button/types.ts
@@ -63,6 +63,7 @@ export const buttonVariants = cva(
         false: ''
       },
       size: {
+        xs: 'h-9 px-2 fs-xs',
         sm: 'px-sm h-11 fs-small',
         md: 'px-md h-11 fs-base',
         lg: 'px-lg h-12 fs-h6'
@@ -84,7 +85,7 @@ export const buttonVariants = cva(
 
 type ButtonVariant = VariantProps<typeof buttonVariants>['variant'];
 type ButtonTypeVariants = 'button' | 'submit' | 'reset';
-type ButtonSizeVariants = 'md' | 'sm' | 'lg';
+type ButtonSizeVariants = 'xs' | 'sm' | 'md' | 'lg';
 type NativeButtonProps = Omit<ComponentProps<'button'>, 'type' | 'disabled' | 'className' | 'children' | 'aria-label'>;
 type ButtonAccessibleContent =
   | {

--- a/src/components/atoms/button/useButton.ts
+++ b/src/components/atoms/button/useButton.ts
@@ -75,6 +75,8 @@ const getAriaLabel = (
 
 const getIconSize = (size: NonNullable<ButtonProps['size']>): string => {
   switch (size) {
+    case 'xs':
+      return 'h-sm w-auto';
     case 'sm':
       return 'h-md w-auto';
     case 'lg':
@@ -86,6 +88,8 @@ const getIconSize = (size: NonNullable<ButtonProps['size']>): string => {
 
 const getContentGap = (size: NonNullable<ButtonProps['size']>): string => {
   switch (size) {
+    case 'xs':
+      return 'gap-1';
     case 'sm':
       return 'gap-1.5';
     case 'lg':

--- a/src/components/atoms/icon-button/IconButton.stories.tsx
+++ b/src/components/atoms/icon-button/IconButton.stories.tsx
@@ -10,7 +10,7 @@ import { IconButton } from './IconButton';
  * Uses Lucide dynamic icons for the visual glyph.
  *
  * ## Usage Guide
- * Provide a meaningful accessible name with `title`, `ariaLabel`, or `aria-label`. Named sizes (`sm`, `md`, `lg`) change both the button target and the icon; legacy numeric sizes keep the exact icon size and map the button target to the closest named size. Use `shadow={false}` only when a quiet context needs to suppress glow, and use `aria-pressed` only to announce toggle-button state to assistive technology.
+ * Provide a meaningful accessible name with `title`, `ariaLabel`, or `aria-label`. Use `xs` for dense, visibly shorter controls and `sm` or above for the 44px action target; legacy numeric sizes keep the exact icon size and map the button target to the closest named size. Use `shadow={false}` only when a quiet context needs to suppress glow, and use `aria-pressed` only to announce toggle-button state to assistive technology.
  */
 const meta: Meta<typeof IconButton> = {
   title: 'Atoms/IconButton',
@@ -54,11 +54,12 @@ export const Variant: Story = {
 };
 
 /**
- * Shows size options changing the full button target and the icon together.
+ * Shows the full `xs` to `lg` size scale with `xs` visibly shorter than `sm`.
  */
 export const Size: Story = {
   render: () => (
     <div className='flex gap-4 items-center flex-wrap'>
+      <IconButton icon='menu' size='xs' title='Open extra small menu' onClick={action('xs-click')} />
       <IconButton icon='menu' size='sm' title='Open small menu' onClick={action('small-click')} />
       <IconButton icon='menu' size='md' title='Open medium menu' onClick={action('medium-click')} />
       <IconButton icon='menu' size='lg' title='Open large menu' onClick={action('large-click')} />

--- a/src/components/atoms/icon-button/IconButton.test.tsx
+++ b/src/components/atoms/icon-button/IconButton.test.tsx
@@ -48,14 +48,26 @@ describe('useIconButton — logic', () => {
   });
 
   it('derives icon size from the component size', () => {
+    const { result: compactResult } = renderHook(() => useIconButton({ icon: 'menu', title: 'Open menu', size: 'xs' }));
     const { result: smallResult } = renderHook(() => useIconButton({ icon: 'menu', title: 'Open menu', size: 'sm' }));
     const { result: largeResult } = renderHook(() => useIconButton({ icon: 'menu', title: 'Open menu', size: 'lg' }));
 
+    expect(compactResult.current.iconSize).toBe(14);
+    expect(compactResult.current.size).toBe('xs');
     expect(smallResult.current.iconSize).toBe(16);
     expect(smallResult.current.size).toBe('sm');
     expect(largeResult.current.iconSize).toBe(24);
     expect(largeResult.current.size).toBe('lg');
-    expect(smallResult.current.className).not.toBe(largeResult.current.className);
+    expect(compactResult.current.className).toContain('h-9');
+    expect(compactResult.current.className).toContain('w-9');
+    expect(compactResult.current.className).not.toBe(largeResult.current.className);
+  });
+
+  it('maps compact legacy numeric icon sizes to the xs button target', () => {
+    const { result } = renderHook(() => useIconButton({ icon: 'menu', title: 'Open menu', size: 14 }));
+
+    expect(result.current.iconSize).toBe(14);
+    expect(result.current.size).toBe('xs');
   });
 
   it('keeps legacy numeric icon sizes while deriving the closest button size', () => {
@@ -95,10 +107,10 @@ describe('IconButton — component behavior', () => {
   });
 
   it('renders the requested icon with the derived component size', () => {
-    render(<IconButton icon='menu' size='lg' title='Open menu' />);
+    render(<IconButton icon='menu' size='xs' title='Open menu' />);
 
     expect(screen.getByTestId('icon-button-icon')).toHaveAttribute('data-name', 'menu');
-    expect(screen.getByTestId('icon-button-icon')).toHaveAttribute('data-size', '24');
+    expect(screen.getByTestId('icon-button-icon')).toHaveAttribute('data-size', '14');
   });
 
   it('calls onClick when the button is clicked', async () => {

--- a/src/components/atoms/icon-button/IconButton.test.tsx
+++ b/src/components/atoms/icon-button/IconButton.test.tsx
@@ -63,11 +63,11 @@ describe('useIconButton — logic', () => {
     expect(compactResult.current.className).not.toBe(largeResult.current.className);
   });
 
-  it('maps compact legacy numeric icon sizes to the xs button target', () => {
+  it('keeps compact legacy numeric icon sizes on the sm button target', () => {
     const { result } = renderHook(() => useIconButton({ icon: 'menu', title: 'Open menu', size: 14 }));
 
     expect(result.current.iconSize).toBe(14);
-    expect(result.current.size).toBe('xs');
+    expect(result.current.size).toBe('sm');
   });
 
   it('keeps legacy numeric icon sizes while deriving the closest button size', () => {

--- a/src/components/atoms/icon-button/types.ts
+++ b/src/components/atoms/icon-button/types.ts
@@ -9,7 +9,6 @@ export const iconButtonVariants = cva(
     'transition-[box-shadow,background,border-color,transform,color] duration-250 ease-out',
     'inline-flex shrink-0 items-center justify-center',
     'whitespace-nowrap',
-    'min-w-11 min-h-11',
     'focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-brand-light/35 dark:focus-visible:ring-brand-dark/40',
     'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-40'
   ],
@@ -50,6 +49,7 @@ export const iconButtonVariants = cva(
         false: ''
       },
       size: {
+        xs: 'h-9 w-9',
         sm: 'h-11 w-11',
         md: 'h-12 w-12',
         lg: 'h-14 w-14'

--- a/src/components/atoms/icon-button/useIconButton.ts
+++ b/src/components/atoms/icon-button/useIconButton.ts
@@ -72,6 +72,10 @@ const getButtonSize = (size: NonNullable<IconButtonProps['size']>): IconButtonSi
     return size;
   }
 
+  if (size <= 14) {
+    return 'xs';
+  }
+
   if (size <= 16) {
     return 'sm';
   }
@@ -89,6 +93,7 @@ const getIconSize = (size: NonNullable<IconButtonProps['size']>, buttonSize: Ico
   }
 
   const iconSizes = {
+    xs: 14,
     sm: 16,
     md: 20,
     lg: 24

--- a/src/components/atoms/icon-button/useIconButton.ts
+++ b/src/components/atoms/icon-button/useIconButton.ts
@@ -72,10 +72,6 @@ const getButtonSize = (size: NonNullable<IconButtonProps['size']>): IconButtonSi
     return size;
   }
 
-  if (size <= 14) {
-    return 'xs';
-  }
-
   if (size <= 16) {
     return 'sm';
   }

--- a/src/components/atoms/link/Link.stories.tsx
+++ b/src/components/atoms/link/Link.stories.tsx
@@ -19,7 +19,7 @@ const VariantRow = ({ children }: { children: ReactNode }) => (
  * Uses `lucide-react/dynamic.js` when the optional `icon` prop is provided.
  *
  * ## Usage Guide
- * Use `regular` for inline navigation, `outlined` for secondary call-to-action links, and `button` when a link must visually match a primary action while preserving link semantics when `href` is present. When `href` is omitted, Link behaves as a local action control with button semantics and keyboard activation.
+ * Use `regular` for inline navigation, `outlined` for secondary call-to-action links, and `button` when a link must visually match a primary action while preserving link semantics when `href` is present. `size='xs'` makes action links denser through smaller type, icon, gap, padding, and height; use `sm` or above when the 44px action target is required. When `href` is omitted, Link behaves as a local action control with button semantics and keyboard activation.
  */
 const meta: Meta<typeof Link> = {
   title: 'Atoms/Link',
@@ -103,13 +103,16 @@ export const Shadow: Story = {
 };
 
 /**
- * Shows how size changes typography and horizontal rhythm while preserving each variant treatment.
+ * Shows the full `xs` to `lg` size scale with `xs` as the visibly shorter dense CTA size.
  */
 export const Sizes: Story = {
   render: () => (
     <StoryCanvas>
       <div className='grid gap-4'>
         <VariantRow>
+          <Link size='xs' href='https://github.com/egdev6'>
+            Extra small inline
+          </Link>
           <Link size='sm' href='https://github.com/egdev6'>
             Small inline
           </Link>
@@ -121,6 +124,9 @@ export const Sizes: Story = {
           </Link>
         </VariantRow>
         <VariantRow>
+          <Link size='xs' variant='outlined' href='https://github.com/egdev6'>
+            Extra small outlined
+          </Link>
           <Link size='sm' variant='outlined' href='https://github.com/egdev6'>
             Small outlined
           </Link>
@@ -132,6 +138,9 @@ export const Sizes: Story = {
           </Link>
         </VariantRow>
         <VariantRow>
+          <Link size='xs' variant='button' href='https://github.com/egdev6'>
+            Extra small button
+          </Link>
           <Link size='sm' variant='button' href='https://github.com/egdev6'>
             Small button
           </Link>

--- a/src/components/atoms/link/Link.test.tsx
+++ b/src/components/atoms/link/Link.test.tsx
@@ -73,6 +73,20 @@ describe('useLink — logic', () => {
     const { result } = renderHook(() => useLink({ children: 'Docs', variant: 'button' }));
     expect(result.current.tabIndex).toBe(0);
   });
+
+  it('uses compact icon sizing for xs links', () => {
+    const { result } = renderHook(() => useLink({ children: 'Docs', size: 'xs', icon: 'arrow-right' }));
+    expect(result.current.iconWidth).toBe(16);
+  });
+
+  it('makes CTA-style xs visibly shorter while keeping sm at the 44px target height', () => {
+    const { result: compactResult } = renderHook(() => useLink({ children: 'Docs', variant: 'button', size: 'xs' }));
+    const { result: smallResult } = renderHook(() => useLink({ children: 'Docs', variant: 'outlined', size: 'sm' }));
+
+    expect(compactResult.current.className).toContain('h-9');
+    expect(compactResult.current.className).toContain('px-2');
+    expect(smallResult.current.className).toContain('h-11');
+  });
 });
 
 // ─────────────────────────────────────────────

--- a/src/components/atoms/link/types.ts
+++ b/src/components/atoms/link/types.ts
@@ -19,14 +19,14 @@ export const linkVariants = cva(
           '[&>svg]:mr-1 [&>svg]:inline-block [&>svg]:align-middle'
         ],
         button: [
-          'inline-flex items-center justify-center gap-1 whitespace-nowrap rounded-pill border border-transparent font-semibold tracking-ui text-white no-underline',
+          'inline-flex items-center justify-center whitespace-nowrap rounded-pill border border-transparent font-semibold tracking-ui text-white no-underline',
           'bg-btn-primary shadow-glow-btn-primary-light dark:shadow-glow-btn-primary',
           'transition-[box-shadow,background,transform] duration-250 ease-[ease]',
           'hover:bg-btn-primary-hover hover:text-white hover:shadow-glow-btn-primary-hover-light dark:hover:shadow-glow-btn-primary-hover',
           'motion-safe:active:scale-[0.98]'
         ],
         outlined: [
-          'inline-flex items-center justify-center gap-1 whitespace-nowrap rounded-pill border font-semibold tracking-ui no-underline',
+          'inline-flex items-center justify-center whitespace-nowrap rounded-pill border font-semibold tracking-ui no-underline',
           'border-red-tint-border bg-red-tint-subtle text-brand-light shadow-glow-btn-secondary-light dark:text-text-dark dark:shadow-glow-btn-secondary',
           'transition-[box-shadow,background,border-color,transform] duration-250 ease-[ease]',
           'hover:border-brand-light/80 hover:bg-red-tint-low hover:text-brand-light-darkest hover:shadow-glow-btn-secondary-hover-light',
@@ -35,6 +35,7 @@ export const linkVariants = cva(
         ]
       },
       size: {
+        xs: 'fs-xs',
         sm: 'fs-small',
         md: 'fs-base',
         lg: 'fs-h5'
@@ -45,9 +46,10 @@ export const linkVariants = cva(
       }
     },
     compoundVariants: [
-      { variant: ['button', 'outlined'], size: 'sm', class: 'h-9 px-sm' },
-      { variant: ['button', 'outlined'], size: 'md', class: 'h-11 px-md' },
-      { variant: ['button', 'outlined'], size: 'lg', class: 'h-12 px-lg' }
+      { variant: ['button', 'outlined'], size: 'xs', class: 'h-9 gap-0-75 px-2' },
+      { variant: ['button', 'outlined'], size: 'sm', class: 'h-11 gap-1 px-sm' },
+      { variant: ['button', 'outlined'], size: 'md', class: 'h-11 gap-1.5 px-md' },
+      { variant: ['button', 'outlined'], size: 'lg', class: 'h-12 gap-2 px-lg' }
     ],
     defaultVariants: {
       variant: 'regular',
@@ -59,7 +61,7 @@ export const linkVariants = cva(
 
 export type LinkVariant = 'regular' | 'button' | 'outlined';
 export type LinkTarget = '_blank' | '_self' | '_parent' | '_top';
-export type LinkSize = 'sm' | 'md' | 'lg';
+export type LinkSize = 'xs' | 'sm' | 'md' | 'lg';
 
 export type LinkProps = Omit<ComponentProps<'a'>, 'children' | 'disabled' | 'target'> &
   VariantProps<typeof linkVariants> & {

--- a/src/components/atoms/link/useLink.ts
+++ b/src/components/atoms/link/useLink.ts
@@ -33,7 +33,7 @@ export const useLink = ({
   onKeyDown,
   ...rest
 }: LinkProps): UseLinkReturn => {
-  const iconWidth = { sm: 18, md: 20, lg: 24 }[size] ?? 20;
+  const iconWidth = { xs: 16, sm: 18, md: 20, lg: 24 }[size] ?? 20;
   const isExternal = target === '_blank';
   const ariaLabel = ariaLabelProp ?? title ?? (typeof children === 'string' ? children : undefined);
   const isAction = !href;

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -53,6 +53,10 @@
     line-height: 1.2;
     font-weight: 600;
   }
+  .fs-xs {
+    font-size: var(--text-xs);
+    line-height: 1.35;
+  }
   .fs-base {
     font-size: var(--text-body-compact);
     line-height: 1.5;
@@ -85,6 +89,9 @@
     }
     .fs-h6 {
       font-size: var(--text-h6);
+    }
+    .fs-xs {
+      font-size: var(--text-xs);
     }
     .fs-base {
       font-size: var(--text-body);


### PR DESCRIPTION
## Summary

- Adds a dense `xs` action size across Button, IconButton, and Link.
- Keeps `sm` and above as the 44px action target scale, while documenting `xs` as the compact exception.
- Updates Storybook, tests, and docs for the resulting `xs | sm | md | lg` scale.

Closes #190

## Type of change

- [ ] 🧩 New component
- [ ] 🐛 Bug fix
- [ ] 🎨 Design tokens
- [x] ♿ Accessibility
- [ ] 🏗️ Infrastructure
- [ ] 📚 Documentation

## Repository checklist

- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`
- [x] Commit messages follow the same commitlint-enforced format
- [x] PR description links the issue with `Closes #NNN`

## Component checklist (skip if not applicable)

- [x] Follows the 5-file structure (`types.ts`, `use*.ts`, `Component.tsx`, `index.ts`, `*.stories.tsx`)
- [x] CVA variants defined in `types.ts`, not inline
- [x] No hardcoded colors — uses tokens from `theme.css`
- [x] No `any` types — TypeScript strict
- [x] ARIA attributes present and correct
- [x] Keyboard navigable (Tab, Enter, Escape where applicable)
- [x] Dark mode works correctly
- [x] Storybook stories cover: default, variants, states (hover, focus, disabled)
- [x] Tests added or updated

## How to test

1. `pnpm test src/components/atoms/button/Button.test.tsx src/components/atoms/icon-button/IconButton.test.tsx src/components/atoms/link/Link.test.tsx`
2. `pnpm build`
3. `pnpm test` (pre-push hook)
4. `pnpm run storybook`
5. Navigate to `Atoms/Button`, `Atoms/IconButton`, and `Atoms/Link`.
6. Verify that `xs` is visibly shorter and tighter than `sm`, while `sm` and above keep the 44px action target scale.

## Screenshots / recordings (if applicable)

N/A

## Notes for reviewer

- `xs` is intentionally documented as a dense exception below the default 44px action target. Use `sm` or above where the full target is required.
- Link CTA `sm` was moved to `h-11` so `sm+` stays aligned with the 44px target scale.
- `.gitattributes` scopes whitespace checks for existing CRLF TypeScript/TSX files to avoid unrelated line-ending churn.
