### PR TITLE
ci: run tests on ubuntu and windows matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,11 @@ on:
 
 jobs:
   test:
-    name: Run tests
-    runs-on: ubuntu-latest
+    name: Run tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
     name: Run tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
 


### PR DESCRIPTION
Closes #216

## Summary
- Add matrix strategy to `test.yml` so tests run on both `ubuntu-latest` and `windows-latest`
- Prevents cross-platform bugs (like #214) from reaching main undetected

## Changes

| File | Change |
|------|--------|
| `.github/workflows/test.yml` | Added `strategy.matrix.os` with ubuntu-latest and windows-latest |

## Motivation
PR #215 fixed a Windows-specific path separator bug that CI never caught because tests only ran on Ubuntu. This change ensures every PR is validated on both platforms.

## Test plan
- [x] All 269 tests pass on Windows (local run)
- [x] Lefthook pre-commit and pre-push hooks pass
- [x] No production code changed — CI config only
