### PR TITLE
fix(modal): complete review checklist

### DIFF
--- a/src/components/organisms/modal/Modal.stories.tsx
+++ b/src/components/organisms/modal/Modal.stories.tsx
@@ -1,208 +1,222 @@
 import { Button } from '@atoms/button';
 import { IconButton } from '@atoms/icon-button';
 import { Link } from '@atoms/link';
+import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Modal } from './index';
+import { Modal } from './Modal';
+import type { ModalActions } from './types';
 
 /**
- * ## DESCRIPTION
- * The Modal component is a versatile dialog box that can be used to display content, forms, or any other information in a focused manner. It supports various sizes, positions, and backdrop styles.
- * It can be triggered by a button or any other element, and it can contain custom headers, footers, and content.
+ * ## Description
+ * Modal presents focused content in a dialog layer above the current page.
  *
- * ## DEPENDENCIES
- * - [Radix UI Dialog](https://www.radix-ui.com/docs/primitives/components/dialog)
- * - Header - for displaying a header in the modal
- * - Text - for displaying text content
- * - Icon - from Lucide React for the close button
- * - IconButton - for closing the modal
- * - Button - for closing the modal
+ * ## Dependencies
+ * Uses Radix Dialog for focus management and accessibility. The examples use `Button`, `IconButton`, and `Link` as trigger and footer content.
  *
+ * ## Usage Guide
+ * Use the default title and description props for standard confirmations. When you provide custom header or body content, also provide `title` and `textContent` so the dialog keeps a clear accessible name and description.
+ * Custom `content` and `footer` can be render props that receive `{ close }`, allowing custom actions to dismiss the dialog without importing Radix internals.
  */
-
 const meta: Meta<typeof Modal> = {
   title: 'Organisms/Modal',
   component: Modal,
   parameters: {
+    layout: 'centered',
     docs: {
       autodocs: true
     }
   },
   tags: ['autodocs']
 };
+
 export default meta;
 
 type Story = StoryObj<typeof Modal>;
 
 const CustomHeader = () => (
-  <div className='w-full flex items-center justify-between bg-color-surface-light dark:bg-color-surface-dark border-1 border-color-brand-light dark:border-color-brand-dark border-dashed'>
-    <p className='text-lg text-color-text-light dark:text-color-text-dark w-full text-center'>header</p>
+  <div className='rounded-md border border-border-light bg-surface-raised-light p-4 text-text-light dark:border-border-dark dark:bg-surface-raised-dark dark:text-text-dark'>
+    <p className='fs-h6 font-semibold'>Transfer project ownership</p>
   </div>
 );
 
