### PR TITLE
fix(test): normalize path separators for Windows compatibility

### DIFF
--- a/src/storybook-explicit-examples.test.ts
+++ b/src/storybook-explicit-examples.test.ts
@@ -48,7 +48,7 @@ const findMapViolationsInSourceFile = (sourceFile: ts.SourceFile): StoryMapViola
       if (mapPropertyName !== undefined) {
         const { line, character } = sourceFile.getLineAndCharacterOfPosition(mapPropertyName.getStart(sourceFile));
         violations.push({
-          file: relative(root, sourceFile.fileName),
+          file: relative(root, sourceFile.fileName).replaceAll('\\', '/'),
           line: line + 1,
           column: character + 1
         });


### PR DESCRIPTION
Closes #214

## Summary
- Normalize path separators in `storybook-explicit-examples.test.ts` so the test passes on both Windows and Unix

## Changes

| File | Change |
|------|--------|
| `src/storybook-explicit-examples.test.ts` | Added `.replaceAll('\\', '/')` to normalize `path.relative()` output |

## Root cause
Node's `path.relative()` returns OS-specific separators: `\` on Windows, `/` on Unix. The test expected `/` hardcoded, causing failure on Windows.

## Test plan
- [x] `pnpm test -- --run src/storybook-explicit-examples.test.ts` passes on Windows
- [x] All 299 tests pass (20 test files)
- [x] No production code changed — test-only fix
