### PR TITLE
fix(snippet): complete review checklist

### DIFF
--- a/src/components/molecules/snippet/Snippet.stories.tsx
+++ b/src/components/molecules/snippet/Snippet.stories.tsx
@@ -1,17 +1,17 @@
+import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
-import Snippet from './Snippet';
+import { Snippet } from './Snippet';
 
 /**
- * ## DESCRIPTION
- * The `Snippet` component displays code or text snippets with optional copy-to-clipboard functionality.
- * It supports multiple variants, colors, sizes, and rounded corners for flexible use in documentation and UI.
- * The component is fully accessible, keyboard-navigable, and screen-reader friendly.
+ * ## Description
+ * Snippet renders short or multiline code blocks with a token-backed surface and an optional copy action.
  *
- * ## DEPENDENCIES
- * - `IconButton` (atom): Used for the copy-to-clipboard button, providing accessible icon button interactions.
- * - `class-variance-authority (CVA)`: Used for scalable and maintainable styling variants.
+ * ## Dependencies
+ * Uses `IconButton` for the copy affordance.
+ *
+ * ## Usage Guide
+ * Use `aria-label` to customize the copy button name for assistive technology or product-specific copy. `disableCopy` removes the action entirely when the snippet is meant to be read-only or decorative.
  */
-
 const meta: Meta<typeof Snippet> = {
   title: 'Molecules/Snippet',
   component: Snippet,
@@ -22,257 +22,172 @@ const meta: Meta<typeof Snippet> = {
   },
   tags: ['autodocs']
 };
+
 export default meta;
 
 type Story = StoryObj<typeof Snippet>;
 
 /**
- * Demonstrates the default usage of the Snippet component with the copy button enabled.
- *
- * **Props used:**
- * - No additional props (uses all default values)
+ * Shows the default snippet configuration without overriding the default visual variants.
  */
 export const Default: Story = {
   args: {
-    children: 'npm install @your/package'
+    children: 'pnpm add @stack-and-flow/design-system',
+    onCopy: action('copy')
   }
 };
 
 /**
- * Demonstrates the Snippet component with the copy button disabled for all variants.
- *
- * **Props used:**
- * - `disableCopy`: Disables the copy button.
- * - `variant`: solid | outline | shadow
- */
-export const DisabledCopy: Story = {
-  render: () => (
-    <div className='grid grid-cols-2 md:grid-cols-3 gap-4'>
-      <Snippet variant='solid' disableCopy={true}>
-        npm install @your/package
-      </Snippet>
-      <Snippet variant='outline' disableCopy={true}>
-        npm install @your/package
-      </Snippet>
-      <Snippet variant='shadow' disableCopy={true}>
-        npm install @your/package
-      </Snippet>
-    </div>
-  )
-};
-
-/**
- * Demonstrates the Snippet component with multiline content for each variant.
- *
- * **Props used:**
- * - `variant`: solid | outline | shadow
- * - `children`: Multiline string content
- */
-export const MultiLine: Story = {
-  render: () => (
-    <div className='grid grid-cols-2 md:grid-cols-3 gap-4'>
-      <Snippet variant='solid'>
-        {`
-# Instalación
-npm install my-library
-
-# Construcción
-npm run build
-
-# Inicio
-npm start
-    `}
-      </Snippet>
-      <Snippet variant='outline'>
-        {`
-# Instalación
-npm install my-library
-
-# Construcción
-npm run build
-
-# Inicio
-npm start
-    `}
-      </Snippet>
-      <Snippet variant='shadow'>
-        {`
-# Instalación
-npm install my-library
-
-# Construcción
-npm run build
-
-# Inicio
-npm start
-    `}
-      </Snippet>
-    </div>
-  )
-};
-
-/**
- * Demonstrates the `variant` prop of the Snippet component, showing all color options for each variant: solid, outline, and shadow.
- *
- * The `variant` prop controls the visual style of the Snippet. Available options are:
- * - `solid`: Filled background (default)
- * - `outline`: Transparent background with border
- * - `shadow`: Adds a shadow effect
+ * Shows the visual hierarchy available through the variant prop.
  */
 export const Variant: Story = {
   render: () => (
-    <div className='space-y-8'>
-      <div>
-        <div className='mb-2 font-semibold text-text-light dark:text-text-dark'>Solid variant</div>
-        <div className='grid grid-cols-2 md:grid-cols-3 gap-4'>
-          <Snippet variant='solid'>npm install @your/package</Snippet>
-          <Snippet variant='solid' color='primary'>
-            npm install @your/package
-          </Snippet>
-          <Snippet variant='solid' color='secondary'>
-            npm install @your/package
-          </Snippet>
-          <Snippet variant='solid' color='info'>
-            npm install @your/package
-          </Snippet>
-          <Snippet variant='solid' color='success'>
-            npm install @your/package
-          </Snippet>
-          <Snippet variant='solid' color='warning'>
-            npm install @your/package
-          </Snippet>
-          <Snippet variant='solid' color='danger'>
-            npm install @your/package
-          </Snippet>
-        </div>
-      </div>
-      <div>
-        <div className='mb-2 font-semibold text-text-light dark:text-text-dark'>Outline variant</div>
-        <div className='grid grid-cols-2 md:grid-cols-3 gap-4'>
-          <Snippet variant='outline'>npm install @your/package</Snippet>
-          <Snippet variant='outline' color='primary'>
-            npm install @your/package
-          </Snippet>
-          <Snippet variant='outline' color='secondary'>
-            npm install @your/package
-          </Snippet>
-          <Snippet variant='outline' color='info'>
-            npm install @your/package
-          </Snippet>
-          <Snippet variant='outline' color='success'>
-            npm install @your/package
-          </Snippet>
-          <Snippet variant='outline' color='warning'>
-            npm install @your/package
-          </Snippet>
-          <Snippet variant='outline' color='danger'>
-            npm install @your/package
-          </Snippet>
-        </div>
-      </div>
-      <div>
-        <div className='mb-2 font-semibold text-text-light dark:text-text-dark'>Shadow variant</div>
-        <div className='grid grid-cols-2 md:grid-cols-3 gap-4'>
-          <Snippet variant='shadow'>npm install @your/package</Snippet>
-          <Snippet variant='shadow' color='primary'>
-            npm install @your/package
-          </Snippet>
-          <Snippet variant='shadow' color='secondary'>
-            npm install @your/package
-          </Snippet>
-          <Snippet variant='shadow' color='info'>
-            npm install @your/package
-          </Snippet>
-          <Snippet variant='shadow' color='success'>
-            npm install @your/package
-          </Snippet>
-          <Snippet variant='shadow' color='warning'>
-            npm install @your/package
-          </Snippet>
-          <Snippet variant='shadow' color='danger'>
-            npm install @your/package
-          </Snippet>
-        </div>
-      </div>
+    <div className='grid gap-4 md:grid-cols-3'>
+      <Snippet onCopy={action('solid-copy')}>Solid snippet</Snippet>
+      <Snippet variant='outline' onCopy={action('outline-copy')}>
+        Outline snippet
+      </Snippet>
+      <Snippet variant='shadow' onCopy={action('shadow-copy')}>
+        Shadow snippet
+      </Snippet>
     </div>
   )
 };
 
 /**
- * Demonstrates the different size options for the Snippet component.
- *
- * **Props used:**
- * - `size`: sm | md | lg
+ * Shows the semantic color surface options while keeping the same structure.
+ */
+export const Color: Story = {
+  render: () => (
+    <div className='grid gap-4 md:grid-cols-2 xl:grid-cols-4'>
+      <Snippet color='default' onCopy={action('default-color-copy')}>
+        Default color
+      </Snippet>
+      <Snippet color='primary' onCopy={action('primary-color-copy')}>
+        Primary color
+      </Snippet>
+      <Snippet color='secondary' onCopy={action('secondary-color-copy')}>
+        Secondary color
+      </Snippet>
+      <Snippet color='success' onCopy={action('success-color-copy')}>
+        Success color
+      </Snippet>
+      <Snippet color='warning' onCopy={action('warning-color-copy')}>
+        Warning color
+      </Snippet>
+      <Snippet color='danger' onCopy={action('danger-color-copy')}>
+        Danger color
+      </Snippet>
+      <Snippet color='info' onCopy={action('info-color-copy')}>
+        Info color
+      </Snippet>
+    </div>
+  )
+};
+
+/**
+ * Shows the supported size scale for compact and large code snippets.
  */
 export const Size: Story = {
   render: () => (
-    <div className='grid grid-cols-2 md:grid-cols-3 gap-4'>
-      <Snippet size='sm'>npm install @your/package</Snippet>
-      <Snippet size='md'>npm install @your/package</Snippet>
-      <Snippet size='lg'>npm install @your/package</Snippet>
+    <div className='grid gap-4'>
+      <Snippet size='sm' onCopy={action('small-copy')}>
+        Small snippet
+      </Snippet>
+      <Snippet size='md' onCopy={action('medium-copy')}>
+        Medium snippet
+      </Snippet>
+      <Snippet size='lg' onCopy={action('large-copy')}>
+        Large snippet
+      </Snippet>
     </div>
   )
 };
 
 /**
- * Demonstrates the different border radius (rounded) options for the Snippet component.
- *
- * **Props used:**
- * - `rounded`: none | xs | sm | md | lg | xl | full
+ * Shows the available rounded scale for surface composition.
  */