-const CustomContent = () => (
-  <div className='w-full flex items-center justify-between min-h-24 bg-color-surface-light dark:bg-color-surface-dark border-1 border-color-brand-light dark:border-color-brand-dark border-dashed'>
-    <p className='text-lg text-color-text-light dark:text-color-text-dark w-full text-center'>content</p>
+const CustomBody = () => (
+  <div className='rounded-md border border-border-light bg-surface-raised-light p-4 text-text-secondary-light dark:border-border-dark dark:bg-surface-raised-dark dark:text-text-secondary-dark'>
+    <p>This action moves all billing and repository permissions to the new owner.</p>
   </div>
 );
 
-const CustomFooter = () => (
-  <div className='w-full flex items-center justify-between bg-color-surface-light dark:bg-color-surface-dark border-1 border-color-brand-light dark:border-color-brand-dark border-dashed'>
-    <p className='text-lg text-color-text-light dark:text-color-text-dark w-full text-center'>footer</p>
-  </div>
-);
+const CustomFooter = ({ close }: ModalActions) => {
+  const handleCancel = () => {
+    action('cancel-click')();
+    close();
+  };
 
+  return (
+    <div className='flex w-full justify-end gap-3'>
+      <Button text='Cancel' variant='ghost' onClick={handleCancel} />
+      <Button text='Transfer' variant='primary' onClick={action('transfer-click')} />
+    </div>
+  );
+};
+
+/**
+ * Shows the default dialog configuration using its default variants.
+ */
 export const Default: Story = {
   args: {
-    size: 'md',
-    position: 'center',
-    backdrop: 'opacity',
-    children: <Button text='Open Modal' />,
-    textContent: 'Modal content goes here.',
-    title: 'Modal title'
+    children: <Button text='Open modal' />,
+    title: 'Delete workspace',
+    textContent: 'This action removes the workspace and all related content.'
   }
 };
 
 /**
- * - You can use the `header`, `content`, and `footer` props to customize the modal.
- * - The `header` prop can be used to display a custom header.
- * - The `content` prop can be used to display custom content.
- * - The `footer` prop can be used to display a custom footer.
- * - The `children` prop can be used to trigger the modal.
+ * Shows a disabled trigger that keeps the dialog unavailable.
  */
-
-export const WithCustomContent: Story = {
+export const Disabled: Story = {
   args: {
-    size: 'md',
-    position: 'center',
-    backdrop: 'opacity',
-    children: <Button text='Open Modal' />,
-    header: <CustomHeader />,
-    content: <CustomContent />,
-    footer: <CustomFooter />
+    children: <Button disabled={true} text='Open modal' />,
+    title: 'Disabled modal trigger',
+    textContent: 'This dialog cannot be opened until the trigger is enabled.'
   }
 };
 
 /**
- * - You can use a custom trigger element to open the modal.
- * - The `children` prop can be any React element that will trigger the modal when clicked.
+ * Shows the full size scale from `xs` to `full`.
  */
+export const Size: Story = {
+  render: () => (
+    <div className='flex max-w-full flex-wrap items-center justify-center gap-4'>
+      <Modal size='xs' title='XS modal' textContent='Preview for the xs size.'>
+        <Button emphasis='flat' text='XS' variant='secondary' />
+      </Modal>
+      <Modal size='sm' title='SM modal' textContent='Preview for the sm size.'>
+        <Button emphasis='flat' text='SM' variant='secondary' />
+      </Modal>
+      <Modal size='md' title='MD modal' textContent='Preview for the md size.'>
+        <Button emphasis='flat' text='MD' variant='secondary' />
+      </Modal>
+      <Modal size='lg' title='LG modal' textContent='Preview for the lg size.'>
+        <Button emphasis='flat' text='LG' variant='secondary' />
+      </Modal>
+      <Modal size='xl' title='XL modal' textContent='Preview for the xl size.'>
+        <Button emphasis='flat' text='XL' variant='secondary' />
+      </Modal>
+      <Modal size='2xl' title='2XL modal' textContent='Preview for the 2xl size.'>
+        <Button emphasis='flat' text='2XL' variant='secondary' />
+      </Modal>
+      <Modal size='3xl' title='3XL modal' textContent='Preview for the 3xl size.'>
+        <Button emphasis='flat' text='3XL' variant='secondary' />
+      </Modal>
+      <Modal size='4xl' title='4XL modal' textContent='Preview for the 4xl size.'>
+        <Button emphasis='flat' text='4XL' variant='secondary' />
+      </Modal>
+      <Modal size='5xl' title='5XL modal' textContent='Preview for the 5xl size.'>
+        <Button emphasis='flat' text='5XL' variant='secondary' />
+      </Modal>
+      <Modal size='full' title='Full modal' textContent='Preview for the full-screen size.'>
+        <Button emphasis='flat' text='FULL' variant='secondary' />
+      </Modal>
+    </div>
+  )
+};
 
+/**
+ * Shows the available dialog placements inside the viewport.
+ */
+export const Position: Story = {
+  render: () => (
+    <div className='flex flex-wrap items-center justify-center gap-4'>
+      <Modal
+        position='center'
+        title='Centered dialog'
+        textContent='Centered placement keeps the dialog anchored in the middle.'
+      >
+        <Button emphasis='flat' text='Center' variant='secondary' />
+      </Modal>
+      <Modal position='top' title='Top dialog' textContent='Top placement keeps the dialog close to the viewport edge.'>
+        <Button emphasis='flat' text='Top' variant='secondary' />
+      </Modal>
+      <Modal
+        position='bottom'
+        title='Bottom dialog'
+        textContent='Bottom placement is useful for mobile-oriented action sheets.'
+      >
+        <Button emphasis='flat' text='Bottom' variant='secondary' />
+      </Modal>
+    </div>
+  )
+};
+
+/**
+ * Shows the supported backdrop treatments for the overlay.
+ */
+export const Backdrop: Story = {
+  render: () => (
+    <div className='flex flex-wrap items-center justify-center gap-4'>
+      <Modal backdrop='opacity' title='Opacity backdrop' textContent='Uses the default overlay token without blur.'>
+        <Button emphasis='flat' text='Opacity' variant='secondary' />
+      </Modal>
+      <Modal backdrop='blur' title='Blur backdrop' textContent='Uses the overlay blur token for extra separation.'>
+        <Button emphasis='flat' text='Blur' variant='secondary' />
+      </Modal>
+      <Modal
+        backdrop='transparent'
+        title='Transparent backdrop'
+        textContent='Keeps the page visible while preserving dialog focus handling.'
+      >
+        <Button emphasis='flat' text='Transparent' variant='secondary' />
+      </Modal>
+    </div>
+  )
+};
+
+/**
+ * Shows custom header, content, and footer slots while preserving accessible title and description text.
+ */
+export const CustomContent: Story = {
+  args: {
+    children: <Button text='Open custom modal' />,
+    title: 'Transfer project ownership',
+    textContent: 'Review the ownership transfer details before continuing.',
+    header: <CustomHeader />,
+    content: <CustomBody />,
+    footer: (actions) => <CustomFooter {...actions} />
+  }
+};
+
+/**
+ * Shows that any single interactive element can be used as the dialog trigger.
+ */
 export const CustomTrigger: Story = {
   render: () => (
-    <div className='flex justify-center items-center gap-4'>
-      <Modal size='md' position='center' title='Custom Trigger Modal'>
+    <div className='flex flex-wrap items-center justify-center gap-4'>
+      <Modal
+        title='Link trigger modal'
+        textContent='A text link can open the dialog when it is the single trigger element.'
+      >
         <Link size='md' variant='regular'>
-          Lorem ipsum
+          Read deployment details
         </Link>
       </Modal>
-      <Modal size='md' position='center' title='Custom Trigger Modal'>
-        <IconButton className='' icon='menu' size={20} title='Menu' variant='primary' />
+      <Modal
+        title='Icon trigger modal'
+        textContent='An icon button trigger works with the same focus and accessibility contract.'
+      >
+        <IconButton icon='menu' title='Open menu details' variant='primary' onClick={action('icon-trigger-click')} />
       </Modal>
     </div>
   )
 };
 
 /**
- * - You can choose the size of the modal using the `size` prop.
- * - The `size` prop accepts the following values: `xs`, `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`, and `full`.
- * - Each size corresponds to a different width and height of the modal.
- * - The modal will automatically adjust its size based on the content.
+ * Shows a custom overlay class layered on top of the shared overlay positioning and animation contract.
  */
-
-export const Sizes: Story = {
-  render: () => (
-    <div className='max-w-full flex justify-center items-center gap-4 flex-wrap'>
-      <Modal size='xs' title='XS'>
-        <Button text='XS' />
-      </Modal>
-      <Modal size='sm' title='SM'>
-        <Button text='SM' />
-      </Modal>
-      <Modal size='md' title='MD'>
-        <Button text='MD' />
-      </Modal>
-      <Modal size='lg' title='LG'>
-        <Button text='LG' />
-      </Modal>
-      <Modal size='xl' title='XL'>
-        <Button text='XL' />
-      </Modal>
-      <Modal size='2xl' title='2XL'>
-        <Button text='2XL' />
-      </Modal>
-      <Modal size='3xl' title='3XL'>
-        <Button text='3XL' />
-      </Modal>
-      <Modal size='4xl' title='4XL'>
-        <Button text='4XL' />
-      </Modal>
-      <Modal size='5xl' title='5XL'>
-        <Button text='5XL' />
-      </Modal>
-      <Modal size='full' title='Full Screen'>
-        <Button text='Full Screen' />
-      </Modal>
-    </div>
-  )
-};
-
-/**
- * - You can choose the position of the modal using the `position` prop.
- * - The `position` prop accepts three values: `center`, `top`, and `bottom`.
- */
-
-export const Positions: Story = {
-  render: () => (
-    <div className='flex justify-center items-center gap-4'>
-      <Modal size='md' position='center' title='Center Position'>
-        <Button text='Center Position' />
-      </Modal>
-      <Modal size='md' position='top' title='Top Position'>
-        <Button text='Top Position' />
-      </Modal>
-      <Modal size='md' position='bottom' title='Bottom Position'>
-        <Button text='Bottom Position' />
-      </Modal>
-    </div>
-  )
-};
-
-/**
- * - You can choose the backdrop style of the modal using the `backdrop` prop.
- * - The `backdrop` prop accepts three values: `opacity`, `blur`, and `transparent`.
- * - The `opacity` backdrop provides a semi-transparent black background.
- * - The `blur` backdrop provides a blurred background effect.
- * - The `transparent` backdrop provides a fully transparent background.
- */
-
-export const BackdropVariants: Story = {
-  render: () => (
-    <div className='flex justify-center items-center gap-4'>
-      <Modal size='md' position='center' backdrop='opacity' title='Opacity Backdrop'>
-        <Button text='Opacity Backdrop' />
-      </Modal>
-      <Modal size='md' position='center' backdrop='blur' title='Blur Backdrop'>
-        <Button text='Blur Backdrop' />
-      </Modal>
-      <Modal size='md' position='center' backdrop='transparent' title='Transparent Backdrop'>
-        <Button text='Transparent Backdrop' />
-      </Modal>
-    </div>
-  )
-};
-
-/**
- * - You can customize teh backdrop of the modal using the `customBackdrop` prop.
- * - The `customBackdrop` prop accepts a string with Tailwind CSS classes to style the backdrop.
- * - This allows you to create unique visual effects, such as gradients or custom colors.
- */
-
 export const CustomBackdrop: Story = {
   args: {
-    size: 'md',
-    position: 'center',
-    customBackdrop: 'bg-linear-to-r from-red-500 to-background-dark',
-    children: <Button text='Open Modal' />,
-    title: 'Modal with Custom Backdrop'
+    children: <Button text='Open custom backdrop modal' />,
+    title: 'Custom backdrop modal',
+    textContent: 'Custom backdrop classes can augment the shared overlay base styles.',
+    customBackdrop: 'bg-black-tint-heavy backdrop-blur-overlay'
   }
 };

--- a/src/components/organisms/modal/Modal.test.tsx
+++ b/src/components/organisms/modal/Modal.test.tsx
@@ -1,0 +1,210 @@
+import { render, renderHook, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('lucide-react/dynamic.js', () => ({
+  // biome-ignore lint/style/useNamingConvention: must match library export name
+  DynamicIcon: ({ name, size }: { name: string; size?: number | string }) => (
+    <svg data-name={name} data-size={String(size ?? '')} data-testid='modal-icon' />
+  )
+}));
+
+vi.mock('spinners-react', () => ({
+  // biome-ignore lint/style/useNamingConvention: must match library export name
+  SpinnerCircular: () => <span data-testid='spinner' />
+}));
+
+import { Button } from '@atoms/button';
+import { Modal as ModalFromIndex } from './index';
+import { Modal } from './Modal';
+import { useModal } from './useModal';
+
+describe('useModal — logic', () => {
+  it('returns default accessible content and trigger semantics', () => {
+    const { result } = renderHook(() =>
+      useModal({
+        children: <button type='button'>Open modal</button>
+      })
+    );
+
+    expect(result.current.title).toBe('Modal title');
+    expect(result.current.textContent).toBe('Modal content goes here.');
+    expect(result.current.getTriggerProps()).toMatchObject({
+      'aria-expanded': false,
+      'aria-haspopup': 'dialog'
+    });
+    expect(result.current.getTriggerProps()['aria-controls']).toBe(result.current.contentId);
+  });
+
+  it('generates unique ids for each modal instance', () => {
+    const first = renderHook(() => useModal({ children: <button type='button'>First</button> }));
+    const second = renderHook(() => useModal({ children: <button type='button'>Second</button> }));
+
+    expect(first.result.current.contentId).not.toBe(second.result.current.contentId);
+    expect(first.result.current.getTriggerProps()['aria-controls']).not.toBe(
+      second.result.current.getTriggerProps()['aria-controls']
+    );
+  });
+
+  it('re-exports the component as a named export from the barrel', () => {
+    expect(ModalFromIndex).toBe(Modal);
+  });
+});
+
+describe('Modal — component behavior', () => {
+  it('opens the dialog and wires trigger aria attributes', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Modal title='Delete workspace' textContent='This action removes the workspace.'>
+        <Button text='Open modal' />
+      </Modal>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open modal' });
+
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).toHaveAttribute('aria-controls');
+
+    await user.click(trigger);
+
+    expect(screen.getByRole('dialog', { name: 'Delete workspace' })).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('This action removes the workspace.')).toBeInTheDocument();
+  });
+
+  it('does not open when the trigger is disabled', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Modal title='Disabled modal trigger' textContent='This dialog cannot be opened until the trigger is enabled.'>
+        <Button disabled={true} text='Open modal' />
+      </Modal>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open modal' }));
+
+    expect(screen.queryByRole('dialog', { name: 'Disabled modal trigger' })).not.toBeInTheDocument();
+  });
+
+  it('closes from the footer button and restores focus to the trigger', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Modal title='Delete workspace' textContent='This action removes the workspace.'>
+        <Button text='Open modal' />
+      </Modal>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open modal' });
+    await user.click(trigger);
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Delete workspace' })).not.toBeInTheDocument();
+    });
+
+    expect(trigger).toHaveFocus();
+  });
+
+  it('closes from the icon close button', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Modal title='Delete workspace' textContent='This action removes the workspace.'>
+        <Button text='Open modal' />
+      </Modal>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open modal' }));
+    await user.click(screen.getByRole('button', { name: 'Close dialog' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Delete workspace' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('closes on Escape and restores focus to the trigger', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Modal title='Delete workspace' textContent='This action removes the workspace.'>
+        <Button text='Open modal' />
+      </Modal>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open modal' });
+    await user.click(trigger);
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Delete workspace' })).not.toBeInTheDocument();
+    });
+
+    expect(trigger).toHaveFocus();
+  });
+
+  it('passes close action to custom content and footer render props', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Modal
+        title='Render prop modal'
+        textContent='Custom slots can close the dialog.'
+        content={({ close }) => (
+          <button type='button' onClick={close}>
+            Close from content
+          </button>
+        )}
+        footer={({ close }) => (
+          <button type='button' onClick={close}>
+            Close from footer
+          </button>
+        )}
+      >
+        <button type='button'>Open render prop modal</button>
+      </Modal>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open render prop modal' });
+
+    await user.click(trigger);
+    await user.click(screen.getByRole('button', { name: 'Close from content' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Render prop modal' })).not.toBeInTheDocument();
+    });
+
+    await user.click(trigger);
+    await user.click(screen.getByRole('button', { name: 'Close from footer' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Render prop modal' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('keeps valid aria references when custom header and content are provided', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Modal
+        title='Transfer project ownership'
+        textContent='Review the ownership transfer details before continuing.'
+        header={<div>Custom header</div>}
+        content={<div>Transfer action details.</div>}
+        footer={<button type='button'>Transfer</button>}
+      >
+        <button type='button'>Open transfer modal</button>
+      </Modal>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open transfer modal' }));
+
+    const dialog = screen.getByRole('dialog', { name: 'Transfer project ownership' });
+
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByText('Custom header')).toBeInTheDocument();
+    expect(screen.getByText('Transfer action details.')).toBeInTheDocument();
+  });
+});

