### PR TITLE
fix(dropdown): complete atom review checklist

### DIFF
--- a/src/components/atoms/dropdown/Dropdown.stories.tsx
+++ b/src/components/atoms/dropdown/Dropdown.stories.tsx
@@ -1,119 +1,106 @@
+import { buttonVariants } from '@atoms/button/types';
 import { Icon } from '@atoms/icon';
+import { iconButtonVariants } from '@atoms/icon-button/types';
+import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Dropdown } from './index';
+import { Dropdown } from './Dropdown';
 import type { DropdownSchema } from './types';
 
+const accountMenuItems: DropdownSchema = [
+  { type: 'label', label: 'My Account' },
+  { type: 'separator' },
+  {
+    type: 'item',
+    label: 'Profile',
+    onClick: action('profile-select'),
+    startContent: <Icon name='user' />,
+    endContent: <span>⇧⌘P</span>
+  },
+  {
+    type: 'item',
+    label: 'Billing',
+    onClick: action('billing-select'),
+    endContent: <span>⌘B</span>
+  },
+  { type: 'separator' },
+  {
+    type: 'submenu',
+    label: 'Team',
+    startContent: <Icon name='users' />,
+    items: [
+      { type: 'item', label: 'Invite users', onClick: action('invite-users-select') },
+      { type: 'item', label: 'New team', onClick: action('new-team-select'), endContent: <span>⌘T</span> }
+    ]
+  }
+];
+
+const destructiveMenuItems: DropdownSchema = [
+  { type: 'label', label: 'Danger zone' },
+  { type: 'separator' },
+  {
+    type: 'item',
+    label: 'Delete project',
+    variant: 'destructive',
+    onClick: action('delete-project-select'),
+    endContent: <span>⌘⌫</span>
+  }
+];
+
+const disabledMenuItems: DropdownSchema = [
+  { type: 'label', label: 'Project actions' },
+  { type: 'separator' },
+  { type: 'item', label: 'Rename project', onClick: action('rename-project-select') },
+  { type: 'item', label: 'Transfer ownership', disabled: true, onClick: action('transfer-ownership-select') }
+];
+
+const iconTrigger = (
+  <span className={iconButtonVariants({ variant: 'primary' })}>
+    <Icon color='text-white' colorDark='dark:text-white' decorative={true} name='ellipsis' size={20} />
+  </span>
+);
+
+const Trigger = ({ label }: { label: string }) => (
+  <span className={buttonVariants({ variant: 'primary' })}>{label}</span>
+);
+
 /**
- * ## DESCRIPTION
- * The Dropdown component is a versatile menu element that allows users to select options or navigate through submenus.
- * It supports various configurations, including custom triggers, widths, offsets, alignments, and positions.
- * The component is designed to be accessible and customizable, making it suitable for a wide range of use cases.
+ * ## Description
+ * Dropdown displays a contextual action menu powered by Radix primitives while following the design-system token, accessibility, and Storybook conventions.
  *
- * ## DEPENDENCIES
- * - [Radix UI Dropdown Menu](https://www.radix-ui.com/docs/primitives/components/dropdown-menu)
- * - [spinners-react](https://github.com/adexin/spinners-react)
- * - Icon - from Lucide React for icons
+ * ## Dependencies
+ * Uses `@radix-ui/react-dropdown-menu` for menu semantics and the `Icon` atom to render optional visual affordances in examples.
  *
- * ## ITEMS STRUCTURE
- * The `items` prop defines the structure of the dropdown menu. It is an array of objects, where each object represents a menu element.
- * The following types of elements are supported:
+ * ## Usage Guide
+ * Compose the menu with the `items` prop. Each entry must declare a `type`, and the supported shapes are:
  *
- * ## POSSIBILITIES
- * - **Customizable Content**: Add icons, shortcuts, or any React node to `startContent` and `endContent`.
- * - **Nested Menus**: Use `submenu` to create hierarchical menus.
- * - **Variants**: Style items as `default` or `destructive` for different use cases.
- * - **Disabled Items**: Disable specific items to indicate unavailable actions.
- * - **Dividers and Labels**: Use `separator` and `label` to organize and group items.
- *
- * ## USAGE
- *
- * ### 1. Label
- * A non-interactive label used to group or describe menu items.
- * ```json
- * {
- *   "type": "label",
- *   "label": "My Account"
- * }
- * ```
- *
- * ### 2. Separator
- * A visual divider used to separate groups of menu items.
- * ```json
- * {
- *   "type": "separator"
- * }
- * ```
- *
- * ### 3. Item
- * A clickable menu item that can trigger an action or navigate to a link.
- * ```json
- * {
- *   "type": "item",
- *   "label": "Profile",
- *   "disabled": false,
- *   "variant": "default",
- *   "onClick": () => alert('Profile clicked'),
- *   "startContent": <Icon name="user" />,
- *   "endContent": <span>⇧⌘P</span>
- * }
- * ```
- * - **Properties**:
- *   - `label`: The text displayed for the menu item.
- *   - `disabled`: Whether the item is disabled.
- *   - `variant`: The visual style of the item (`default` or `destructive`).
- *   - `onClick`: A callback function triggered when the item is clicked.
- *   - `startContent`: Optional content (e.g., an icon) displayed at the start of the item.
- *   - `endContent`: Optional content (e.g., a shortcut) displayed at the end of the item.
- *
- * ### 4. Submenu
- * A nested menu that contains additional items.
- * This allows for organizing related actions under a single menu trigger.
- * You can use `startContent` and `endContent` to customize the submenu trigger.
- * ChevronRight icon is rendered by default but you can be overridden with custom icons if needed.
- * ```json
- * {
- *   "type": "submenu",
- *   "label": "Team",
- *   "startContent": <Icon name="users" />,
- *   "endContent": <ChevronRightIcon className="ml-auto size-4" />,
- *   "items": [
- *     { "type": "item", "label": "Invite users" },
- *     { "type": "item", "label": "New Team", "endContent": <span>⌘+T</span> }
- *   ]
- * }
- * ```
- * - **Properties**:
- *   - `label`: The text displayed for the submenu trigger.
- *   - `items`: An array of `DropdownElement` objects defining the submenu's structure.
- *
- * ## EXAMPLE
- * Here is an example of a complete `items` array:
- * ```json
- * [
- *   { "type": "label", "label": "My Account" },
- *   { "type": "separator" },
+ * ```tsx
+ * const items: DropdownSchema = [
+ *   { type: 'label', label: 'My Account' },
+ *   { type: 'separator' },
  *   {
- *     "type": "item",
- *     "label": "Profile",
- *     "onClick": () => alert('Profile clicked'),
- *     "startContent": <Icon name="user" />,
- *     "endContent": <span>⇧⌘P</span>
+ *     type: 'item',
+ *     label: 'Profile',
+ *     onClick: action('profile-select'),
+ *     startContent: <Icon name='user' />,
+ *     endContent: <span>⇧⌘P</span>
  *   },
- *   { "type": "item", "label": "Billing", "endContent": <span>⌘B</span> },
- *   { "type": "separator" },
  *   {
- *     "type": "submenu",
- *     "label": "Team",
- *     "items": [
- *       { "type": "item", "label": "Invite users" },
- *       { "type": "item", "label": "New Team", "endContent": <span>⌘+T</span> }
+ *     type: 'submenu',
+ *     label: 'Team',
+ *     items: [
+ *       { type: 'item', label: 'Invite users', onClick: action('invite-users-select') }
  *     ]
  *   },
- *   { "type": "separator" },
- *   { "type": "item", "label": "Log out", "variant": "destructive", "endContent": <span>⇧⌘Q</span> }
- * ]
+ *   {
+ *     type: 'item',
+ *     label: 'Delete project',
+ *     variant: 'destructive',
+ *     onClick: action('delete-project-select')
+ *   }
+ * ];
  * ```
  *
+ * Use `label` and `separator` entries to group related actions, `item` entries for selectable actions, and `submenu` entries for nested action groups. Use `disabled` on unavailable items, `variant='destructive'` only for irreversible actions, and `startContent` / `endContent` for icons or keyboard shortcuts. Provide `ariaLabel` when the trigger has no visible text.
  */
 const meta: Meta<typeof Dropdown> = {
   title: 'Atoms/Dropdown',
@@ -125,132 +112,90 @@ const meta: Meta<typeof Dropdown> = {
   },
   tags: ['autodocs']
 };