-export const CustomRounded: Story = {
+export const Rounded: Story = {
   render: () => (
-    <div className='grid grid-cols-2 md:grid-cols-3 gap-4'>
-      <Snippet rounded='none'>npm install @your/package</Snippet>
-      <Snippet rounded='xs'>npm install @your/package</Snippet>
-      <Snippet rounded='sm'>npm install @your/package</Snippet>
-      <Snippet rounded='md'>npm install @your/package</Snippet>
-      <Snippet rounded='lg'>npm install @your/package</Snippet>
-      <Snippet rounded='xl'>npm install @your/package</Snippet>
-      <Snippet rounded='full'>npm install @your/package</Snippet>
+    <div className='grid gap-4 md:grid-cols-2 xl:grid-cols-4'>
+      <Snippet rounded='none' onCopy={action('rounded-none-copy')}>
+        Rounded none
+      </Snippet>
+      <Snippet rounded='xs' onCopy={action('rounded-xs-copy')}>
+        Rounded xs
+      </Snippet>
+      <Snippet rounded='sm' onCopy={action('rounded-sm-copy')}>
+        Rounded sm
+      </Snippet>
+      <Snippet rounded='md' onCopy={action('rounded-md-copy')}>
+        Rounded md
+      </Snippet>
+      <Snippet rounded='lg' onCopy={action('rounded-lg-copy')}>
+        Rounded lg
+      </Snippet>
+      <Snippet rounded='xl' onCopy={action('rounded-xl-copy')}>
+        Rounded xl
+      </Snippet>
+      <Snippet rounded='full' onCopy={action('rounded-full-copy')}>
+        Rounded full
+      </Snippet>
     </div>
   )
 };
 
 /**
- * Demonstrates usage of the `className` prop for custom styles.
- *
- * **Props used:**
- * - `className`: Custom Tailwind or CSS classes
+ * Shows multiline content while preserving the horizontal copy affordance.
+ */
+export const Multiline: Story = {
+  render: () => (
+    <Snippet onCopy={action('multiline-copy')}>
+      {`pnpm install
+pnpm run build
+pnpm test`}
+    </Snippet>
+  )
+};
+
+/**
+ * Shows the non-interactive state when copy is intentionally unavailable.
+ */
+export const Disabled: Story = {
+  args: {
+    children: 'Read-only snippet',
+    disableCopy: true
+  }
+};
+
+/**
+ * Shows how token-backed utility classes can extend the component without bypassing the theme.
  */
 export const CustomClassName: Story = {
   args: {
-    children: 'npm install @your/package',
-    className:
-      'bg-gradient-to-r from-blue-100 to-blue-300 dark:from-blue-600 dark:to-blue-900 border border-blue-800 dark:border-blue-500'
+    children: 'Themed custom class',
+    className: 'border-brand-light bg-red-tint-subtle text-brand-light dark:border-brand-dark dark:text-brand-dark',
+    onCopy: action('custom-class-copy')
   }
 };
 
 /**
- * Demonstrates usage of the `aria-controls` and `aria-label` props for accessibility.
- *
- * **Props used:**
- * - `aria-label`: Accessible label for the copy button
- * - `aria-controls`: ARIA controls attribute for accessibility
+ * Shows accessible copy-button labeling and an explicit controlled content relationship.
  */
-export const WithAriaControls: Story = {
+export const AccessibleCopyAction: Story = {
   args: {
-    id: 'custom-snippet',
-    children: 'npm install @your/package',
-    'aria-label': 'Copy install command',
-    'aria-controls': 'custom-snippet'
+    id: 'install-command',
+    'aria-controls': 'install-command-code',
+    'aria-label': 'Copy installation command',
+    children: 'pnpm add @stack-and-flow/design-system',
+    onCopy: action('accessible-copy')
   }
 };
 
 /**
- * Demonstrates usage of the `onCopy` callback for custom copy feedback.
- *
- * **Props used:**
- * - `onCopy`: Callback executed after copying
+ * Shows the copy callback using the canonical Storybook action helper.
  */
 export const WithOnCopy: Story = {
   args: {
-    children: 'npm install @your/package',
-    onCopy: () => alert('Copied to clipboard!')
+    children: 'pnpm run storybook',
+    onCopy: action('copy-callback')
   }
 };

--- a/src/components/molecules/snippet/Snippet.test.tsx
+++ b/src/components/molecules/snippet/Snippet.test.tsx
@@ -1,0 +1,173 @@
+import { act, render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('lucide-react/dynamic.js', () => ({
+  // biome-ignore lint/style/useNamingConvention: must match library export name
+  DynamicIcon: ({ name, size }: { name: string; size: number }) => (
+    <svg data-name={name} data-size={String(size)} data-testid='snippet-icon' />
+  )
+}));
+
+import { Snippet as SnippetFromIndex } from './index';
+import { Snippet } from './Snippet';
+import { snippetBase } from './types';
+import { useSnippet } from './useSnippet';
+
+const createClipboardMock = () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+
+  Object.defineProperty(window.navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText }
+  });
+
+  return writeText;
+};
+
+describe('useSnippet — logic', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('returns default copy-button semantics and barrel re-export compatibility', () => {
+    const { result } = renderHook(() => useSnippet({ children: 'pnpm install' }));
+
+    expect(result.current.showCopyButton).toBe(true);
+    expect(result.current.copyButtonProps['aria-label']).toBe('Copy snippet');
+    expect(result.current.copyButtonProps.title).toBe('Copy snippet');
+    expect(result.current.copyButtonProps.size).toBe('xs');
+    expect(result.current.preProps.id).toBe(result.current.copyButtonProps['aria-controls']);
+    expect(SnippetFromIndex).toBe(Snippet);
+  });
+
+  it('coordinates text, padding, and copy button size across snippet sizes', () => {
+    const { result: smallResult } = renderHook(() => useSnippet({ children: 'pnpm install', size: 'sm' }));
+    const { result: mediumResult } = renderHook(() => useSnippet({ children: 'pnpm install', size: 'md' }));
+    const { result: largeResult } = renderHook(() => useSnippet({ children: 'pnpm install', size: 'lg' }));
+
+    expect(smallResult.current.rootProps.className).toContain('text-xs');
+    expect(smallResult.current.rootProps.className).toContain('pl-3');
+    expect(smallResult.current.copyButtonProps.size).toBe('xs');
+    expect(mediumResult.current.rootProps.className).toContain('text-sm');
+    expect(mediumResult.current.rootProps.className).toContain('pl-3');
+    expect(mediumResult.current.copyButtonProps.size).toBe('xs');
+    expect(largeResult.current.rootProps.className).toContain('text-base');
+    expect(largeResult.current.rootProps.className).toContain('pl-4');
+    expect(largeResult.current.copyButtonProps.size).toBe('sm');
+  });
+
+  it('keeps the shadow variant visually distinct from solid', () => {
+    expect(snippetBase({ variant: 'solid' })).not.toContain('shadow-glow-chip-secondary');
+    expect(snippetBase({ variant: 'shadow' })).toContain('shadow-glow-chip-secondary-light');
+    expect(snippetBase({ variant: 'shadow' })).toContain('border-border-strong-light');
+  });
+
+  it('maps provided aria props to the copy button and preserves the root id', () => {
+    const { result } = renderHook(() =>
+      useSnippet({
+        children: 'pnpm install',
+        id: 'install-snippet',
+        'aria-controls': 'install-snippet-code',
+        'aria-label': 'Copy installation command'
+      })
+    );
+
+    expect(result.current.rootProps.id).toBe('install-snippet');
+    expect(result.current.preProps.id).toBe('install-snippet-code');
+    expect(result.current.copyButtonProps['aria-controls']).toBe('install-snippet-code');
+    expect(result.current.copyButtonProps['aria-label']).toBe('Copy installation command');
+  });
+
+  it('copies the snippet text, calls onCopy, and clears copied state after the timeout', async () => {
+    const writeText = createClipboardMock();
+    const handleCopy = vi.fn();
+    const { result } = renderHook(() => useSnippet({ children: 'pnpm install', onCopy: handleCopy }));
+    const pre = document.createElement('pre');
+
+    pre.textContent = 'pnpm install';
+    result.current.preRef.current = pre;
+
+    await act(async () => {
+      await result.current.copyButtonProps.onClick?.(new MouseEvent('click') as never);
+    });
+
+    expect(writeText).toHaveBeenCalledWith('pnpm install');
+    expect(handleCopy).toHaveBeenCalledTimes(1);
+    expect(result.current.copied).toBe(true);
+    expect(result.current.copyAnnouncement).toBe('Snippet copied to clipboard');
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.copied).toBe(false);
+    expect(result.current.copyAnnouncement).toBeUndefined();
+  });
+
+  it('does not copy when the action is disabled', async () => {
+    const writeText = createClipboardMock();
+    const handleCopy = vi.fn();
+    const { result } = renderHook(() =>
+      useSnippet({ children: 'pnpm install', disableCopy: true, onCopy: handleCopy })
+    );
+    const pre = document.createElement('pre');
+
+    pre.textContent = 'pnpm install';
+    result.current.preRef.current = pre;
+
+    await act(async () => {
+      await result.current.copyButtonProps.onClick?.(new MouseEvent('click') as never);
+    });
+
+    expect(writeText).not.toHaveBeenCalled();
+    expect(handleCopy).not.toHaveBeenCalled();
+    expect(result.current.copied).toBe(false);
+  });
+});
+
+describe('Snippet — component behavior', () => {
+  it('renders the snippet content and keeps aria props on the copy button instead of the container', () => {
+    render(
+      <Snippet id='install-snippet' aria-label='Copy installation command'>
+        pnpm install
+      </Snippet>
+    );
+
+    const button = screen.getByRole('button', { name: 'Copy installation command' });
+    const code = screen.getByText('pnpm install');
+
+    expect(button).toHaveAttribute('aria-controls', 'install-snippet-content');
+    expect(button).toHaveClass('h-9', 'w-9');
+    expect(screen.getByTestId('snippet-icon')).toHaveAttribute('data-size', '14');
+    expect(code.closest('pre')).toHaveAttribute('id', 'install-snippet-content');
+    expect(screen.getByText('pnpm install').parentElement?.parentElement).not.toHaveAttribute(
+      'aria-label',
+      'Copy installation command'
+    );
+  });
+
+  it('hides the copy action when disableCopy is true', () => {
+    render(<Snippet disableCopy={true}>Read-only snippet</Snippet>);
+
+    expect(screen.queryByRole('button', { name: /copy/i })).not.toBeInTheDocument();
+  });
+
+  it('writes to the clipboard and calls onCopy when the button is clicked', async () => {
+    const writeText = createClipboardMock();
+    const handleCopy = vi.fn();
+
+    render(<Snippet onCopy={handleCopy}>pnpm add @stack-and-flow/design-system</Snippet>);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy snippet' }));
+
+    expect(writeText).toHaveBeenCalledWith('pnpm add @stack-and-flow/design-system');
+    expect(handleCopy).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('status')).toHaveTextContent('Snippet copied to clipboard');
+  });
+});