--- a/src/components/organisms/modal/Modal.tsx
+++ b/src/components/organisms/modal/Modal.tsx
@@ -1,84 +1,87 @@
 import { Button } from '@atoms/button';
-import { Header } from '@atoms/header';
 import { IconButton } from '@atoms/icon-button';
-import { Text } from '@atoms/text';
 import * as ModalPrimitive from '@radix-ui/react-dialog';
-import type { FC } from 'react';
-import { cn } from '@/lib/utils';
-import type { ModalProps } from './types';
-import { modalVariants } from './types';
+import { cloneElement, type FC, type ReactNode } from 'react';
+import type { ModalActions, ModalProps } from './types';
 import { useModal } from './useModal';
 
-const Modal: FC<Omit<ModalProps, 'isOpen'>> = ({ ...props }) => {
+const renderModalSlot = (slot: ModalProps['content'], actions: ModalActions): ReactNode =>
+  typeof slot === 'function' ? slot(actions) : slot;
+
+export const Modal: FC<ModalProps> = (props) => {
   const {
-    isOpen,
-    setIsOpen,
-    contentId,
+    bodyClassName,
     children,
-    currentBackdrop,
-    position,
-    titleId,
-    descriptionId,
-    size,
-    header,
-    title,
+    closeModal,
+    containerClassName,
     content,
+    contentId,
+    footer,
+    getTriggerProps,
+    handleCloseAutoFocus,
+    handleOpenChange,
+    header,
+    isOpen,
+    overlayClassName,
+    panelClassName,
+    shouldRenderCustomContent,
+    shouldRenderCustomFooter,
+    shouldRenderCustomHeader,
     textContent,
-    footer
+    title
   } = useModal(props);
 
+  const modalActions: ModalActions = { close: closeModal };
+  const renderedContent = renderModalSlot(content, modalActions);
+  const renderedFooter = renderModalSlot(footer, modalActions);
+
   return (
-    <ModalPrimitive.Root open={isOpen} onOpenChange={setIsOpen}>
-      <ModalPrimitive.Trigger asChild={true} aria-controls={isOpen ? contentId : undefined}>
-        {children}
-      </ModalPrimitive.Trigger>
+    <ModalPrimitive.Root open={isOpen} onOpenChange={handleOpenChange}>
+      {cloneElement(children, getTriggerProps(children.props.onClick))}
       <ModalPrimitive.Portal>
-        <ModalPrimitive.Overlay className={currentBackdrop} />
-        <div
-          className={cn(
-            'fixed w-full inset-0 z-modal flex p-0 md:p-4',
-            position === 'center' && 'items-center justify-center',
-            position === 'top' && 'items-start justify-center',
-            position === 'bottom' && 'items-end justify-center'
-          )}
-        >
-          <ModalPrimitive.Content
-            id={contentId}
-            aria-labelledby={titleId}
-            aria-describedby={descriptionId}
-            className={cn(
-              modalVariants({ size, position }),
-              'data-[state=open]:animate-in data-[state=closed]:animate-out',
-              'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95'
-            )}
-          >
-            <div className='relative pb-4'>
-              <div className='w-full flex items-start justify-start pr-8'>
-                {header ?? (
-                  <Header tag='h5' id={titleId} className='text-text-light dark:text-text-dark text-lg font-semibold'>
-                    {title}
-                  </Header>
-                )}
-              </div>
+        <ModalPrimitive.Overlay className={overlayClassName} />
+        <div className={containerClassName}>
+          <ModalPrimitive.Content id={contentId} className={panelClassName} onCloseAutoFocus={handleCloseAutoFocus}>
+            <div className='relative pb-4 pr-12'>
+              {shouldRenderCustomHeader ? (
+                <>
+                  <ModalPrimitive.Title className='sr-only'>{title}</ModalPrimitive.Title>
+                  {header}
+                </>
+              ) : (
+                <ModalPrimitive.Title className='fs-h5 font-semibold text-text-light dark:text-text-dark'>
+                  {title}
+                </ModalPrimitive.Title>
+              )}
               <IconButton
+                className='absolute right-0 top-0'
                 icon='x'
-                size={18}
-                title='Close'
+                onClick={closeModal}
+                size='sm'
+                title='Close dialog'
                 variant='ghost'
-                rounded={true}
-                onClick={() => setIsOpen(false)}
-                className='p-1 absolute top-0 right-0'
               />
             </div>
-            <div id={descriptionId} className='py-4 flex-1 overflow-y-auto max-h-[80dvh]'>
-              {content || (
-                <Text tag='p' className='text-sm text-text-secondary-light dark:text-text-secondary-dark'>
+
+            <div className={bodyClassName}>
+              {shouldRenderCustomContent ? (
+                <>
+                  <ModalPrimitive.Description className='sr-only'>{textContent}</ModalPrimitive.Description>
+                  {renderedContent}
+                </>
+              ) : (
+                <ModalPrimitive.Description className='text-sm text-text-secondary-light dark:text-text-secondary-dark'>
                   {textContent}
-                </Text>
+                </ModalPrimitive.Description>
               )}
             </div>
+
             <div className='flex justify-end pt-4'>
-              {footer || <Button text='Close' size='sm' variant='outlined' onClick={() => setIsOpen(false)} />}
+              {shouldRenderCustomFooter ? (
+                renderedFooter
+              ) : (
+                <Button onClick={closeModal} size='sm' text='Close' variant='outlined' />
+              )}
             </div>
           </ModalPrimitive.Content>
         </div>
@@ -86,5 +89,3 @@ const Modal: FC<Omit<ModalProps, 'isOpen'>> = ({ ...props }) => {
     </ModalPrimitive.Root>
   );
 };
-
-export default Modal;

--- a/src/components/organisms/modal/Modal.tsx
+++ b/src/components/organisms/modal/Modal.tsx
@@ -2,10 +2,10 @@ import { Button } from '@atoms/button';
 import { IconButton } from '@atoms/icon-button';
 import * as ModalPrimitive from '@radix-ui/react-dialog';
 import { cloneElement, type FC, type ReactNode } from 'react';
-import type { ModalActions, ModalProps } from './types';
+import type { ModalActions, ModalProps, ModalSlot } from './types';
 import { useModal } from './useModal';
 
-const renderModalSlot = (slot: ModalProps['content'], actions: ModalActions): ReactNode =>
+const renderModalSlot = (slot: ModalSlot, actions: ModalActions): ReactNode =>
   typeof slot === 'function' ? slot(actions) : slot;
 
 export const Modal: FC<ModalProps> = (props) => {

--- a/src/components/organisms/modal/index.ts
+++ b/src/components/organisms/modal/index.ts
@@ -1,2 +1,2 @@
-export { default as Modal } from './Modal';
+export { Modal } from './Modal';
 export * from './types';

--- a/src/components/organisms/modal/types.ts
+++ b/src/components/organisms/modal/types.ts
@@ -1,43 +1,91 @@
 import { cva, type VariantProps } from 'class-variance-authority';
-import type { JSX, ReactNode } from 'react';
+import type { MouseEvent, ReactElement, ReactNode } from 'react';
 
 export const modalVariants = cva(
   [
-    'w-full z-modal p-6 shadow-shadow-dropdown',
+    'z-modal flex w-full flex-col border p-6 shadow-modal dark:shadow-modal-dark',
     'bg-surface-light dark:bg-surface-dark',
-    'border border-border-light dark:border-border-dark',
-    'flex flex-col'
+    'border-border-light dark:border-border-dark',
+    'data-[state=closed]:animate-out data-[state=open]:animate-in',
+    'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95'
   ],
   {
     variants: {
       size: {
-        xs: 'max-w-xs m-0 sm:m-1 rounded-md max-h-modal',
-        sm: 'max-w-sm m-0 sm:m-1 rounded-md max-h-modal',
-        md: 'max-w-full sm:max-w-md m-0 sm:m-1 rounded-md max-h-modal',
-        lg: 'max-w-full sm:max-w-lg m-0 sm:m-1 rounded-md max-h-modal',
-        xl: 'max-w-full sm:max-w-xl m-0 sm:m-1 rounded-md max-h-modal',
-        '2xl': 'max-w-full sm:max-w-2xl m-0 sm:m-1 rounded-md max-h-modal',
-        '3xl': 'max-w-full sm:max-w-3xl m-0 sm:m-1 rounded-md max-h-modal',
-        '4xl': 'max-w-full sm:max-w-4xl m-0 sm:m-1 rounded-lg max-h-modal',
-        '5xl': 'max-w-full sm:max-w-5xl m-0 sm:m-1 rounded-lg max-h-modal',
-        full: 'max-w-full m-0 rounded-none h-dvh'
-      },
-      position: {
-        center: 'm-auto',
-        top: 'top-0',
-        bottom: 'bottom-0'
+        xs: 'm-0 max-h-modal max-w-modal-xs rounded-md sm:m-1',
+        sm: 'm-0 max-h-modal max-w-modal-sm rounded-md sm:m-1',
+        md: 'm-0 max-h-modal max-w-modal-md rounded-md sm:m-1',
+        lg: 'm-0 max-h-modal max-w-modal-lg rounded-md sm:m-1',
+        xl: 'm-0 max-h-modal max-w-modal-xl rounded-md sm:m-1',
+        '2xl': 'm-0 max-h-modal max-w-modal-2xl rounded-md sm:m-1',
+        '3xl': 'm-0 max-h-modal max-w-modal-3xl rounded-md sm:m-1',
+        '4xl': 'm-0 max-h-modal max-w-modal-4xl rounded-lg sm:m-1',
+        '5xl': 'm-0 max-h-modal max-w-modal-5xl rounded-lg sm:m-1',
+        full: 'm-0 h-dvh max-w-full rounded-none'
       }
     },
     defaultVariants: {
-      size: 'md',
-      position: 'center'
+      size: 'md'
     }
   }
 );
 
-type ModalSize = VariantProps<typeof modalVariants>['size'];
+export const modalContainerVariants = cva('fixed inset-0 z-modal flex w-full p-0 md:p-4', {
+  variants: {
+    position: {
+      center: 'items-center justify-center',
+      top: 'items-start justify-center',
+      bottom: 'items-end justify-center'
+    }
+  },
+  defaultVariants: {
+    position: 'center'
+  }
+});
 
-export type ModalProps = VariantProps<typeof modalVariants> & {
+export const modalOverlayVariants = cva(
+  [
+    'fixed inset-0 z-modal',
+    'data-[state=closed]:animate-out data-[state=open]:animate-in',
+    'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0'
+  ],
+  {
+    variants: {
+      backdrop: {
+        opacity: 'bg-overlay-dark',
+        blur: 'bg-overlay-dark backdrop-blur-overlay',
+        transparent: 'bg-transparent'
+      }
+    },
+    defaultVariants: {
+      backdrop: 'opacity'
+    }
+  }
+);
+
+type ModalVariantProps = VariantProps<typeof modalVariants>;
+export type ModalSize = NonNullable<ModalVariantProps['size']>;
+export type ModalPosition = NonNullable<VariantProps<typeof modalContainerVariants>['position']>;
+export type ModalBackdrop = NonNullable<VariantProps<typeof modalOverlayVariants>['backdrop']>;
+
+export type ModalTriggerProps = {
+  onClick?: (event: MouseEvent<HTMLElement>) => void;
+  'aria-controls'?: string;
+  'aria-expanded'?: boolean;
+  'aria-haspopup'?: 'dialog';
+};
+
+export type ModalActions = {
+  close: () => void;
+};
+
+type ModalSlot = ReactNode | ((actions: ModalActions) => ReactNode);
+
+export type ModalProps = {
+  /**
+   * @control custom
+   */
+  children: ReactElement<ModalTriggerProps>;
   /**
    * @control select
    * @default md
@@ -47,29 +95,36 @@ export type ModalProps = VariantProps<typeof modalVariants> & {
    * @control select
    * @default center
    */
-  position?: 'center' | 'top' | 'bottom';
+  position?: ModalPosition;
   /**
    * @control select
    * @default opacity
    */
-  backdrop?: 'opacity' | 'blur' | 'transparent';
+  backdrop?: ModalBackdrop;
   /**
    * @control text
-   * @default 'Modal title'
+   * @default Modal title
    */
   title?: string;
-  header?: ReactNode | JSX.Element;
-  /**
-   * @control text
-   * @default 'Modal content goes here.'
-   */
-  textContent?: string;
-  content?: ReactNode | JSX.Element;
-  footer?: ReactNode | JSX.Element;
-  children?: ReactNode;
   /**
    * @control custom
-   * @default undefined
+   */
+  header?: ReactNode;
+  /**
+   * @control text
+   * @default Modal content goes here.
+   */
+  textContent?: string;
+  /**
+   * @control custom
+   */
+  content?: ModalSlot;
+  /**
+   * @control custom
+   */
+  footer?: ModalSlot;
+  /**
+   * @control custom
    */
   customBackdrop?: string;
 };

--- a/src/components/organisms/modal/types.ts
+++ b/src/components/organisms/modal/types.ts
@@ -79,7 +79,7 @@ export type ModalActions = {
   close: () => void;
 };
 
-type ModalSlot = ReactNode | ((actions: ModalActions) => ReactNode);
+export type ModalSlot = ReactNode | ((actions: ModalActions) => ReactNode);
 
 export type ModalProps = {
   /**

--- a/src/components/organisms/modal/useModal.ts
+++ b/src/components/organisms/modal/useModal.ts
@@ -1,10 +1,9 @@
-import type * as ModalPrimitive from '@radix-ui/react-dialog';
-import { type ComponentPropsWithoutRef, type MouseEvent, useId, useRef, useState } from 'react';
+import type { DialogContentProps } from '@radix-ui/react-dialog';
+import { type MouseEvent, useId, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { type ModalProps, modalContainerVariants, modalOverlayVariants, modalVariants } from './types';
 
-type ContentProps = ComponentPropsWithoutRef<typeof ModalPrimitive.Content>;
-type CloseAutoFocusEvent = Parameters<NonNullable<ContentProps['onCloseAutoFocus']>>[0];
+type CloseAutoFocusEvent = Parameters<NonNullable<DialogContentProps['onCloseAutoFocus']>>[0];
 
 type UseModalReturn = {
   bodyClassName: string;

--- a/src/components/organisms/modal/useModal.ts
+++ b/src/components/organisms/modal/useModal.ts
@@ -1,52 +1,105 @@
-import { useState } from 'react';
+import type * as ModalPrimitive from '@radix-ui/react-dialog';
+import { type ComponentPropsWithoutRef, type MouseEvent, useId, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
-import type { ModalProps } from './types';
+import { type ModalProps, modalContainerVariants, modalOverlayVariants, modalVariants } from './types';
+
+type ContentProps = ComponentPropsWithoutRef<typeof ModalPrimitive.Content>;
+type CloseAutoFocusEvent = Parameters<NonNullable<ContentProps['onCloseAutoFocus']>>[0];
+
+type UseModalReturn = {
+  bodyClassName: string;
+  children: ModalProps['children'];
+  closeModal: () => void;
+  containerClassName: string;
+  content: ModalProps['content'];
+  contentId: string;
+  footer: ModalProps['footer'];
+  getTriggerProps: (originalOnClick?: ModalProps['children']['props']['onClick']) => ModalProps['children']['props'];
+  handleCloseAutoFocus: (event: CloseAutoFocusEvent) => void;
+  handleOpenChange: (open: boolean) => void;
+  header: ModalProps['header'];
+  isOpen: boolean;
+  overlayClassName: string;
+  panelClassName: string;
+  shouldRenderCustomContent: boolean;
+  shouldRenderCustomFooter: boolean;
+  shouldRenderCustomHeader: boolean;
+  textContent: string;
+  title: string;
+};
 
 export const useModal = ({
-  title = 'Modal title',
-  textContent = 'Modal content goes here.',
-  header,
-  content,
-  footer,
-  children,
-  size = 'md',
-  position = 'center',
   backdrop = 'opacity',
-  customBackdrop
-}: Omit<ModalProps, 'isOpen'>) => {
+  children,
+  content,
+  customBackdrop,
+  footer,
+  header,
+  position = 'center',
+  size = 'md',
+  textContent = 'Modal content goes here.',
+  title = 'Modal title'
+}: ModalProps): UseModalReturn => {
   const [isOpen, setIsOpen] = useState(false);
-  const titleId = 'modal-title';
-  const descriptionId = 'modal-description';
-  const contentId = 'modal-content';
-  const currentBackdrop = !customBackdrop
-    ? cn(
-        'fixed inset-0 z-modal',
-        backdrop === 'opacity' && 'bg-black/60',
-        backdrop === 'blur' && 'bg-black/60 backdrop-blur-sm',
-        backdrop === 'transparent' && 'bg-transparent',
-        'data-[state=open]:animate-in data-[state=closed]:animate-out',
-        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0'
-      )
-    : cn(
-        'fixed inset-0 z-modal',
-        customBackdrop,
-        'data-[state=open]:animate-in data-[state=closed]:animate-out',
-        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0'
-      );
+  const triggerElementRef = useRef<HTMLElement | null>(null);
+  const idBase = useId().replace(/:/g, '');
+
+  const contentId = `modal-${idBase}-content`;
+
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open);
+  };
+
+  const getTriggerProps = (
+    originalOnClick?: ModalProps['children']['props']['onClick']
+  ): ModalProps['children']['props'] => ({
+    'aria-controls': contentId,
+    'aria-expanded': isOpen,
+    'aria-haspopup': 'dialog',
+    onClick: (event: MouseEvent<HTMLElement>) => {
+      triggerElementRef.current = event.currentTarget;
+      originalOnClick?.(event);
+      if (!event.defaultPrevented) {
+        setIsOpen(true);
+      }
+    }
+  });
+
+  const handleCloseAutoFocus = (event: CloseAutoFocusEvent) => {
+    event.preventDefault();
+    triggerElementRef.current?.focus();
+  };
+
+  const closeModal = () => {
+    setIsOpen(false);
+  };
+
   return {
-    isOpen,
-    setIsOpen,
-    contentId,
+    bodyClassName: cn('flex-1 overflow-y-auto py-4', size !== 'full' && 'max-h-modal'),
     children,
-    currentBackdrop,
-    position,
-    titleId,
-    descriptionId,
-    size,
-    header,
-    title,
+    closeModal,
+    containerClassName: modalContainerVariants({ position }),
     content,
+    contentId,
+    footer,
+    getTriggerProps,
+    handleCloseAutoFocus,
+    handleOpenChange,
+    header,
+    isOpen,
+    overlayClassName: customBackdrop
+      ? cn(
+          'fixed inset-0 z-modal',
+          'data-[state=closed]:animate-out data-[state=open]:animate-in',
+          'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+          customBackdrop
+        )
+      : modalOverlayVariants({ backdrop }),
+    panelClassName: modalVariants({ size }),
+    shouldRenderCustomContent: content !== undefined,
+    shouldRenderCustomFooter: footer !== undefined,
+    shouldRenderCustomHeader: header !== undefined,
     textContent,
-    footer
+    title
   };
 };

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -382,6 +382,18 @@
   --spacing-2xl: 3rem; /* 48px */
   --spacing-3xl: 5rem; /* 80px */
 
+  /* ── Modal sizing ────────────────────────────────────────────── */
+  --size-modal-viewport: calc(100vw - var(--spacing-8));
+  --size-modal-xs: 20rem;
+  --size-modal-sm: 24rem;
+  --size-modal-md: 28rem;
+  --size-modal-lg: 32rem;
+  --size-modal-xl: 36rem;
+  --size-modal-2xl: 42rem;
+  --size-modal-3xl: 48rem;
+  --size-modal-4xl: 56rem;
+  --size-modal-5xl: 64rem;
+
   /* ── Transiciones ────────────────────────────────────────────── */
   --transition-fast: 150ms ease-in-out;
   --transition-base: 250ms ease;
@@ -435,4 +447,57 @@
 
 @utility max-h-modal {
   max-height: 80dvh;
+}
+
+@utility z-modal {
+  z-index: var(--z-modal);
+}
+
+@utility shadow-modal {
+  box-shadow: var(--shadow-dropdown-light);
+}
+
+@utility shadow-modal-dark {
+  box-shadow: var(--shadow-dropdown);
+}
+
+@utility backdrop-blur-overlay {
+  backdrop-filter: var(--blur-overlay);
+  -webkit-backdrop-filter: var(--blur-overlay);
+}
+
+@utility max-w-modal-xs {
+  max-width: min(var(--size-modal-viewport), var(--size-modal-xs));
+}
+
+@utility max-w-modal-sm {
+  max-width: min(var(--size-modal-viewport), var(--size-modal-sm));
+}
+
+@utility max-w-modal-md {
+  max-width: min(var(--size-modal-viewport), var(--size-modal-md));
+}
+
+@utility max-w-modal-lg {
+  max-width: min(var(--size-modal-viewport), var(--size-modal-lg));
+}
+
+@utility max-w-modal-xl {
+  max-width: min(var(--size-modal-viewport), var(--size-modal-xl));
+}
+
+@utility max-w-modal-2xl {
+  max-width: min(var(--size-modal-viewport), var(--size-modal-2xl));
+}
+
+@utility max-w-modal-3xl {
+  max-width: min(var(--size-modal-viewport), var(--size-modal-3xl));
+}
+
+@utility max-w-modal-4xl {
+  max-width: min(var(--size-modal-viewport), var(--size-modal-4xl));
+}
+
+@utility max-w-modal-5xl {
+  max-width: min(var(--size-modal-viewport), var(--size-modal-5xl));
 }


### PR DESCRIPTION
## Summary

Completes the Modal review checklist with typed props, token-backed variants, accessible Radix dialog wiring, Storybook coverage, and focused tests.

Closes #133

## Type of change

- [ ] 🧩 New component
- [x] 🐛 Bug fix
- [ ] 🎨 Design tokens
- [ ] ♿ Accessibility
- [ ] 🏗️ Infrastructure
- [ ] 📚 Documentation

## Repository checklist

- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`
- [x] Commit messages follow the same commitlint-enforced format
- [x] PR description links the issue with `Closes #NNN`
- [x] Security checks pass, or any false positives are documented in the PR

## Component checklist (skip if not applicable)

- [x] Follows the 5-file structure (`types.ts`, `use*.ts`, `Component.tsx`, `index.ts`, `*.stories.tsx`)
- [x] CVA variants defined in `types.ts`, not inline
- [x] No hardcoded colors — uses tokens from `theme.css`
- [x] No `any` types — TypeScript strict
- [x] ARIA attributes present and correct
- [x] Keyboard navigable (Tab, Enter, Escape where applicable)
- [x] Dark mode works correctly
- [x] Storybook stories cover: default, variants, states (hover, focus, disabled)
- [x] Tests added or updated

## Changes

| File | Change |
|------|--------|
| `src/components/organisms/modal/types.ts` | Tightened props, added render-prop slot actions, centralized CVA variants, and switched modal widths to semantic token utilities |
| `src/components/organisms/modal/useModal.ts` | Owns state, IDs, trigger ARIA props, focus restoration, and class composition |
| `src/components/organisms/modal/Modal.tsx` | Named presentational component with valid ARIA wiring and `{ close }` slot rendering |
| `src/components/organisms/modal/Modal.test.tsx` | Adds behavior, accessibility, focus, disabled trigger, and custom close-slot coverage |
| `src/components/organisms/modal/Modal.stories.tsx` | Reworks docs and examples, including Usage Guide for custom `{ close }` render props |
| `src/styles/theme.css` | Adds semantic Modal sizing/elevation/overlay utilities used by the component |
| `src/components/organisms/modal/index.ts` | Switches to named exports |

## How to test

1. `pnpm exec vitest run src/components/organisms/modal/Modal.test.tsx src/storybook-explicit-examples.test.ts`
2. `pnpm exec tsc --noEmit`
3. `pnpm storybook-build`
4. `git push` pre-push hook: full `pnpm test` suite passed (`229` tests)
5. Run Storybook and inspect `Organisms/Modal` stories: default, disabled, size, position, backdrop, custom content, custom trigger, custom backdrop

## Screenshots / recordings (if applicable)

N/A

## Notes for reviewer

- The issue title says `atom: Modal`, but the existing component lives in `src/components/organisms/modal`; this PR keeps the existing location and fixes the current component in place.
- Custom `content` and `footer` slots can now be render props receiving `{ close }`, so consumers can dismiss the modal without importing Radix internals.
- Modal width/elevation/overlay utilities are defined in `theme.css` to avoid broken/generated Tailwind utility mismatches seen during visual review.