+
 export default meta;
 
 type Story = StoryObj<typeof Dropdown>;
 
-const Trigger = ({ label }: { label: string }) => (
-  <span className='inline-flex min-h-[44px] items-center rounded-md border border-border-light px-3 py-2 text-sm font-medium text-text-light dark:border-border-dark dark:text-text-dark'>
-    {label}
-  </span>
-);
-
-const schema: DropdownSchema = [
-  { type: 'label', label: 'My Account' },
-  { type: 'separator' },
-  {
-    type: 'item',
-    label: 'Profile',
-    endContent: <span>⇧⌘P</span>,
-    onClick: () => alert('Profile clicked'),
-    startContent: <Icon name='user' />
-  },
-  { type: 'item', label: 'Billing', endContent: <span>⌘B</span> },
-  { type: 'separator' },
-  {
-    type: 'submenu',
-    label: 'Team',
-    items: [
-      { type: 'item', label: 'Invite users' },
-      { type: 'item', label: 'New Team', endContent: <span>⌘+T</span>, onClick: () => alert('Profile clicked') }
-    ]
-  },
-  { type: 'separator' },
-  { type: 'item', label: 'Log out', endContent: <span>⇧⌘Q</span>, variant: 'destructive' }
-];
-
 /**
- * - **Default Dropdown**: A basic dropdown with default settings.
+ * Shows the default menu using the component defaults and a text trigger.
  */
 export const Default: Story = {
   args: {
-    width: '250px',
-    position: 'bottom',
-    align: 'center',
-    offset: 1,
-    closeOnSelect: true,
-    loading: false,
-    className: '',
-    items: schema,
-    children: <Trigger label='Open Menu' />
+    items: accountMenuItems,
+    children: <Trigger label='Open menu' />
   }
 };
-/**
- * - **Loading State**: A dropdown that simulates a loading state.
- *   This is useful for scenarios where the menu items are being fetched asynchronously.
- */
 
+/**
+ * Shows the non-interactive disabled-item state while keeping the menu accessible.
+ */
+export const Disabled: Story = {
+  args: {
+    items: disabledMenuItems,
+    children: <Trigger label='Disabled item' />
+  }
+};
+
+/**
+ * Shows a destructive action item for irreversible operations.
+ */
+export const DestructiveItem: Story = {
+  args: {
+    items: destructiveMenuItems,
+    children: <Trigger label='Danger zone' />
+  }
+};
+
+/**
+ * Shows the loading state used while menu items are being prepared.
+ */
 export const Loading: Story = {
-  render: () => (
-    <div className='flex gap-4 items-start min-h-[250px]'>
-      <Dropdown items={schema} width='250px' loading={true}>
-        <Trigger label='Loading Menu' />
-      </Dropdown>
-    </div>
-  )
+  args: {
+    items: accountMenuItems,
+    loading: true,
+    children: <Trigger label='Loading menu' />
+  }
 };
 
 /**
- * - **Custom Trigger**: Demonstrates how to use custom elements as triggers for the dropdown.
+ * Shows the width variants available for menu content.
  */