--- a/src/components/molecules/snippet/Snippet.test.tsx
+++ b/src/components/molecules/snippet/Snippet.test.tsx
@@ -14,9 +14,7 @@ import { Snippet } from './Snippet';
 import { snippetBase } from './types';
 import { useSnippet } from './useSnippet';
 
-const createClipboardMock = () => {
-  const writeText = vi.fn().mockResolvedValue(undefined);
-
+const createClipboardMock = (writeText = vi.fn().mockResolvedValue(undefined)) => {
   Object.defineProperty(window.navigator, 'clipboard', {
     configurable: true,
     value: { writeText }
@@ -107,6 +105,58 @@ describe('useSnippet — logic', () => {
     });
 
     expect(result.current.copied).toBe(false);
+    expect(result.current.copyAnnouncement).toBeUndefined();
+  });
+
+  it('announces clipboard failures without calling onCopy', async () => {
+    const writeText = createClipboardMock(vi.fn().mockRejectedValue(new Error('Clipboard denied')));
+    const handleCopy = vi.fn();
+    const { result } = renderHook(() => useSnippet({ children: 'pnpm install', onCopy: handleCopy }));
+    const pre = document.createElement('pre');
+
+    pre.textContent = 'pnpm install';
+    result.current.preRef.current = pre;
+
+    await act(async () => {
+      await result.current.copyButtonProps.onClick?.(new MouseEvent('click') as never);
+    });
+
+    expect(writeText).toHaveBeenCalledWith('pnpm install');
+    expect(handleCopy).not.toHaveBeenCalled();
+    expect(result.current.copied).toBe(false);
+    expect(result.current.copyAnnouncement).toBe('Unable to copy snippet');
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.copyAnnouncement).toBeUndefined();
+  });
+
+  it('announces unsupported clipboard access', async () => {
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: undefined
+    });
+    const handleCopy = vi.fn();
+    const { result } = renderHook(() => useSnippet({ children: 'pnpm install', onCopy: handleCopy }));
+    const pre = document.createElement('pre');
+
+    pre.textContent = 'pnpm install';
+    result.current.preRef.current = pre;
+
+    await act(async () => {
+      await result.current.copyButtonProps.onClick?.(new MouseEvent('click') as never);
+    });
+
+    expect(handleCopy).not.toHaveBeenCalled();
+    expect(result.current.copied).toBe(false);
+    expect(result.current.copyAnnouncement).toBe('Unable to copy snippet');
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
     expect(result.current.copyAnnouncement).toBeUndefined();
   });
 

--- a/src/components/molecules/snippet/Snippet.tsx
+++ b/src/components/molecules/snippet/Snippet.tsx
@@ -3,41 +3,32 @@ import { IconButton } from '@/components/atoms/icon-button';
 import type { SnippetProps } from './types';
 import { useSnippet } from './useSnippet';
 
-/**
- * Snippet component
- *
- * Displays a code or text snippet with optional copy-to-clipboard functionality.
- * Supports multiple variants, colors, sizes, and rounded corners.
- *
- * @component
- * @param {SnippetProps} props - Props for Snippet component
- * @returns {JSX.Element}
- */
-const Snippet: FC<SnippetProps> = ({ ...props }) => {
-  const { preRef, size, copied, handleCopy, slots, children, ariaProps } = useSnippet(props);
+export const Snippet: FC<SnippetProps> = (props) => {
+  const {
+    children,
+    copyAnnouncement,
+    copyButtonProps,
+    copyButtonWrapperClassName,
+    preProps,
+    preRef,
+    rootProps,
+    showCopyButton,
+    statusClassName
+  } = useSnippet(props);
+
   return (
-    <div className={`${slots.base}`} {...ariaProps}>
-      <pre
-        ref={preRef}
-        className={`${slots.pre}`}
-        /* If you use Tailwind Scrollbar plugin, these classes will work. Otherwise, add custom CSS below. */
-      >
+    <div {...rootProps}>
+      <pre {...preProps} ref={preRef}>
         {children}
       </pre>
-      {!props.disableCopy && (
-        <div className='flex items-center justify-center h-full'>
-          <IconButton
-            className={slots.copyButtonAnimations}
-            icon={copied ? 'check' : 'copy'}
-            size={slots.sizeButton[size ?? 'md']}
-            title='copy to clipboard'
-            variant='ghost'
-            onClick={handleCopy}
-          />
+      {showCopyButton ? (
+        <div className={copyButtonWrapperClassName}>
+          <IconButton {...copyButtonProps} />
+          <span aria-live='polite' className={statusClassName} role='status'>
+            {copyAnnouncement}
+          </span>
         </div>
-      )}
+      ) : null}
     </div>
   );
 };
-
-export default Snippet;

--- a/src/components/molecules/snippet/index.ts
+++ b/src/components/molecules/snippet/index.ts
@@ -1,2 +1,2 @@
-export { default as Snippet } from './Snippet';
+export { Snippet } from './Snippet';
 export * from './types';

--- a/src/components/molecules/snippet/types.ts
+++ b/src/components/molecules/snippet/types.ts
@@ -1,33 +1,34 @@
 import { cva, type VariantProps } from 'class-variance-authority';
-import type { ReactNode } from 'react';
-import type { IconSizes } from '@/types';
+import type { ComponentProps, ReactNode } from 'react';
+import type { IconButtonSize } from '@/components/atoms/icon-button';
+import type { DynamicIconName } from '@/types';
 
-/**
- * CVA configuration for the Snippet component.
- * Controls base styles, variants, and compound variants.
- */
 export const snippetBase = cva(
-  'w-full max-w-full box-border overflow-hidden flex flex-row justify-start items-center gap-2 p-2 font-mono whitespace-pre-wrap text-text-light dark:text-text-dark text-justify',
+  [
+    'box-border flex w-full max-w-full items-start overflow-hidden border',
+    'font-mono text-left text-text-light dark:text-text-dark',
+    'transition-[background-color,border-color,box-shadow] duration-200 ease-out'
+  ],
   {
     variants: {
       size: {
-        sm: 'text-xs',
-        md: 'text-sm',
-        lg: 'text-base'
+        sm: 'gap-1 py-1 pr-1 pl-3 text-xs',
+        md: 'gap-2 py-1 pr-1 pl-3 text-sm',
+        lg: 'gap-2 py-1.5 pr-1.5 pl-4 text-base'
       },
       rounded: {
+        none: 'rounded-none',
         xs: 'rounded-xs',
         sm: 'rounded-sm',
         md: 'rounded-md',
         lg: 'rounded-lg',
         xl: 'rounded-xl',
-        full: 'rounded-full',
-        none: 'rounded-none'
+        full: 'rounded-full'
       },
       variant: {
         solid: '',
-        outline: 'border-2 bg-transparent',
-        shadow: 'shadow-lg'
+        outline: 'bg-transparent',
+        shadow: 'shadow-glow-chip-secondary-light dark:shadow-glow-chip-secondary'
       },
       color: {
         default: '',
@@ -43,86 +44,78 @@ export const snippetBase = cva(
       {
         variant: ['solid', 'shadow'],
         color: 'default',
-        class: 'bg-color-surface-light dark:bg-color-surface-dark'
+        class: 'bg-surface-light border-border-light dark:bg-surface-dark dark:border-border-dark'
       },
       {
         variant: ['solid', 'shadow'],
         color: 'primary',
-        class: 'bg-color-surface-raised-light dark:bg-color-brand-dark'
+        class: 'bg-red-tint-subtle border-brand-light/20 dark:bg-red-tint-low dark:border-brand-dark/30'
       },
       {
         variant: ['solid', 'shadow'],
         color: 'secondary',
-        class: 'bg-color-surface-raised-dark dark:bg-color-surface-raised-dark'
+        class:
+          'bg-surface-raised-light border-border-strong-light dark:bg-surface-raised-dark dark:border-border-strong-dark'
       },
       {
         variant: ['solid', 'shadow'],
         color: 'success',
-        class: 'bg-green-400 dark:bg-green-700'
+        class: 'bg-success-tint border-success-light/30 dark:bg-success-tint dark:border-success/30'
       },
       {
         variant: ['solid', 'shadow'],
         color: 'warning',
-        class: 'bg-yellow-400 dark:bg-yellow-700'
+        class: 'bg-warning-tint border-warning-light/30 dark:bg-warning-tint dark:border-warning/30'
       },
       {
         variant: ['solid', 'shadow'],
         color: 'danger',
-        class: 'bg-red-400 dark:bg-red-700'
+        class: 'bg-error-tint border-error-light/30 dark:bg-error-tint dark:border-error/30'
       },
       {
         variant: ['solid', 'shadow'],
         color: 'info',
-        class: 'bg-blue-400 dark:bg-blue-700'
+        class: 'bg-info-tint border-info-light/30 dark:bg-info-tint dark:border-info/30'
       },
-
       {
         variant: 'outline',
         color: 'default',
-        class: 'border-color-border-light dark:border-color-border-dark'
+        class: 'border-border-light dark:border-border-dark'
       },
       {
         variant: 'outline',
         color: 'primary',
-        class: 'border-color-brand-light dark:border-color-brand-dark'
+        class: 'border-brand-light dark:border-brand-dark'
       },
       {
         variant: 'outline',
         color: 'secondary',
-        class: 'border-color-surface-raised-dark dark:border-color-surface-raised-dark'
+        class: 'border-border-strong-light dark:border-border-strong-dark'
       },
       {
         variant: 'outline',
         color: 'success',
-        class: 'border-green-400 dark:border-green-700'
+        class: 'border-success-light dark:border-success'
       },
       {
         variant: 'outline',
         color: 'warning',
-        class: 'border-yellow-400 dark:border-yellow-700'
+        class: 'border-warning-light dark:border-warning'
       },
       {
         variant: 'outline',
         color: 'danger',
-        class: 'border-red-400 dark:border-red-700'
+        class: 'border-error-light dark:border-error'
       },
       {
         variant: 'outline',
         color: 'info',
-        class: 'border-blue-400 dark:border-blue-700'
+        class: 'border-info-light dark:border-info'
       },
-
-      { variant: 'shadow', color: 'default', class: 'shadow-color-text-muted-light/50' },
-      { variant: 'shadow', color: 'primary', class: 'shadow-red-600/50' },
       {
         variant: 'shadow',
-        color: 'secondary',
-        class: 'shadow-color-text-muted-light/50'
-      },
-      { variant: 'shadow', color: 'success', class: 'shadow-green-600/50' },
-      { variant: 'shadow', color: 'warning', class: 'shadow-yellow-600/50' },
-      { variant: 'shadow', color: 'danger', class: 'shadow-red-600/50' },
-      { variant: 'shadow', color: 'info', class: 'shadow-blue-600/50' }
+        class: 'border-border-strong-light dark:border-border-strong-dark'
+      }
     ],
     defaultVariants: {
       size: 'md',
@@ -133,34 +126,65 @@ export const snippetBase = cva(
   }
 );
 
-/**
- * Snippet component variants generated from CVA.
- */
-export type SnippetVariants = VariantProps<typeof snippetBase>;
+export const snippetPreClassName =
+  'm-0 min-h-9 min-w-0 flex-1 overflow-x-auto whitespace-pre break-words bg-transparent py-2 text-inherit scrollbar-thin scrollbar-thumb-transparent scrollbar-track-transparent';
 
-type Size = 'sm' | 'md' | 'lg';
+export const snippetCopyButtonWrapperClassName = 'shrink-0 self-start';
 
-/**
- * Icon button sizes for each snippet size.
- */
-export type SizeButton = Record<Size, IconSizes>;
+export const snippetCopyButtonClassName =
+  'opacity-100 transition-[opacity,box-shadow,background-color,color] duration-200 ease-out';
 
-/**
- * Props for the Snippet component.
- * Variants (size, rounded, color, variant) come from SnippetVariants (CVA).
- * @property {ReactNode} children - Content to display inside the snippet.
- * @property {string} [className] - Additional class names.
- * @property {boolean} [disableCopy] - Disables the copy button.
- * @property {() => void} [onCopy] - Callback after copying.
- * @property {string} ['aria-controls'] - ARIA controls attribute.
- * @property {string} ['aria-label'] - ARIA label attribute.
- */
-export type SnippetProps = SnippetVariants & {
+export const snippetStatusClassName = 'sr-only';
+
+export const snippetCopyButtonIcons = {
+  idle: 'copy',
+  success: 'check'
+} as const satisfies Record<'idle' | 'success', DynamicIconName>;
+
+export type SnippetSize = NonNullable<VariantProps<typeof snippetBase>['size']>;
+
+export const snippetCopyButtonSizes = {
+  sm: 'xs',
+  md: 'xs',
+  lg: 'sm'
+} as const satisfies Record<SnippetSize, IconButtonSize>;
+
+export type SnippetVariantProps = VariantProps<typeof snippetBase>;
+
+type NativeSnippetProps = Omit<
+  ComponentProps<'div'>,
+  'aria-controls' | 'aria-label' | 'children' | 'className' | 'color'
+>;
+
+export type SnippetProps = NativeSnippetProps & {
+  /** @control text */
   children: ReactNode;
-  id?: string;
+  /** @control select
+   * @default md
+   */
+  size?: NonNullable<SnippetVariantProps['size']>;
+  /** @control select
+   * @default md
+   */
+  rounded?: NonNullable<SnippetVariantProps['rounded']>;
+  /** @control select
+   * @default solid
+   */
+  variant?: NonNullable<SnippetVariantProps['variant']>;
+  /** @control select
+   * @default default
+   */
+  color?: NonNullable<SnippetVariantProps['color']>;
+  /** @control text */
   className?: string;
+  /** @control boolean
+   * @default false
+   */
   disableCopy?: boolean;
+  /** @control action */
   onCopy?: () => void;
+  /** @control text */
   'aria-controls'?: string;
+  /** @control text */
   'aria-label'?: string;
 };

--- a/src/components/molecules/snippet/types.ts
+++ b/src/components/molecules/snippet/types.ts
@@ -153,7 +153,7 @@ export type SnippetVariantProps = VariantProps<typeof snippetBase>;
 
 type NativeSnippetProps = Omit<
   ComponentProps<'div'>,
-  'aria-controls' | 'aria-label' | 'children' | 'className' | 'color'
+  'aria-controls' | 'aria-label' | 'children' | 'className' | 'color' | 'onCopy'
 >;
 
 export type SnippetProps = NativeSnippetProps & {

--- a/src/components/molecules/snippet/useSnippet.ts
+++ b/src/components/molecules/snippet/useSnippet.ts
@@ -1,74 +1,138 @@
-import { useCallback, useRef, useState } from 'react';
-import { type SizeButton, type SnippetProps, snippetBase } from './types';
+import type { MouseEventHandler, MutableRefObject } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import type { IconButtonProps } from '@/components/atoms/icon-button';
+import { cn } from '@/lib/utils';
+import {
+  type SnippetProps,
+  snippetBase,
+  snippetCopyButtonClassName,
+  snippetCopyButtonIcons,
+  snippetCopyButtonSizes,
+  snippetCopyButtonWrapperClassName,
+  snippetPreClassName,
+  snippetStatusClassName
+} from './types';
 
-/**
- * Custom hook for Snippet component logic.
- *
- * Handles copy-to-clipboard, slot class generation, and accessibility props.
- *
- * @param {SnippetProps} props - Props for the Snippet component
- * @returns {{
- *   preRef: React.RefObject<HTMLPreElement>,
- *   copied: boolean,
- *   handleCopy: () => Promise<void>,
- *   slots: any,
- *   children: React.ReactNode,
- *   size: string,
- *   variant: string,
- *   color: string,
- *   ariaProps: object
- * }}
- */
-export function useSnippet({
+type SnippetRootProps = Omit<
+  SnippetProps,
+  | 'aria-controls'
+  | 'aria-label'
+  | 'children'
+  | 'className'
+  | 'color'
+  | 'disableCopy'
+  | 'onCopy'
+  | 'rounded'
+  | 'size'
+  | 'variant'
+> & {
+  className: string;
+};
+
+type SnippetPreProps = {
+  className: string;
+  id?: string;
+};
+
+type SnippetCopyButtonProps = {
+  'aria-controls': string;
+  'aria-label': string;
+  className: string;
+  icon: NonNullable<IconButtonProps['icon']>;
+  onClick: MouseEventHandler<HTMLButtonElement>;
+  size: NonNullable<IconButtonProps['size']>;
+  title: string;
+  variant: NonNullable<IconButtonProps['variant']>;
+};
+
+export type UseSnippetReturn = {
+  children: SnippetProps['children'];
+  copied: boolean;
+  copyAnnouncement: string | undefined;
+  copyButtonProps: SnippetCopyButtonProps;
+  copyButtonWrapperClassName: string;
+  preProps: SnippetPreProps;
+  preRef: MutableRefObject<HTMLPreElement | null>;
+  rootProps: SnippetRootProps;
+  showCopyButton: boolean;
+  statusClassName: string;
+};
+
+export const useSnippet = ({
   children,
   size = 'md',
   rounded = 'md',
   className,
   color = 'default',
   variant = 'solid',
-  disableCopy,
+  disableCopy = false,
   onCopy,
-  ...ariaProps
-}: SnippetProps) {
+  id,
+  'aria-controls': ariaControls,
+  'aria-label': ariaLabel,
+  ...rootProps
+}: SnippetProps): UseSnippetReturn => {
+  const generatedId = useId();
   const [copied, setCopied] = useState(false);
   const preRef = useRef<HTMLPreElement>(null);
+  const resetTimeoutRef = useRef<number | null>(null);
+  const contentId = ariaControls ?? (id ? `${id}-content` : `snippet-${generatedId}`);
+  const copyLabel = ariaLabel ?? (copied ? 'Snippet copied' : 'Copy snippet');
 
-  /**
-   * Copies the snippet content to clipboard and triggers feedback.
-   */
-  const handleCopy = useCallback(async () => {
-    if (disableCopy || !preRef.current) {
+  useEffect(
+    () => () => {
+      if (resetTimeoutRef.current) {
+        window.clearTimeout(resetTimeoutRef.current);
+      }
+    },
+    []
+  );
+
+  const handleCopy: MouseEventHandler<HTMLButtonElement> = useCallback(async () => {
+    if (disableCopy || !preRef.current || typeof navigator.clipboard?.writeText !== 'function') {
       return;
     }
 
-    const text = preRef.current.textContent || '';
-    await navigator.clipboard.writeText(text).then(() => {
-      setCopied(true);
-      onCopy?.();
-      setTimeout(() => setCopied(false), 2000);
-    });
+    await navigator.clipboard.writeText(preRef.current.textContent ?? '');
+
+    setCopied(true);
+    onCopy?.();
+
+    if (resetTimeoutRef.current) {
+      window.clearTimeout(resetTimeoutRef.current);
+    }
+
+    resetTimeoutRef.current = window.setTimeout(() => {
+      setCopied(false);
+    }, 2000);
   }, [disableCopy, onCopy]);
 
-  const slots = {
-    base: snippetBase({ size, variant, color, rounded, className }),
-    pre: 'w-full max-w-full overflow-x-auto whitespace-pre break-words box-border scrollbar-thin scrollbar-thumb-transparent scrollbar-track-transparent flex-1 m-0 bg-transparent border-none',
-    sizeButton: {
-      sm: 12,
-      md: 16,
-      lg: 20
-    } as const satisfies SizeButton,
-    copyButtonAnimations: `transition-opacity duration-300 ease-in-out opacity-100`
-  };
-
   return {
-    preRef,
-    copied,
-    handleCopy,
-    slots,
     children,
-    size,
-    variant,
-    color,
-    ariaProps
+    copied,
+    copyAnnouncement: copied ? 'Snippet copied to clipboard' : undefined,
+    copyButtonProps: {
+      'aria-controls': contentId,
+      'aria-label': copyLabel,
+      className: snippetCopyButtonClassName,
+      icon: copied ? snippetCopyButtonIcons.success : snippetCopyButtonIcons.idle,
+      onClick: handleCopy,
+      size: snippetCopyButtonSizes[size],
+      title: copyLabel,
+      variant: 'ghost'
+    },
+    copyButtonWrapperClassName: snippetCopyButtonWrapperClassName,
+    preProps: {
+      className: snippetPreClassName,
+      id: contentId
+    },
+    preRef,
+    rootProps: {
+      ...rootProps,
+      className: cn(snippetBase({ size, rounded, variant, color }), className),
+      id
+    },
+    showCopyButton: !disableCopy,
+    statusClassName: snippetStatusClassName
   };
-}
+};

--- a/src/components/molecules/snippet/useSnippet.ts
+++ b/src/components/molecules/snippet/useSnippet.ts
@@ -74,6 +74,7 @@ export const useSnippet = ({
 }: SnippetProps): UseSnippetReturn => {
   const generatedId = useId();
   const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState(false);
   const preRef = useRef<HTMLPreElement>(null);
   const resetTimeoutRef = useRef<number | null>(null);
   const contentId = ariaControls ?? (id ? `${id}-content` : `snippet-${generatedId}`);
@@ -88,29 +89,46 @@ export const useSnippet = ({
     []
   );
 
-  const handleCopy: MouseEventHandler<HTMLButtonElement> = useCallback(async () => {
-    if (disableCopy || !preRef.current || typeof navigator.clipboard?.writeText !== 'function') {
-      return;
-    }
-
-    await navigator.clipboard.writeText(preRef.current.textContent ?? '');
-
-    setCopied(true);
-    onCopy?.();
-
+  const resetCopyStatus = useCallback(() => {
     if (resetTimeoutRef.current) {
       window.clearTimeout(resetTimeoutRef.current);
     }
 
     resetTimeoutRef.current = window.setTimeout(() => {
       setCopied(false);
+      setCopyError(false);
     }, 2000);
-  }, [disableCopy, onCopy]);
+  }, []);
+
+  const handleCopy: MouseEventHandler<HTMLButtonElement> = useCallback(async () => {
+    if (disableCopy || !preRef.current) {
+      return;
+    }
+
+    if (typeof navigator.clipboard?.writeText !== 'function') {
+      setCopied(false);
+      setCopyError(true);
+      resetCopyStatus();
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(preRef.current.textContent ?? '');
+      setCopyError(false);
+      setCopied(true);
+      onCopy?.();
+    } catch {
+      setCopied(false);
+      setCopyError(true);
+    }
+
+    resetCopyStatus();
+  }, [disableCopy, onCopy, resetCopyStatus]);
 
   return {
     children,
     copied,
-    copyAnnouncement: copied ? 'Snippet copied to clipboard' : undefined,
+    copyAnnouncement: copyError ? 'Unable to copy snippet' : copied ? 'Snippet copied to clipboard' : undefined,
     copyButtonProps: {
       'aria-controls': contentId,
       'aria-label': copyLabel,


### PR DESCRIPTION
## Summary

Completes the Snippet molecule review checklist: typed props/hook return, token-backed CVA variants, named exports, ARIA/copy behavior, Storybook coverage, and tests.

Closes #210

## Type of change

- [ ] 🧩 New component
- [x] 🐛 Bug fix
- [ ] 🎨 Design tokens
- [ ] ♿ Accessibility
- [ ] 🏗️ Infrastructure
- [ ] 📚 Documentation

## Repository checklist

- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`
- [x] Commit messages follow the same commitlint-enforced format
- [x] PR description links the issue with `Closes #NNN`
- [x] Security checks pass, or any false positives are documented in the PR

## Component checklist (skip if not applicable)

- [x] Follows the 5-file structure (`types.ts`, `use*.ts`, `Component.tsx`, `index.ts`, `*.stories.tsx`)
- [x] CVA variants defined in `types.ts`, not inline
- [x] No hardcoded colors — uses tokens from `theme.css`
- [x] No `any` types — TypeScript strict
- [x] ARIA attributes present and correct
- [x] Keyboard navigable (Tab, Enter, Escape where applicable)
- [x] Dark mode works correctly
- [x] Storybook stories cover: default, variants, states (hover, focus, disabled)
- [x] Tests added or updated

## How to test

1. `pnpm exec biome check src/components/molecules/snippet`
2. `pnpm exec vitest run src/components/molecules/snippet/Snippet.test.tsx`
3. `pnpm exec tsc --noEmit`
4. `pnpm test`
5. `pnpm run storybook`, then review `Molecules/Snippet` default, variants, colors, sizes, rounded, multiline, disabled, accessible copy action, and callback stories.

## Screenshots / recordings (if applicable)

Visual review completed locally in Storybook; no assets attached.

## Notes for reviewer

- The copy action uses compact `IconButton` sizing by default; large snippets scale the copy action to `sm`.
- The `shadow` variant is intentionally distinct from `solid` via token-backed glow and stronger border.
- No scripts were modified, so shellcheck is not applicable.