-export const CustomTrigger: Story = {
+export const Width: Story = {
   render: () => (
-    <div className='flex gap-4 items-start min-h-[250px]'>
-      <Dropdown items={schema} width='250px'>
-        <Trigger label='Lorem ipsum' />
+    <div className='flex min-h-64 flex-wrap items-start gap-4'>
+      <Dropdown items={accountMenuItems} width='auto'>
+        <Trigger label='Auto width' />
       </Dropdown>
-      <Dropdown items={schema} width='250px'>
-        <span className='inline-flex items-center'>
-          <Icon color='text-color-brand-light' colorDark='dark:text-color-brand-dark' name='image-plus' size={24} />
-          <span className='sr-only'>Open image menu</span>
-        </span>
+      <Dropdown items={accountMenuItems} width='sm'>
+        <Trigger label='Small width' />
+      </Dropdown>
+      <Dropdown items={accountMenuItems} width='md'>
+        <Trigger label='Medium width' />
+      </Dropdown>
+      <Dropdown items={accountMenuItems} width='lg'>
+        <Trigger label='Large width' />
       </Dropdown>
     </div>
   )
 };
 
 /**
- * - **Custom Width**: A dropdown with a custom width of 500px.
- */
-export const CustomWidth: Story = {
-  render: () => (
-    <div className='flex gap-4 items-start min-h-[250px]'>
-      <Dropdown items={schema} width='500px'>
-        <Trigger label='Custom Width' />
-      </Dropdown>
-    </div>
-  )
-};
-
-/**
- * - **Custom Offset**: A dropdown with a custom offset of 20px.
- */
-export const CustomOffset: Story = {
-  render: () => (
-    <div className='flex gap-4 items-start min-h-[250px]'>
-      <Dropdown items={schema} offset={20} width='250px'>
-        <Trigger label='Custom Offset' />
-      </Dropdown>
-    </div>
-  )
-};
-
-/**
- * - **Position**: Demonstrates dropdowns positioned at different sides (top, bottom, left, right).
+ * Shows menu placement on each supported side.
  */
 export const Position: Story = {
   render: () => (
-    <div className='flex gap-4 items-center min-h-[400px]'>
-      <Dropdown items={schema} position='bottom' width='250px'>
+    <div className='flex min-h-80 flex-wrap items-center gap-4'>
+      <Dropdown items={accountMenuItems} position='bottom'>
         <Trigger label='Bottom' />
       </Dropdown>
-      <Dropdown items={schema} position='top' width='250px'>
+      <Dropdown items={accountMenuItems} position='top'>
         <Trigger label='Top' />
       </Dropdown>
-      <Dropdown items={schema} position='left' width='250px'>
+      <Dropdown items={accountMenuItems} position='left'>
         <Trigger label='Left' />
       </Dropdown>
-      <Dropdown items={schema} position='right' width='250px'>
+      <Dropdown items={accountMenuItems} position='right'>
         <Trigger label='Right' />
       </Dropdown>
     </div>
@@ -258,20 +203,52 @@ export const Position: Story = {
 };
 
 /**
- * - **Alignment**: Demonstrates dropdowns aligned to the start, center, and end.
+ * Shows start, center, and end alignment for the menu content.
  */
 export const Alignment: Story = {
   render: () => (
-    <div className='flex gap-4 items-start min-h-[250px]'>
-      <Dropdown items={schema} align='start' position='bottom' width='250px'>
+    <div className='flex min-h-64 flex-wrap items-start gap-4'>
+      <Dropdown items={accountMenuItems} align='start'>
         <Trigger label='Start' />
       </Dropdown>
-      <Dropdown items={schema} align='center' position='bottom' width='250px'>
+      <Dropdown items={accountMenuItems} align='center'>
         <Trigger label='Center' />
       </Dropdown>
-      <Dropdown items={schema} align='end' position='bottom' width='250px'>
+      <Dropdown items={accountMenuItems} align='end'>
         <Trigger label='End' />
       </Dropdown>
     </div>
   )
+};
+
+/**
+ * Shows a nested submenu structure for grouped actions.
+ */
+export const Submenu: Story = {
+  args: {
+    items: accountMenuItems,
+    children: <Trigger label='Team actions' />
+  }
+};
+
+/**
+ * Shows how to keep the menu open after an item is selected.
+ */
+export const CloseOnSelectFalse: Story = {
+  args: {
+    items: accountMenuItems,
+    closeOnSelect: false,
+    children: <Trigger label='Persistent menu' />
+  }
+};
+
+/**
+ * Shows an icon-only trigger with an explicit accessible label.
+ */
+export const CustomTrigger: Story = {
+  args: {
+    ariaLabel: 'Open account actions',
+    items: accountMenuItems,
+    children: iconTrigger
+  }
 };

--- a/src/components/atoms/dropdown/Dropdown.test.tsx
+++ b/src/components/atoms/dropdown/Dropdown.test.tsx
@@ -129,13 +129,21 @@ describe('Dropdown — component behavior', () => {
 
   it('shows loading status semantics without rendering actionable menu items', async () => {
     render(
-      <Dropdown loading={true} items={[{ type: 'item', label: 'Profile', onClick: vi.fn() }]}>
+      <Dropdown
+        loading={true}
+        items={[
+          { type: 'label', label: 'Account actions' },
+          { type: 'item', label: 'Profile', onClick: vi.fn() }
+        ]}
+      >
         <span>Open menu</span>
       </Dropdown>
     );
 
     await userEvent.click(screen.getByRole('button', { name: 'Open menu' }));
 
+    const menu = await screen.findByRole('menu', { name: 'Account actions' });
+    expect(menu).not.toHaveAttribute('aria-labelledby');
     expect(await screen.findByRole('status')).toHaveTextContent('Loading menu items');
     expect(screen.queryByRole('menuitem', { name: 'Profile' })).not.toBeInTheDocument();
   });

--- a/src/components/atoms/dropdown/Dropdown.test.tsx
+++ b/src/components/atoms/dropdown/Dropdown.test.tsx
@@ -1,0 +1,210 @@
+import { render, renderHook, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('lucide-react', () => ({
+  // biome-ignore lint/style/useNamingConvention: must match library export name
+  ChevronRightIcon: () => <span data-testid='submenu-chevron' />
+}));
+
+import { Dropdown } from './Dropdown';
+import type { DropdownItem, DropdownSchema } from './types';
+import { useDropdown } from './useDropdown';
+
+const menuItems: DropdownSchema = [
+  { type: 'label', label: 'My Account' },
+  { type: 'separator' },
+  { type: 'item', label: 'Profile', onClick: vi.fn() },
+  { type: 'item', label: 'Archive', disabled: true, onClick: vi.fn() },
+  {
+    type: 'submenu',
+    label: 'Team',
+    items: [{ type: 'item', label: 'Invite users', onClick: vi.fn() }]
+  }
+];
+
+describe('useDropdown — logic', () => {
+  it('returns the default placement and width values', () => {
+    const { result } = renderHook(() => useDropdown({ items: [...menuItems], children: <span>Open</span> }));
+
+    expect(result.current.contentProps.side).toBe('bottom');
+    expect(result.current.contentProps.align).toBe('start');
+    expect(result.current.contentProps.className).toEqual(expect.any(String));
+  });
+
+  it('uses the first menu label for content labeling without overriding visible trigger text', () => {
+    const { result } = renderHook(() => useDropdown({ items: [...menuItems], children: <span>Open</span> }));
+
+    expect(result.current.triggerProps['aria-label']).toBeUndefined();
+    expect(result.current.contentProps['aria-labelledby']).toEqual(expect.any(String));
+  });
+
+  it('prefers the explicit ariaLabel prop when provided', () => {
+    const { result } = renderHook(() =>
+      useDropdown({ ariaLabel: 'Open account actions', items: [...menuItems], children: <span>Open</span> })
+    );
+
+    expect(result.current.triggerProps['aria-label']).toBe('Open account actions');
+  });
+
+  it('keeps the menu open when closeOnSelect is false', () => {
+    const item: DropdownItem = { type: 'item', label: 'Stay open', onClick: vi.fn() };
+    const { result } = renderHook(() =>
+      useDropdown({ closeOnSelect: false, items: [item], children: <span>Open</span> })
+    );
+
+    const element = result.current.elements[0];
+
+    if (element.type !== 'item') {
+      throw new Error('Expected the first element to be an item');
+    }
+
+    const itemProps = result.current.getItemProps(element);
+    const event = new Event('select');
+    const preventDefault = vi.spyOn(event, 'preventDefault');
+
+    itemProps.onSelect(event);
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(item.onClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Dropdown — component behavior', () => {
+  it('renders a button trigger using the visible trigger text as its accessible name', () => {
+    render(
+      <Dropdown
+        items={[
+          { type: 'label', label: 'My Account' },
+          { type: 'item', label: 'Profile', onClick: vi.fn() }
+        ]}
+      >
+        <span>Open menu</span>
+      </Dropdown>
+    );
+
+    expect(screen.getByRole('button', { name: 'Open menu' })).toBeInTheDocument();
+  });
+
+  it('uses ariaLabel for an icon-only trigger', () => {
+    render(
+      <Dropdown ariaLabel='Open account actions' items={[{ type: 'item', label: 'Profile', onClick: vi.fn() }]}>
+        <span aria-hidden='true'>⋯</span>
+      </Dropdown>
+    );
+
+    expect(screen.getByRole('button', { name: 'Open account actions' })).toBeInTheDocument();
+  });
+
+  it('opens the menu and calls the item action on click', async () => {
+    const onClick = vi.fn();
+    render(
+      <Dropdown items={[{ type: 'item', label: 'Profile', onClick }]}>
+        <span>Open menu</span>
+      </Dropdown>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'Profile' }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not call the action for a disabled item', async () => {
+    const onClick = vi.fn();
+    render(
+      <Dropdown items={[{ type: 'item', label: 'Archive', disabled: true, onClick }]}>
+        <span>Open menu</span>
+      </Dropdown>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'Archive' }));
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('shows loading status semantics without rendering actionable menu items', async () => {
+    render(
+      <Dropdown loading={true} items={[{ type: 'item', label: 'Profile', onClick: vi.fn() }]}>
+        <span>Open menu</span>
+      </Dropdown>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+
+    expect(await screen.findByRole('status')).toHaveTextContent('Loading menu items');
+    expect(screen.queryByRole('menuitem', { name: 'Profile' })).not.toBeInTheDocument();
+  });
+
+  it('keeps the menu open after selection when closeOnSelect is false', async () => {
+    const onClick = vi.fn();
+    render(
+      <Dropdown closeOnSelect={false} items={[{ type: 'item', label: 'Profile', onClick }]}>
+        <span>Open menu</span>
+      </Dropdown>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'Profile' }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  it('supports keyboard opening, roving focus, and Escape close', async () => {
+    const user = userEvent.setup();
+    render(
+      <Dropdown
+        items={[
+          { type: 'item', label: 'Profile', onClick: vi.fn() },
+          { type: 'item', label: 'Billing', onClick: vi.fn() }
+        ]}
+      >
+        <span>Open menu</span>
+      </Dropdown>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open menu' });
+    trigger.focus();
+
+    await user.keyboard('{ArrowDown}');
+
+    const profileItem = await screen.findByRole('menuitem', { name: 'Profile' });
+    expect(profileItem).toHaveFocus();
+
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('menuitem', { name: 'Billing' })).toHaveFocus();
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+    expect(trigger).toHaveFocus();
+  });
+
+  it('renders submenu content when the submenu trigger is opened', async () => {
+    render(
+      <Dropdown
+        items={[
+          {
+            type: 'submenu',
+            label: 'Team',
+            items: [{ type: 'item', label: 'Invite users', onClick: vi.fn() }]
+          }
+        ]}
+      >
+        <span>Open menu</span>
+      </Dropdown>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    await userEvent.hover(await screen.findByRole('menuitem', { name: 'Team' }));
+
+    expect(await screen.findByRole('menuitem', { name: 'Invite users' })).toBeInTheDocument();
+  });
+});

--- a/src/components/atoms/dropdown/Dropdown.tsx
+++ b/src/components/atoms/dropdown/Dropdown.tsx
@@ -1,169 +1,119 @@
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import { ChevronRightIcon } from 'lucide-react';
 import type { FC } from 'react';
-import { SpinnerCircular } from 'spinners-react';
-import { cn } from '@/lib/utils';
-import type { DropdownElement, DropdownProps } from './types';
-import { useDropdown } from './useDropdown';
+import type { DropdownProps } from './types';
+import { type DropdownRenderableElement, useDropdown } from './useDropdown';
 
-const renderDropdownItem = (element: DropdownElement, index: number) => {
-  if (element.type === 'item') {
-    return (
-      <DropdownMenuPrimitive.Item
-        key={index}
-        disabled={element.disabled}
-        data-variant={element.variant}
-        aria-disabled={element.disabled || undefined}
-        className={cn(
-          'relative flex cursor-default justify-between items-center gap-2 rounded-sm px-2 py-1.5 text-sm',
-          'transition-[background,color] duration-150 ease-[ease]',
-          'hover:bg-white-tint-mid hover:text-text-dark dark:hover:bg-white-tint-mid',
-          'focus-visible:outline-none focus-visible:shadow-glow-focus-light dark:focus-visible:shadow-glow-focus-dark',
-          element.variant === 'destructive' && 'bg-error-light dark:bg-error text-white hover:bg-brand-light-dark'
-        )}
-        onClick={element.onClick}
-      >
-        {element.startContent && <span className='flex items-center'>{element.startContent}</span>}
-        <span className='w-full max-w-full'>{element.label}</span>
-        {element.endContent && <span className='flex items-center'>{element.endContent}</span>}
-      </DropdownMenuPrimitive.Item>
-    );
-  }
-};
-
-const renderDropdownSubmenu = (element: DropdownElement, index: number) => {
-  if (element.type === 'submenu') {
-    const submenuId = `submenu-${index}`;
-    return (
-      <DropdownMenuPrimitive.Sub key={index}>
-        <DropdownMenuPrimitive.SubTrigger
-          aria-haspopup='menu'
-          aria-controls={submenuId}
-          aria-expanded={false}
-          className={cn(
-            'flex items-center rounded-md justify-between px-2 py-1.5 text-sm',
-            'transition-[background,color] duration-150 ease-[ease]',
-            'hover:bg-white-tint-mid hover:text-text-dark dark:hover:bg-white-tint-mid',
-            'focus-visible:outline-none focus-visible:shadow-glow-focus-light dark:focus-visible:shadow-glow-focus-dark'
-          )}
-        >
-          {element.startContent && <span className='flex items-center'>{element.startContent}</span>}
-          <span className='w-full max-w-full'>{element.label}</span>
-          {element.endContent ? (
-            <span className='flex items-center'>{element.endContent}</span>
-          ) : (
-            <ChevronRightIcon className='ml-auto size-4' />
-          )}
-        </DropdownMenuPrimitive.SubTrigger>
-        <DropdownMenuPrimitive.SubContent
-          id={submenuId}
-          className={cn(
-            'min-w-[8rem] ml-2 rounded-md border p-1 shadow-lg',
-            'transition-[background,color] duration-150 ease-[ease]',
-            'focus-visible:outline-none focus-visible:shadow-glow-focus-light dark:focus-visible:shadow-glow-focus-dark',
-            'bg-surface-light border-border-light',
-            'text-text-light dark:text-text-dark dark:bg-surface-dark dark:border-border-dark'
-          )}
-        >
-          {element.items.map((subElement, subIndex) => renderDropdownElement(subElement, subIndex))}
-        </DropdownMenuPrimitive.SubContent>
-      </DropdownMenuPrimitive.Sub>
-    );
-  }
-};
-
-const renderDropdownElement = (element: DropdownElement, index: number) => {
+const renderDropdownElement = ({
+  element,
+  getItemProps,
+  getLabelProps,
+  getSeparatorProps,
+  getSubContentProps,
+  getSubTriggerProps
+}: {
+  element: DropdownRenderableElement;
+  getItemProps: ReturnType<typeof useDropdown>['getItemProps'];
+  getLabelProps: ReturnType<typeof useDropdown>['getLabelProps'];
+  getSeparatorProps: ReturnType<typeof useDropdown>['getSeparatorProps'];
+  getSubContentProps: ReturnType<typeof useDropdown>['getSubContentProps'];
+  getSubTriggerProps: ReturnType<typeof useDropdown>['getSubTriggerProps'];
+}) => {
   switch (element.type) {
-    case 'item':
-      return renderDropdownItem(element, index);
-    case 'submenu':
-      return renderDropdownSubmenu(element, index);
-    case 'separator':
-      return <DropdownMenuPrimitive.Separator key={index} className='my-1 h-px bg-border-light dark:bg-border-dark' />;
-    case 'label': {
-      const labelId = `dropdown-label-${index}`;
+    case 'item': {
+      const itemProps = getItemProps(element);
+
       return (
-        <DropdownMenuPrimitive.Label key={index} id={labelId} className='px-2 py-1.5 text-sm font-medium'>
+        <DropdownMenuPrimitive.Item key={element.key} {...itemProps} textValue={element.label}>
+          {element.startContent && <span className='flex items-center'>{element.startContent}</span>}
+          <span className='flex-1 truncate'>{element.label}</span>
+          {element.endContent && <span className='flex items-center'>{element.endContent}</span>}
+        </DropdownMenuPrimitive.Item>
+      );
+    }
+    case 'submenu': {
+      const subTriggerProps = getSubTriggerProps(element);
+      const subContentProps = getSubContentProps(element);
+
+      return (
+        <DropdownMenuPrimitive.Sub key={element.key}>
+          <DropdownMenuPrimitive.SubTrigger {...subTriggerProps} textValue={element.label}>
+            {element.startContent && <span className='flex items-center'>{element.startContent}</span>}
+            <span className='flex-1 truncate'>{element.label}</span>
+            {element.endContent ? (
+              <span className='flex items-center'>{element.endContent}</span>
+            ) : (
+              <ChevronRightIcon aria-hidden='true' className='ml-auto size-4' />
+            )}
+          </DropdownMenuPrimitive.SubTrigger>
+          <DropdownMenuPrimitive.SubContent {...subContentProps}>
+            {element.items.map((subElement) =>
+              renderDropdownElement({
+                element: subElement,
+                getItemProps,
+                getLabelProps,
+                getSeparatorProps,
+                getSubContentProps,
+                getSubTriggerProps
+              })
+            )}
+          </DropdownMenuPrimitive.SubContent>
+        </DropdownMenuPrimitive.Sub>
+      );
+    }
+    case 'separator':
+      return <DropdownMenuPrimitive.Separator key={element.key} {...getSeparatorProps()} />;
+    case 'label':
+      return (
+        <DropdownMenuPrimitive.Label key={element.key} {...getLabelProps(element)}>
           {element.label}
         </DropdownMenuPrimitive.Label>
       );
-    }
-    default:
-      return null;
   }
 };
 
-const Dropdown: FC<DropdownProps> = ({ ...props }) => {
+export const Dropdown: FC<DropdownProps> = (props) => {
   const {
-    items,
+    contentProps,
+    elements,
     loading,
-    closeOnSelect,
-    position,
-    align,
-    offset,
-    width,
-    className,
-    accessibleLabelId,
-    marginClasses,
-    firstLabelId,
-    fallbackId
+    loadingClassName,
+    loadingLabel,
+    spinnerClassName,
+    triggerProps,
+    getItemProps,
+    getLabelProps,
+    getSeparatorProps,
+    getSubContentProps,
+    getSubTriggerProps
   } = useDropdown(props);
 
   return (
     <DropdownMenuPrimitive.Root>
       <DropdownMenuPrimitive.Trigger asChild={true}>
-        <button type='button'>{props.children}</button>
+        <button {...triggerProps}>{props.children}</button>
       </DropdownMenuPrimitive.Trigger>
       <DropdownMenuPrimitive.Portal>
-        <DropdownMenuPrimitive.Content
-          role='menu'
-          aria-labelledby={accessibleLabelId}
-          className={cn(
-            'min-w-[8rem] rounded-md border p-1 shadow-shadow-dropdown-light dark:shadow-shadow-dropdown',
-            'text-text-light dark:text-text-dark',
-            'bg-surface-light border-border-light',
-            'dark:bg-surface-dark dark:border-border-dark',
-            'data-[state=closed]:animate-out data-[state=open]:animate-in',
-            'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-            'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-            marginClasses[position],
-            className
-          )}
-          style={{ width }}
-          side={position}
-          align={align}
-          sideOffset={offset}
-          collisionPadding={8}
-          avoidCollisions={true}
-          onCloseAutoFocus={(e) => {
-            if (!closeOnSelect) {
-              e.preventDefault();
-            }
-          }}
-        >
+        <DropdownMenuPrimitive.Content {...contentProps}>
           {loading ? (
-            <div className='flex justify-center items-center p-4'>
-              <SpinnerCircular
-                color={'currentColor'}
-                secondaryColor={'rgba(45, 6, 9, 0.2)'}
-                thickness={200}
-                size='1.5em'
-              />
+            <div className={loadingClassName} role='status' aria-live='polite'>
+              <span aria-hidden='true' className={spinnerClassName} />
+              <span className='sr-only'>{loadingLabel}</span>
             </div>
           ) : (
-            <>
-              {!firstLabelId && (
-                <span id={fallbackId} className='sr-only'>
-                  Dropdown menu
-                </span>
-              )}
-              {items.map(renderDropdownElement)}
-            </>
+            elements.map((element) =>
+              renderDropdownElement({
+                element,
+                getItemProps,
+                getLabelProps,
+                getSeparatorProps,
+                getSubContentProps,
+                getSubTriggerProps
+              })
+            )
           )}
         </DropdownMenuPrimitive.Content>
       </DropdownMenuPrimitive.Portal>
     </DropdownMenuPrimitive.Root>
   );
 };
-
-export default Dropdown;

--- a/src/components/atoms/dropdown/index.ts
+++ b/src/components/atoms/dropdown/index.ts
@@ -1,2 +1,2 @@
-export { default as Dropdown } from './Dropdown';
+export { Dropdown } from './Dropdown';
 export * from './types';

--- a/src/components/atoms/dropdown/types.ts
+++ b/src/components/atoms/dropdown/types.ts
@@ -1,24 +1,140 @@
-import type { ReactNode } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { ComponentProps, ReactNode } from 'react';
 
-export type DropdownProps = {
-  /**
-   * @control text
-   * @default '56px'
-   */
-  width?: string;
+export const dropdownContentVariants = cva(
+  [
+    'min-w-40 rounded-md border p-1 shadow-dropdown-light dark:shadow-dropdown',
+    'bg-background-light text-text-light border-border-light',
+    'dark:bg-surface-dark dark:text-text-dark dark:border-border-dark',
+    'data-[state=closed]:animate-out data-[state=open]:animate-in',
+    'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+    'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+    'transition-[opacity,transform] duration-150 ease-out'
+  ],
+  {
+    variants: {
+      width: {
+        auto: 'w-auto',
+        sm: 'w-48',
+        md: 'w-56',
+        lg: 'w-72',
+        full: 'w-full'
+      },
+      side: {
+        top: 'mb-2',
+        bottom: 'mt-2',
+        left: 'mr-2',
+        right: 'ml-2'
+      }
+    },
+    defaultVariants: {
+      width: 'auto',
+      side: 'bottom'
+    }
+  }
+);
+
+export const dropdownItemVariants = cva(
+  [
+    'relative flex min-h-11 w-full cursor-pointer items-center gap-2 rounded-sm px-3 py-2 text-sm',
+    'transition-[background,color,box-shadow] duration-150 ease-out',
+    'focus-visible:outline-none focus-visible:shadow-glow-focus-light',
+    'dark:focus-visible:shadow-glow-focus-dark',
+    'data-[disabled]:pointer-events-none data-[disabled]:cursor-not-allowed data-[disabled]:opacity-40'
+  ],
+  {
+    variants: {
+      variant: {
+        default: [
+          'text-text-secondary-light dark:text-text-secondary-dark',
+          'hover:bg-surface-raised-light hover:!text-text-light',
+          'dark:hover:bg-white-tint-mid dark:hover:!text-text-dark',
+          'data-[highlighted]:bg-surface-raised-light data-[highlighted]:!text-text-light',
+          'dark:data-[highlighted]:bg-white-tint-mid dark:data-[highlighted]:!text-text-dark'
+        ],
+        destructive: [
+          'text-error-light dark:text-error',
+          'hover:bg-red-tint-subtle dark:hover:bg-red-tint-low',
+          'data-[highlighted]:bg-red-tint-subtle dark:data-[highlighted]:bg-red-tint-low'
+        ]
+      }
+    },
+    defaultVariants: {
+      variant: 'default'
+    }
+  }
+);
+
+export const dropdownSubTriggerVariants = cva([
+  'relative flex min-h-11 w-full cursor-pointer items-center gap-2 rounded-sm px-3 py-2 text-sm',
+  'transition-[background,color,box-shadow] duration-150 ease-out',
+  'text-text-secondary-light dark:text-text-secondary-dark',
+  'hover:bg-surface-raised-light hover:!text-text-light',
+  'dark:hover:bg-white-tint-mid dark:hover:!text-text-dark',
+  'data-[highlighted]:bg-surface-raised-light data-[highlighted]:!text-text-light',
+  'dark:data-[highlighted]:bg-white-tint-mid dark:data-[highlighted]:!text-text-dark',
+  'focus-visible:outline-none focus-visible:shadow-glow-focus-light',
+  'dark:focus-visible:shadow-glow-focus-dark'
+]);
+
+export const dropdownSubContentVariants = cva([
+  'min-w-40 rounded-md border p-1 shadow-dropdown-light dark:shadow-dropdown',
+  'bg-background-light text-text-light border-border-light',
+  'dark:bg-surface-dark dark:text-text-dark dark:border-border-dark',
+  'ml-2 transition-[opacity,transform] duration-150 ease-out'
+]);
+
+export const dropdownSeparatorVariants = cva('my-1 h-px bg-border-light dark:bg-border-dark');
+
+export const dropdownLabelVariants = cva(
+  'px-3 py-2 text-sm font-medium text-text-secondary-light dark:text-text-secondary-dark'
+);
+
+export const dropdownLoadingVariants = cva(
+  'flex min-h-11 items-center justify-center gap-2 px-3 py-2 text-sm text-text-secondary-light dark:text-text-secondary-dark'
+);
+
+export const dropdownSpinnerVariants = cva([
+  'size-5 animate-spin rounded-full border-2 border-border-light border-t-brand-light',
+  'dark:border-border-dark dark:border-t-brand-dark motion-reduce:animate-none'
+]);
+
+export const dropdownTriggerVariants = cva([
+  'inline-flex min-h-11 min-w-11 items-center justify-center rounded-md',
+  'focus-visible:outline-none focus-visible:shadow-glow-focus-light',
+  'dark:focus-visible:shadow-glow-focus-dark',
+  'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-40'
+]);
+
+export type DropdownItemVariant = NonNullable<VariantProps<typeof dropdownItemVariants>['variant']>;
+export type DropdownWidth = NonNullable<VariantProps<typeof dropdownContentVariants>['width']>;
+type DropdownSide = NonNullable<VariantProps<typeof dropdownContentVariants>['side']>;
+export type DropdownAlign = 'start' | 'center' | 'end';
+type NativeTriggerProps = Omit<ComponentProps<'button'>, 'aria-label' | 'children' | 'className' | 'type'>;
+
+type DropdownBaseElement = {
+  id?: string;
+};
+
+export type DropdownProps = NativeTriggerProps & {
   /**
    * @control select
-   * @default 'bottom'
+   * @default auto
    */
-  position?: 'top' | 'bottom' | 'left' | 'right';
+  width?: DropdownWidth;
   /**
    * @control select
-   * @default 'start'
+   * @default bottom
    */
-  align?: 'start' | 'center' | 'end';
+  position?: DropdownSide;
+  /**
+   * @control select
+   * @default start
+   */
+  align?: DropdownAlign;
   /**
    * @control number
-   * @default 1
+   * @default 0
    */
   offset?: number;
   /**
@@ -34,7 +150,18 @@ export type DropdownProps = {
   /**
    * @control text
    */
+  ariaLabel?: string;
+  /**
+   * @control text
+   */
+  'aria-label'?: string;
+  /**
+   * @control object
+   */
   children: ReactNode;
+  /**
+   * @control object
+   */
   items: DropdownSchema;
   /**
    * @control text
@@ -42,17 +169,17 @@ export type DropdownProps = {
   className?: string;
 };
 
-export type DropdownItem = {
+export type DropdownItem = DropdownBaseElement & {
   type: 'item';
   label: string;
   disabled?: boolean;
-  variant?: 'default' | 'destructive';
+  variant?: DropdownItemVariant;
   onClick?: () => void;
   startContent?: ReactNode;
   endContent?: ReactNode;
 };
 
-export type DropdownSubmenu = {
+export type DropdownSubmenu = DropdownBaseElement & {
   type: 'submenu';
   label: string;
   items: DropdownElement[];
@@ -60,11 +187,11 @@ export type DropdownSubmenu = {
   endContent?: ReactNode;
 };
 
-export type DropdownSeparator = {
+export type DropdownSeparator = DropdownBaseElement & {
   type: 'separator';
 };
 
-export type DropdownLabel = {
+export type DropdownLabel = DropdownBaseElement & {
   type: 'label';
   label: string;
 };

--- a/src/components/atoms/dropdown/useDropdown.ts
+++ b/src/components/atoms/dropdown/useDropdown.ts
@@ -183,8 +183,12 @@ export const useDropdown = ({
       sideOffset: offset,
       avoidCollisions: true,
       className: cn(dropdownContentVariants({ width, side: position }), className),
-      'aria-labelledby': firstLabel?.labelId,
-      'aria-label': firstLabel ? undefined : (explicitAriaLabel ?? 'Dropdown menu')
+      'aria-labelledby': loading ? undefined : firstLabel?.labelId,
+      'aria-label': loading
+        ? (explicitAriaLabel ?? firstLabel?.label ?? 'Dropdown menu')
+        : firstLabel
+          ? undefined
+          : (explicitAriaLabel ?? 'Dropdown menu')
     },
     loadingClassName: dropdownLoadingVariants(),
     spinnerClassName: dropdownSpinnerVariants(),

--- a/src/components/atoms/dropdown/useDropdown.ts
+++ b/src/components/atoms/dropdown/useDropdown.ts
@@ -1,40 +1,222 @@
-import type { DropdownProps } from './types';
+import type { ComponentProps } from 'react';
+import { useId } from 'react';
+import { cn } from '@/lib/utils';
+import {
+  type DropdownAlign,
+  type DropdownElement,
+  type DropdownItem,
+  type DropdownLabel,
+  type DropdownProps,
+  type DropdownSchema,
+  type DropdownSeparator,
+  type DropdownSubmenu,
+  dropdownContentVariants,
+  dropdownItemVariants,
+  dropdownLabelVariants,
+  dropdownLoadingVariants,
+  dropdownSeparatorVariants,
+  dropdownSpinnerVariants,
+  dropdownSubContentVariants,
+  dropdownSubTriggerVariants,
+  dropdownTriggerVariants
+} from './types';
+
+type DropdownRenderableBase = {
+  key: string;
+};
+
+type DropdownRenderableItem = DropdownItem & DropdownRenderableBase;
+type DropdownRenderableSeparator = DropdownSeparator & DropdownRenderableBase;
+type DropdownRenderableLabel = DropdownLabel & DropdownRenderableBase & { labelId: string };
+type DropdownRenderableSubmenu = Omit<DropdownSubmenu, 'items'> &
+  DropdownRenderableBase & {
+    items: DropdownRenderableElement[];
+    submenuId: string;
+  };
+
+export type DropdownRenderableElement =
+  | DropdownRenderableItem
+  | DropdownRenderableSeparator
+  | DropdownRenderableLabel
+  | DropdownRenderableSubmenu;
+
+type DropdownContentProps = {
+  align: DropdownAlign;
+  avoidCollisions: true;
+  className: string;
+  side: NonNullable<DropdownProps['position']>;
+  sideOffset: number;
+  role: 'menu';
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+};
+
+type UseDropdownReturn = {
+  contentProps: DropdownContentProps;
+  elements: DropdownRenderableElement[];
+  loading: boolean;
+  loadingClassName: string;
+  loadingLabel: string;
+  spinnerClassName: string;
+  triggerProps: ComponentProps<'button'>;
+  getItemProps: (element: DropdownRenderableItem) => {
+    'aria-disabled': true | undefined;
+    className: string;
+    disabled: boolean | undefined;
+    onSelect: (event: Event) => void;
+  };
+  getLabelProps: (element: DropdownRenderableLabel) => {
+    className: string;
+    id: string;
+  };
+  getSeparatorProps: () => {
+    className: string;
+  };
+  getSubContentProps: (element: DropdownRenderableSubmenu) => {
+    className: string;
+    id: string;
+    sideOffset: number;
+  };
+  getSubTriggerProps: (element: DropdownRenderableSubmenu) => {
+    'aria-controls': string;
+    'aria-haspopup': 'menu';
+    className: string;
+  };
+};
+
+const getElementKey = ({
+  element,
+  index,
+  prefix
+}: {
+  element: DropdownElement;
+  index: number;
+  prefix: string;
+}): string => element.id ?? `${prefix}-${element.type}-${index}`;
+
+const normalizeDropdownElements = ({
+  items,
+  prefix
+}: {
+  items: DropdownSchema;
+  prefix: string;
+}): DropdownRenderableElement[] => {
+  return items.map((element, index) => {
+    const key = getElementKey({ element, index, prefix });
+
+    switch (element.type) {
+      case 'submenu':
+        return {
+          ...element,
+          key,
+          submenuId: `${key}-submenu`,
+          items: normalizeDropdownElements({ items: element.items, prefix: key })
+        };
+      case 'label':
+        return {
+          ...element,
+          key,
+          labelId: `${key}-label`
+        };
+      default:
+        return {
+          ...element,
+          key
+        };
+    }
+  });
+};
+
+const getFirstLabel = (items: DropdownRenderableElement[]): DropdownRenderableLabel | undefined => {
+  const firstElement = items.find((element) => element.type === 'label');
+
+  if (firstElement?.type === 'label') {
+    return firstElement;
+  }
+
+  return undefined;
+};
+
+const getExplicitAriaLabel = ({
+  ariaLabel,
+  nativeAriaLabel
+}: {
+  ariaLabel: string | undefined;
+  nativeAriaLabel: string | undefined;
+}): string | undefined => ariaLabel ?? nativeAriaLabel;
 
 export const useDropdown = ({
-  items = [],
+  items,
   loading = false,
   closeOnSelect = true,
   position = 'bottom',
   align = 'start',
   offset = 0,
   width = 'auto',
-  className = ''
-}: DropdownProps) => {
-  const marginClasses = {
-    top: 'mb-2',
-    bottom: 'mt-2',
-    left: 'mr-2',
-    right: 'ml-2'
-  };
-
-  const firstLabelId = items.find((item) => item.type === 'label')?.label
-    ? `dropdown-label-${items.findIndex((item) => item.type === 'label')}`
-    : undefined;
-  const fallbackId = 'dropdown-fallback-label';
-  const accessibleLabelId = firstLabelId || fallbackId;
+  className,
+  ariaLabel,
+  'aria-label': nativeAriaLabel,
+  ...triggerProps
+}: DropdownProps): UseDropdownReturn => {
+  const generatedId = useId().replaceAll(':', '');
+  const prefix = `dropdown-${generatedId}`;
+  const elements = normalizeDropdownElements({ items, prefix });
+  const firstLabel = getFirstLabel(elements);
+  const explicitAriaLabel = getExplicitAriaLabel({
+    ariaLabel,
+    nativeAriaLabel
+  });
 
   return {
-    items,
+    elements,
     loading,
-    closeOnSelect,
-    position,
-    align,
-    offset,
-    width,
-    className,
-    accessibleLabelId,
-    marginClasses,
-    firstLabelId,
-    fallbackId
+    triggerProps: {
+      ...triggerProps,
+      type: 'button',
+      className: dropdownTriggerVariants(),
+      'aria-label': explicitAriaLabel
+    },
+    contentProps: {
+      role: 'menu',
+      side: position,
+      align,
+      sideOffset: offset,
+      avoidCollisions: true,
+      className: cn(dropdownContentVariants({ width, side: position }), className),
+      'aria-labelledby': firstLabel?.labelId,
+      'aria-label': firstLabel ? undefined : (explicitAriaLabel ?? 'Dropdown menu')
+    },
+    loadingClassName: dropdownLoadingVariants(),
+    spinnerClassName: dropdownSpinnerVariants(),
+    loadingLabel: 'Loading menu items',
+    getItemProps: (element) => ({
+      disabled: element.disabled,
+      'aria-disabled': element.disabled || undefined,
+      className: dropdownItemVariants({ variant: element.variant }),
+      onSelect: (event) => {
+        if (closeOnSelect === false) {
+          event.preventDefault();
+        }
+
+        element.onClick?.();
+      }
+    }),
+    getSubTriggerProps: (element) => ({
+      'aria-haspopup': 'menu',
+      'aria-controls': element.submenuId,
+      className: dropdownSubTriggerVariants()
+    }),
+    getSubContentProps: (element) => ({
+      id: element.submenuId,
+      sideOffset: offset,
+      className: dropdownSubContentVariants()
+    }),
+    getSeparatorProps: () => ({
+      className: dropdownSeparatorVariants()
+    }),
+    getLabelProps: (element) => ({
+      id: element.labelId,
+      className: dropdownLabelVariants()
+    })
   };
 };


### PR DESCRIPTION
## Summary

Completes the Dropdown atom review checklist by tightening typing, moving visual variants into CVA, improving accessibility behavior, and refreshing stories/tests.

Closes #127

## Type of change

- [ ] 🧩 New component
- [x] 🐛 Bug fix
- [ ] 🎨 Design tokens
- [ ] ♿ Accessibility
- [ ] 🏗️ Infrastructure
- [ ] 📚 Documentation

## Repository checklist

- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`
- [x] Commit messages follow the same commitlint-enforced format
- [x] PR description links the issue with `Closes #NNN`
- [x] Security checks pass, or any false positives are documented in the PR

## Component checklist (skip if not applicable)

- [x] Follows the 5-file structure (`types.ts`, `use*.ts`, `Component.tsx`, `index.ts`, `*.stories.tsx`)
- [x] CVA variants defined in `types.ts`, not inline
- [x] No hardcoded colors — uses tokens from `theme.css`
- [x] No `any` types — TypeScript strict
- [x] ARIA attributes present and correct
- [x] Keyboard navigable (Tab, Enter, Escape where applicable)
- [x] Dark mode works correctly
- [x] Storybook stories cover: default, variants, states (hover, focus, disabled)
- [x] Tests added or updated

## Changes

| File | Change |
|------|--------|
| `src/components/atoms/dropdown/types.ts` | Adds Dropdown CVA variants, tokenized width variants, typed schema props, and corrected visual tokens. |
| `src/components/atoms/dropdown/useDropdown.ts` | Moves Dropdown logic, ARIA labeling, normalized elements, and Radix prop getters into the hook. |
| `src/components/atoms/dropdown/Dropdown.tsx` | Converts to named export and thinner presentational Radix rendering. |
| `src/components/atoms/dropdown/Dropdown.test.tsx` | Adds hook/component coverage for defaults, ARIA, keyboard, loading, disabled items, submenu, and close-on-select behavior. |
| `src/components/atoms/dropdown/Dropdown.stories.tsx` | Rewrites docs/stories, restores the item schema usage guide, and aligns triggers with Button/IconButton visuals. |
| `src/components/atoms/dropdown/index.ts` | Exports the named Dropdown component. |

## How to test

- [x] `pnpm exec biome check src/components/atoms/dropdown`
- [x] `pnpm exec vitest run src/components/atoms/dropdown/Dropdown.test.tsx`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run build`
- [x] pre-push test hook: 19 files / 269 tests passed
- [x] Storybook visual smoke for Dropdown trigger/menu in light and dark mode

## Screenshots / recordings (if applicable)

Not attached. Visual smoke was performed locally in Storybook.

## Notes for reviewer

- `width` is now tokenized (`auto | sm | md | lg | full`) to avoid arbitrary inline sizing and keep the component on design-system tokens.
- Dropdown story triggers intentionally use `buttonVariants` / `iconButtonVariants` classes instead of rendering `Button` / `IconButton` directly, because Dropdown wraps its child in a Radix trigger button and direct Button usage would nest buttons.
