### PR TITLE
fix(input): complete atom review

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.ts whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol
 *.tsx whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol
+*.css whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol

--- a/src/components/atoms/input/Input.stories.tsx
+++ b/src/components/atoms/input/Input.stories.tsx
@@ -1,23 +1,20 @@
+import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Icon } from '../icon';
 import { Text } from '../text';
-import { Input } from './index';
+import { Input } from './Input';
 
 /**
- * ## DESCRIPTION
- * The Input component is a versatile form element that allows users to enter text or other data.
- * It supports various input types, styles, and configurations to suit different use cases.
- * It can be used for text, email, password, number inputs, and more.
- * The component also supports features like labels, placeholders, hints, and different visual styles.
- * It can be customized with rounded corners, different sizes, and variants such as regular, underlined, line, and bordered.
- * Additionally, it can handle controlled and uncontrolled values, making it flexible for both simple and complex forms.
- * It also supports start and end content, allowing for additional elements like icons or text to be displayed alongside the input.
- * The Input component is designed to be accessible and user-friendly, providing a consistent experience across different devices and screen sizes.
- * It can be easily integrated into forms and other UI components, making it a fundamental building block for web applications.
+ * ## Description
+ * Input lets users enter and edit short form values. It supports labels, placeholders, validation hints,
+ * adornments, native input attributes, and token-backed visual variants for common form layouts.
  *
- * ## DEPENDENCIES
- * - Icon: Uses Icon component from `lucide-react` for icons.
- * - Text: Uses Text component for displaying labels and hints.
+ * ## Dependencies
+ * Uses `Icon` for inline adornment and validation status examples. Uses `Text` to show text adornments.
+ *
+ * ## Usage Guide
+ * Provide a visible `label` when possible. When a visual label is not appropriate, pass `aria-label` or
+ * `aria-labelledby` so the input still has an accessible name.
  */
 const meta: Meta<typeof Input> = {
   title: 'Atoms/Input',
@@ -29,301 +26,213 @@ const meta: Meta<typeof Input> = {
   },
   tags: ['autodocs']
 };
-export default meta;
 
+export default meta;
 type Story = StoryObj<typeof Input>;
 
+/**
+ * Shows the default input configuration using its default visual variants.
+ */
 export const Default: Story = {
   args: {
-    id: 'input',
-    label: 'Lorem Ipsum',
-    type: 'text',
-    variant: 'regular',
-    rounded: false,
-    className: '',
-    size: 'md',
-    disabled: false,
-    isFullWidth: false,
-    isRequired: false
+    id: 'input-default',
+    label: 'Email',
+    placeholder: 'name@example.com',
+    onChange: action('change')
   }
 };
 
 /**
- * - **Controlled Input**: The value of the input is managed by React state. Changes to the input value are handled through an `onChange` event, allowing for immediate updates and validation.
+ * Shows the underlined visual variant.
  */
-
-export const ControlledValue: Story = {
-  parameters: {
-    docs: {
-      source: {
-        language: 'tsx',
-        code: `
-import { useState, type ChangeEvent } from 'react';
-import Input from './Input';
-      
-const ControlledInput = () => {
-  const [value, setValue] = useState('Controlled Value');
-
-  const handleChange = (e: ChangeEvent<HTMLInputElement>, value) => {
-    setValue(value);
-    console.log(value);
+export const Underlined: Story = {
+  args: {
+    ...Default.args,
+    id: 'input-underlined',
+    variant: 'underlined'
   }
-  
-  return (
-    <Input
-      id='controlled-input'
-      label='Controlled Input'
-      value={value}
-      onChange={handleChange}
-      variant='regular'
-      size='md'
-    />
-  );
-}
-`
-      }
-    }
-  },
+};
+
+/**
+ * Shows the single-line visual variant.
+ */
+export const Line: Story = {
+  args: {
+    ...Default.args,
+    id: 'input-line',
+    variant: 'line'
+  }
+};
+
+/**
+ * Shows the bordered visual variant.
+ */
+export const Bordered: Story = {
+  args: {
+    ...Default.args,
+    id: 'input-bordered',
+    variant: 'bordered'
+  }
+};
+
+/**
+ * Shows the available size axis without mixing other variants.
+ */
+export const Sizes: Story = {
   render: () => (
-    <div className='flex items-center gap-4'>
-      <Input id='input1' label='Lorem Ipsum' variant='regular' size='md' />
+    <div className='flex flex-col gap-4'>
+      <Input id='input-size-sm' label='Small' size='sm' defaultValue='Small value' onChange={action('small change')} />
+      <Input
+        id='input-size-md'
+        label='Medium'
+        size='md'
+        defaultValue='Medium value'
+        onChange={action('medium change')}
+      />
+      <Input id='input-size-lg' label='Large' size='lg' defaultValue='Large value' onChange={action('large change')} />
     </div>
   )
 };
 
 /**
- * - **Uncontrolled Input**: The input value is not managed by React state. Instead, it uses a `defaultValue` prop to set the initial value, and changes are logged through an `onChange` event.
+ * Shows the rounded shape axis.
  */
-
-export const UncontrolledValue: Story = {
-  parameters: {
-    docs: {
-      source: {
-        language: 'tsx',
-        code: `
-import { useState, type ChangeEvent } from 'react';
-import Input from './Input';
-      
-const UncontrolledInput = () => {
-  const handleChange = (e: ChangeEvent<HTMLInputElement>, value: string) => {
-    console.log(value);
-  };
-
-  return (
-    <Input
-      id='controlled-input'
-      label='Controlled Input'
-      defaultValue={'Uncontrolled Value'}
-      onChange={handleChange}
-      variant='regular'
-      size='md'
-    />
-  );
-}
-`
-      }
-    }
-  },
-  render: () => (
-    <div className='flex items-center gap-4'>
-      <Input id='input2' label='Lorem Ipsum' variant='regular' size='md' />
-    </div>
-  )
+export const Rounded: Story = {
+  args: {
+    ...Default.args,
+    id: 'input-rounded',
+    rounded: true
+  }
 };
 
 /**
- * - You can use isRequired to indicate that the input field is mandatory.
- * - This will add an asterisk (*) next to the label to indicate that the field is required.
+ * Shows required field affordance and native required semantics.
  */
 export const Required: Story = {
-  render: () => (
-    <div className='flex items-center gap-4'>
-      <Input id='input38' label='Lorem Ipsum' variant='regular' size='md' isRequired={true} />
-      <Input id='input39' label='Lorem Ipsum' variant='regular' size='lg' isRequired={true} />
-    </div>
-  )
-};
-/**
- * - A standard input field with a solid background.
- */
-
-export const Regular: Story = {
-  render: () => (
-    <div className='flex items-center gap-4'>
-      <Input id='input3' label='Lorem Ipsum' variant='regular' size='sm' />
-      <Input id='input4' label='Lorem Ipsum' variant='regular' size='md' />
-      <Input id='input5' label='Lorem Ipsum' variant='regular' size='lg' />
-    </div>
-  )
+  args: {
+    ...Default.args,
+    id: 'input-required',
+    isRequired: true
+  }
 };
 
 /**
- * - A variant with an underlined style, suitable for minimalistic designs.
- * - ⚠️ This variant uses a transparent background by default. To ensure proper visibility, place it inside a container with a solid or plain background.
+ * Shows validation and helper hint tones.
  */
-
-export const Underlined: Story = {
+export const HintStates: Story = {
   render: () => (
-    <div className='flex items-center gap-4'>
-      <Input id='input6' label='Lorem Ipsum' variant='underlined' size='sm' />
-      <Input id='input7' label='Lorem Ipsum' variant='underlined' size='md' />
-      <Input id='input8' label='Lorem Ipsum' variant='underlined' size='lg' />
+    <div className='flex flex-col gap-4'>
+      <Input id='input-hint-error' label='Error' hint={{ type: 'error', message: 'This field is required.' }} />
+      <Input id='input-hint-warning' label='Warning' hint={{ type: 'warning', message: 'Double-check this value.' }} />
+      <Input id='input-hint-success' label='Success' hint={{ type: 'success', message: 'Looks good.' }} />
+      <Input id='input-hint-info' label='Info' hint={{ type: 'info', message: 'Use your primary email.' }} />
     </div>
   )
 };
 
 /**
- * - A variant with a line style, providing a clean and modern look.
- * - ⚠️ This variant uses a transparent background by default. To ensure proper visibility, place it inside a container with a solid or plain background.
+ * Shows the non-interactive disabled state.
  */
-
-export const Line: Story = {
-  render: () => (
-    <div className='flex items-center gap-4'>
-      <Input id='input9' label='Lorem Ipsum' variant='line' size='sm' />
-      <Input id='input10' label='Lorem Ipsum' variant='line' size='md' />
-      <Input id='input11' label='Lorem Ipsum' variant='line' size='lg' />
-    </div>
-  )
-};
-
-/**
- * - A bordered variant that provides a distinct outline around the input field.
- */
-
-export const Bordered: Story = {
-  render: () => (
-    <div className='flex items-center gap-4'>
-      <Input id='input12' label='Lorem Ipsum' variant='bordered' size='sm' />
-      <Input id='input13' label='Lorem Ipsum' variant='bordered' size='md' />
-      <Input id='input14' label='Lorem Ipsum' variant='bordered' size='lg' />
-    </div>
-  )
-};
-
-/**
- * - A variant with rounded corners for a softer appearance.
- * - This variant can be applied to any of the input styles (regular, underlined, line, bordered).
- */
-
-export const Rounded: Story = {
-  render: () => (
-    <div className='flex flex-col justify-center gap-4'>
-      <Input id='input15' label='Lorem Ipsum' variant='regular' rounded={true} />
-      <Input id='input16' label='Lorem Ipsum' variant='underlined' rounded={true} />
-      <Input id='input17' label='Lorem Ipsum' variant='line' rounded={true} />
-      <Input id='input18' label='Lorem Ipsum' variant='bordered' rounded={true} />
-    </div>
-  )
-};
-
-/**
- * - Input fields for number inputs, allowing users to enter numeric values.
- */
-
-export const InputNumber: Story = {
-  render: () => (
-    <div className='flex flex-col justify-center gap-4'>
-      <Input id='input19' label='Lorem Ipsum' variant='regular' type='number' />
-      <Input id='input20' label='Lorem Ipsum' variant='underlined' type='number' />
-      <Input id='input21' label='Lorem Ipsum' variant='line' type='number' />
-      <Input id='input22' label='Lorem Ipsum' variant='bordered' type='number' />
-    </div>
-  )
-};
-
-/**
- * - Input fields specifically for password entry, which typically include features like masking the input.
- */
-
-export const InputPassword: Story = {
-  render: () => (
-    <div className='flex flex-col justify-center gap-4'>
-      <Input id='input23' label='Lorem Ipsum' variant='regular' type='password' />
-      <Input id='input24' label='Lorem Ipsum' variant='underlined' type='password' />
-      <Input id='input25' label='Lorem Ipsum' variant='line' type='password' />
-      <Input id='input26' label='Lorem Ipsum' variant='bordered' type='password' />
-    </div>
-  )
-};
-
-/**
- * - Input fields with hints to provide additional context or instructions to the user.
- * - Hints can be styled based on their type (error, warning, success, info).
- * - ⚠️ This variant uses a transparent background by default. To ensure proper visibility, place it inside a container with a solid or plain background.
- */
-
-export const Hint: Story = {
-  render: () => (
-    <div className='flex flex-col justify-center gap-4'>
-      <Input id='input27' label='Lorem Ipsum' variant='regular' hint={{ type: 'error', message: 'Lorem ipsum' }} />
-      <Input id='input28' label='Lorem Ipsum' variant='regular' hint={{ type: 'warning', message: 'Lorem ipsum' }} />
-      <Input id='input29' label='Lorem Ipsum' variant='regular' hint={{ type: 'success', message: 'Lorem ipsum' }} />
-      <Input id='input30' label='Lorem Ipsum' variant='regular' hint={{ type: 'info', message: 'Lorem ipsum' }} />
-    </div>
-  )
-};
-
-/**
- * - Disabled input fields that cannot be interacted with.
- * - Useful for indicating that a field is not currently available for input.
- */
-
 export const Disabled: Story = {
+  args: {
+    ...Default.args,
+    id: 'input-disabled',
+    disabled: true
+  }
+};
+
+/**
+ * Shows the password input with an accessible visibility toggle.
+ */
+export const Password: Story = {
+  args: {
+    id: 'input-password',
+    label: 'Password',
+    type: 'password',
+    onChange: action('password change')
+  }
+};
+
+/**
+ * Shows number input controls.
+ */
+export const NumberInput: Story = {
+  args: {
+    id: 'input-number',
+    label: 'Quantity',
+    type: 'number',
+    defaultValue: 1,
+    onChange: action('number change')
+  }
+};
+
+/**
+ * Shows common native input type variants.
+ */
+export const TypeVariants: Story = {
   render: () => (
-    <div className='flex flex-col justify-center items-center gap-4'>
-      <Input id='input31' label='Lorem Ipsum' variant='regular' disabled={true} />
-      <Input id='input32' label='Lorem Ipsum' variant='underlined' disabled={true} />
-      <Input id='input33' label='Lorem Ipsum' variant='line' disabled={true} />
-      <Input id='input34' label='Lorem Ipsum' variant='bordered' disabled={true} />
+    <div className='flex flex-col gap-4'>
+      <Input id='input-type-text' label='Text' type='text' onChange={action('text change')} />
+      <Input id='input-type-email' label='Email' type='email' onChange={action('email change')} />
+      <Input id='input-type-tel' label='Phone' type='tel' onChange={action('phone change')} />
+      <Input id='input-type-url' label='Website' type='url' onChange={action('url change')} />
+      <Input id='input-type-search' label='Search' type='search' onChange={action('search change')} />
     </div>
   )
 };
 
 /**
- * - Input fields with additional content at the start or end, such as icons or text.
- * - This can enhance the usability and visual appeal of the input field.
+ * Shows start and end content slots for prefixes, suffixes, and icons.
  */
-
-export const StartAndEnd: Story = {
+export const StartAndEndContent: Story = {
   render: () => (
     <div className='flex flex-col gap-4'>
       <Input
-        id='input35'
-        placeholder='Placeholder'
-        variant='regular'
+        id='input-start-end-text'
+        label='Amount'
+        placeholder='0.00'
         startContent={
-          <Text tag='p' className='pt-[2px]'>
-            Start
+          <Text tag='small' className='font-medium text-text-secondary-light dark:text-text-secondary-dark'>
+            $
           </Text>
         }
         endContent={
-          <Text tag='p' className='pt-[2px]'>
-            End
+          <Text tag='small' className='font-medium text-text-secondary-light dark:text-text-secondary-dark'>
+            USD
           </Text>
         }
+        onChange={action('amount change')}
       />
       <Input
-        id='input36'
+        id='input-start-end-icon'
         type='email'
-        placeholder='Placeholder'
-        startContent={<Icon name='mail' color='text-color-text-light' colorDark='dark:text-color-text-dark' />}
+        label='Email'
+        startContent={<Icon name='mail' tone='muted' decorative={true} />}
         endContent={
-          <Text tag='p' className='pt-[2px]'>
-            @gmail.com
+          <Text tag='small' className='font-medium text-text-secondary-light dark:text-text-secondary-dark'>
+            @example.com
           </Text>
         }
-      />
-      <Input
-        id='input37'
-        type='url'
-        placeholder='Placeholder'
-        startContent={
-          <Text tag='p' className='pt-[2px]'>
-            https://
-          </Text>
-        }
+        onChange={action('email change')}
       />
     </div>
   )
+};
+
+/**
+ * Shows full-width layout behavior.
+ */
+export const FullWidth: Story = {
+  args: {
+    ...Default.args,
+    id: 'input-full-width',
+    isFullWidth: true
+  },
+  decorators: [
+    (StoryComponent) => (
+      <div className='w-full max-w-modal-md'>
+        <StoryComponent />
+      </div>
+    )
+  ]
 };

--- a/src/components/atoms/input/Input.test.tsx
+++ b/src/components/atoms/input/Input.test.tsx
@@ -1,0 +1,223 @@
+import { render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+// --- Mocks (declared before component import) ---
+
+vi.mock('lucide-react/dynamic.js', () => ({
+  // biome-ignore lint/style/useNamingConvention: must match library export name
+  DynamicIcon: () => null
+}));
+
+// --- Imports after mocks ---
+
+import { Input } from './Input';
+import { useInput } from './useInput';
+
+// ─────────────────────────────────────────────
+// HOOK TESTS — useInput
+// ─────────────────────────────────────────────
+
+describe('useInput — logic', () => {
+  it('uses text type by default', () => {
+    const { result } = renderHook(() => useInput({ id: 'input', label: 'Name' }));
+    expect(result.current.inputProps.type).toBe('text');
+  });
+
+  it('does not convert non-password inputs to password', () => {
+    const { result } = renderHook(() => useInput({ id: 'input', label: 'Name', type: 'email' }));
+    expect(result.current.inputProps.type).toBe('email');
+  });
+
+  it('derives aria-labelledby from the visible label', () => {
+    const { result } = renderHook(() => useInput({ id: 'email', label: 'Email' }));
+    expect(result.current.inputProps['aria-labelledby']).toBe('email-label');
+  });
+
+  it('derives aria-describedby from hint content', () => {
+    const { result } = renderHook(() =>
+      useInput({ id: 'email', label: 'Email', hint: { type: 'error', message: 'Required' } })
+    );
+    expect(result.current.inputProps['aria-describedby']).toBe('email-hint');
+  });
+
+  it('uses placeholder as an accessible name when no label or aria name is provided', () => {
+    const { result } = renderHook(() => useInput({ id: 'search', placeholder: 'Search products' }));
+    expect(result.current.inputProps['aria-label']).toBe('Search products');
+  });
+
+  it('updates floating-label state when controlled value changes after mount', () => {
+    const { result, rerender } = renderHook(({ value }) => useInput({ id: 'name', label: 'Name', value }), {
+      initialProps: { value: '' }
+    });
+
+    expect(result.current.labelProps.className).toContain('top-1/2');
+
+    rerender({ value: 'Alice' });
+
+    expect(result.current.labelProps.className).not.toContain('top-1/2');
+  });
+
+  it('floats visible labels and adds vertical content spacing when start adornments are present', () => {
+    const { result } = renderHook(() =>
+      useInput({ id: 'email', label: 'Email', startContent: 'https://', endContent: '.com' })
+    );
+
+    expect(result.current.labelProps.className).not.toContain('top-1/2');
+    expect(result.current.labelProps.className).toContain('left-4');
+    expect(result.current.labelProps.className).not.toContain('left-12');
+    expect(result.current.contentClassName).toContain('translate-y-2');
+    expect(result.current.contentClassName).not.toContain('pl-1');
+  });
+
+  it('uses a smaller floating label for the compact size', () => {
+    const { result } = renderHook(() => useInput({ id: 'email', label: 'Email', size: 'sm', placeholder: 'Email' }));
+
+    expect(result.current.labelProps.className).toContain('top-0.5');
+    expect(result.current.labelProps.className).toContain('fs-xs');
+  });
+
+  it('applies full width to the outer wrapper', () => {
+    const { result } = renderHook(() => useInput({ id: 'email', label: 'Email', isFullWidth: true }));
+
+    expect(result.current.wrapperClassName).toContain('w-full');
+  });
+
+  it('uses compact content spacing for the small size', () => {
+    const { result } = renderHook(() => useInput({ id: 'email', label: 'Email', size: 'sm', startContent: '$' }));
+
+    expect(result.current.containerProps.className).toContain('h-12');
+    expect(result.current.containerProps.className).toContain('px-3');
+    expect(result.current.contentClassName).toContain('gap-2');
+    expect(result.current.adornmentClassName).toContain('fs-small');
+  });
+});
+
+// ─────────────────────────────────────────────
+// COMPONENT TESTS — Input
+// ─────────────────────────────────────────────
+
+describe('Input — component behavior', () => {
+  it('renders an input with a visible label', () => {
+    render(<Input id='email' label='Email' />);
+    expect(screen.getByRole('textbox', { name: 'Email' })).toBeInTheDocument();
+  });
+
+  it('calls onChange with the event and next value', async () => {
+    const handleChange = vi.fn();
+    render(<Input id='name' label='Name' onChange={handleChange} />);
+
+    await userEvent.type(screen.getByRole('textbox', { name: 'Name' }), 'Ana');
+
+    expect(handleChange.mock.lastCall?.[1]).toBe('Ana');
+  });
+
+  it('sets required and aria-required when isRequired is true', () => {
+    render(<Input id='email' label='Email' isRequired={true} />);
+    const input = screen.getByRole('textbox', { name: /Email/i });
+
+    expect(input).toBeRequired();
+    expect(input).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('honors the native required prop', () => {
+    render(<Input id='email' label='Email' required={true} />);
+    expect(screen.getByRole('textbox', { name: 'Email' })).toBeRequired();
+  });
+
+  it('sets invalid and describedby when an error hint is provided', () => {
+    render(<Input id='email' label='Email' hint={{ type: 'error', message: 'Invalid email' }} />);
+    const input = screen.getByRole('textbox', { name: 'Email' });
+
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAccessibleDescription('Invalid email');
+  });
+
+  it('merges custom aria-describedby with the rendered hint', () => {
+    render(
+      <div>
+        <span id='external-description'>External description</span>
+        <Input
+          id='email'
+          label='Email'
+          aria-describedby='external-description'
+          hint={{ type: 'error', message: 'Invalid email' }}
+        />
+      </div>
+    );
+
+    expect(screen.getByRole('textbox', { name: 'Email' })).toHaveAccessibleDescription(
+      'External description Invalid email'
+    );
+  });
+
+  it('is disabled when disabled is true', () => {
+    render(<Input id='email' label='Email' disabled={true} />);
+    const input = screen.getByRole('textbox', { name: 'Email' });
+
+    expect(input).toBeDisabled();
+    expect(input).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('toggles password visibility with an accessible button', async () => {
+    render(<Input id='password' label='Password' type='password' />);
+    const input = screen.getByLabelText('Password');
+    const toggle = screen.getByRole('button', { name: 'Show password' });
+
+    expect(input).toHaveAttribute('type', 'password');
+
+    await userEvent.click(toggle);
+
+    expect(input).toHaveAttribute('type', 'text');
+    expect(screen.getByRole('button', { name: 'Hide password' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('renders number step buttons as non-submit controls', async () => {
+    render(<Input id='quantity' label='Quantity' type='number' defaultValue={1} />);
+    const input = screen.getByRole('spinbutton', { name: 'Quantity' });
+    const increase = screen.getByRole('button', { name: 'Increase value' });
+    const decrease = screen.getByRole('button', { name: 'Decrease value' });
+
+    expect(increase).toHaveAttribute('type', 'button');
+    expect(decrease).toHaveAttribute('type', 'button');
+
+    await userEvent.click(increase);
+    expect(input).toHaveValue(2);
+
+    await userEvent.click(decrease);
+    expect(input).toHaveValue(1);
+  });
+
+  it('honors native step, min, and max with number controls', async () => {
+    render(<Input id='quantity' label='Quantity' type='number' defaultValue={0.5} min={0} max={1} step={0.5} />);
+    const input = screen.getByRole('spinbutton', { name: 'Quantity' });
+    const increase = screen.getByRole('button', { name: 'Increase value' });
+    const decrease = screen.getByRole('button', { name: 'Decrease value' });
+
+    await userEvent.click(increase);
+    expect(input).toHaveValue(1);
+
+    await userEvent.click(increase);
+    expect(input).toHaveValue(1);
+
+    await userEvent.click(decrease);
+    expect(input).toHaveValue(0.5);
+
+    await userEvent.click(decrease);
+    expect(input).toHaveValue(0);
+
+    await userEvent.click(decrease);
+    expect(input).toHaveValue(0);
+  });
+
+  it('supports native aria-labelledby overrides', () => {
+    render(
+      <div>
+        <span id='external-label'>External label</span>
+        <Input id='custom' aria-labelledby='external-label' />
+      </div>
+    );
+
+    expect(screen.getByRole('textbox', { name: 'External label' })).toBeInTheDocument();
+  });
+});

--- a/src/components/atoms/input/Input.test.tsx
+++ b/src/components/atoms/input/Input.test.tsx
@@ -104,10 +104,11 @@ describe('Input — component behavior', () => {
   });
 
   it('calls onChange with the event and next value', async () => {
+    const user = userEvent.setup();
     const handleChange = vi.fn();
     render(<Input id='name' label='Name' onChange={handleChange} />);
 
-    await userEvent.type(screen.getByRole('textbox', { name: 'Name' }), 'Ana');
+    await user.type(screen.getByRole('textbox', { name: 'Name' }), 'Ana');
 
     expect(handleChange.mock.lastCall?.[1]).toBe('Ana');
   });
@@ -131,6 +132,12 @@ describe('Input — component behavior', () => {
 
     expect(input).toHaveAttribute('aria-invalid', 'true');
     expect(input).toHaveAccessibleDescription('Invalid email');
+  });
+
+  it('preserves native aria-invalid values when no error hint is provided', () => {
+    render(<Input id='email' label='Email' aria-invalid='grammar' />);
+
+    expect(screen.getByRole('textbox', { name: 'Email' })).toHaveAttribute('aria-invalid', 'grammar');
   });
 
   it('merges custom aria-describedby with the rendered hint', () => {
@@ -160,19 +167,21 @@ describe('Input — component behavior', () => {
   });
 
   it('toggles password visibility with an accessible button', async () => {
+    const user = userEvent.setup();
     render(<Input id='password' label='Password' type='password' />);
     const input = screen.getByLabelText('Password');
     const toggle = screen.getByRole('button', { name: 'Show password' });
 
     expect(input).toHaveAttribute('type', 'password');
 
-    await userEvent.click(toggle);
+    await user.click(toggle);
 
     expect(input).toHaveAttribute('type', 'text');
     expect(screen.getByRole('button', { name: 'Hide password' })).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('renders number step buttons as non-submit controls', async () => {
+    const user = userEvent.setup();
     render(<Input id='quantity' label='Quantity' type='number' defaultValue={1} />);
     const input = screen.getByRole('spinbutton', { name: 'Quantity' });
     const increase = screen.getByRole('button', { name: 'Increase value' });
@@ -181,33 +190,65 @@ describe('Input — component behavior', () => {
     expect(increase).toHaveAttribute('type', 'button');
     expect(decrease).toHaveAttribute('type', 'button');
 
-    await userEvent.click(increase);
+    await user.click(increase);
     expect(input).toHaveValue(2);
 
-    await userEvent.click(decrease);
+    await user.click(decrease);
     expect(input).toHaveValue(1);
   });
 
   it('honors native step, min, and max with number controls', async () => {
+    const user = userEvent.setup();
     render(<Input id='quantity' label='Quantity' type='number' defaultValue={0.5} min={0} max={1} step={0.5} />);
     const input = screen.getByRole('spinbutton', { name: 'Quantity' });
     const increase = screen.getByRole('button', { name: 'Increase value' });
     const decrease = screen.getByRole('button', { name: 'Decrease value' });
 
-    await userEvent.click(increase);
+    await user.click(increase);
     expect(input).toHaveValue(1);
 
-    await userEvent.click(increase);
+    await user.click(increase);
     expect(input).toHaveValue(1);
 
-    await userEvent.click(decrease);
+    await user.click(decrease);
     expect(input).toHaveValue(0.5);
 
-    await userEvent.click(decrease);
+    await user.click(decrease);
     expect(input).toHaveValue(0);
 
-    await userEvent.click(decrease);
+    await user.click(decrease);
     expect(input).toHaveValue(0);
+  });
+
+  it('falls back to manual number controls when step is any', async () => {
+    const user = userEvent.setup();
+    render(<Input id='quantity' label='Quantity' type='number' defaultValue={1} min={0} max={2} step='any' />);
+    const input = screen.getByRole('spinbutton', { name: 'Quantity' });
+    const increase = screen.getByRole('button', { name: 'Increase value' });
+    const decrease = screen.getByRole('button', { name: 'Decrease value' });
+
+    await user.click(increase);
+    expect(input).toHaveValue(2);
+
+    await user.click(increase);
+    expect(input).toHaveValue(2);
+
+    await user.click(decrease);
+    expect(input).toHaveValue(1);
+  });
+
+  it('keeps status border precedence while focused', async () => {
+    const user = userEvent.setup();
+    render(<Input id='email' label='Email' hint={{ type: 'error', message: 'Invalid email' }} />);
+    const input = screen.getByRole('textbox', { name: 'Email' });
+
+    await user.click(input);
+
+    const containerClassName = input.closest('div.relative')?.className ?? '';
+    expect(containerClassName).toContain('!border-error-light');
+    expect(containerClassName.lastIndexOf('!border-error-light')).toBeGreaterThan(
+      containerClassName.lastIndexOf('!border-brand-light/50')
+    );
   });
 
   it('supports native aria-labelledby overrides', () => {

--- a/src/components/atoms/input/Input.tsx
+++ b/src/components/atoms/input/Input.tsx
@@ -1,269 +1,77 @@
-import type { VariantProps } from 'class-variance-authority';
-import type { ComponentProps, FC, RefObject } from 'react';
-import { cn } from '@/lib/utils';
+import type { FC } from 'react';
 import { Icon } from '../icon';
-import { type InputProps, inputVariants, labelVariants } from './types';
+import type { InputProps } from './types';
 import { useInput } from './useInput';
 
-const Input: FC<
-  Omit<VariantProps<typeof inputVariants>, 'state' | 'focused'> &
-    InputProps &
-    Omit<ComponentProps<'input'>, 'size' | 'id'> & {
-      ariaDescribedBy?: string | string[];
-      ariaLabelledBy?: string | string[];
-    }
-> = ({ ...props }) => {
+export const Input: FC<InputProps> = (props) => {
   const {
-    containerRef,
-    size,
-    rounded,
-    variant,
-    isFocused,
-    type,
-    isFullWidth,
-    label,
-    hint,
-    disabled,
-    className,
-    ref,
-    id,
-    hasValue,
-    placeholder,
-    startContent,
+    adornmentClassName,
+    containerProps,
+    contentClassName,
+    decrementButtonProps,
     endContent,
+    hasHint,
+    hasLabel,
+    hintIconProps,
+    hintMessage,
+    hintMessageClassName,
+    incrementButtonProps,
+    inputProps,
     isRequired,
-    formatAriaIds,
-    ariaDescribedBy,
-    ariaLabelledBy,
-    handleBlur,
-    handleChange,
-    handleFocus,
-    handleKeyDown,
-    showPassword,
-    value,
-    defaultValue,
-    setHasValue,
-    setShowPassword,
-    ...rest
+    label,
+    labelProps,
+    passwordButtonProps,
+    passwordIconName,
+    shouldRenderNumberControls,
+    shouldRenderPasswordToggle,
+    startContent,
+    stepButtonGroupClassName,
+    toggleButtonGroupClassName,
+    wrapperClassName
   } = useInput(props);
-  const getIconByHintType = (type: string) => {
-    switch (type) {
-      case 'error':
-        return <Icon name='circle-alert' color='text-color-error-light' colorDark='dark:text-color-error' size={16} />;
-      case 'warning':
-        return (
-          <Icon name='triangle-alert' color='text-color-warning-light' colorDark='dark:text-color-warning' size={16} />
-        );
-      case 'success':
-        return (
-          <Icon name='circle-check' color='text-color-success-light' colorDark='dark:text-color-success' size={16} />
-        );
-      default:
-        return (
-          <Icon
-            name='info'
-            color='text-color-text-tertiary-light'
-            colorDark='dark:text-color-text-tertiary-dark'
-            size={16}
-          />
-        );
-    }
-  };
-  const IncrementDecrementButtons = ({
-    ref,
-    setHasValue
-  }: {
-    ref: RefObject<HTMLInputElement>;
-    setHasValue: (value: boolean) => void;
-  }) => (
-    <div className='absolute right-2 top-0 bottom-0 flex flex-col justify-center items-center gap-[2px] z-10'>
-      <button
-        role='button'
-        aria-label='Increase value'
-        className='bg-surface-light hover:bg-surface-raised-light dark:bg-surface-dark dark:hover:bg-surface-raised-dark rounded-t-sm px-1 cursor-pointer focus-visible:outline-none focus-visible:shadow-glow-focus-light dark:focus-visible:shadow-glow-focus-dark'
-        onClick={() => {
-          if (ref.current) {
-            const currentValue = parseFloat(ref.current.value !== '' ? ref.current.value : '0');
-            ref.current.value = (currentValue + 1).toString();
-            setHasValue(!!ref.current.value);
-          }
-        }}
-      >
-        <Icon name='chevron-up' color='text-color-text-light' colorDark='dark:text-color-text-dark' size={16} />
-      </button>
-      <button
-        role='button'
-        aria-label='Decrease value'
-        className='bg-surface-light hover:bg-surface-raised-light dark:bg-surface-dark dark:hover:bg-surface-raised-dark rounded-b-sm px-1 cursor-pointer focus-visible:outline-none focus-visible:shadow-glow-focus-light dark:focus-visible:shadow-glow-focus-dark'
-        onClick={() => {
-          if (ref.current) {
-            const currentValue = parseFloat(ref.current.value !== '' ? ref.current.value : '0');
-            ref.current.value = (currentValue - 1).toString();
-            setHasValue(!!ref.current.value);
-          }
-        }}
-      >
-        <Icon name='chevron-down' color='text-color-text-light' colorDark='dark:text-color-text-dark' size={16} />
-      </button>
-    </div>
-  );
 
-  const PasswordToggleButton = ({
-    showPassword,
-    setShowPassword
-  }: {
-    showPassword: boolean;
-    setShowPassword: (value: boolean) => void;
-  }) => (
-    <div className='absolute right-2 top-0 bottom-0 flex flex-col justify-center items-center gap-[2px] z-10'>
-      <button
-        role='button'
-        aria-label={!showPassword ? 'Show password' : 'Hide password'}
-        className='cursor-pointer focus-visible:outline-none focus-visible:shadow-glow-focus-light dark:focus-visible:shadow-glow-focus-dark'
-        onClick={() => setShowPassword(!showPassword)}
-      >
-        <Icon
-          name={!showPassword ? 'eye' : 'eye-off'}
-          color='text-color-text-light'
-          colorDark='dark:text-color-text-dark'
-          className='hover:opacity-70'
-          size={20}
-        />
-      </button>
-    </div>
-  );
   return (
-    <div className={`flex flex-col gap-2${type === 'hidden' ? ' hidden' : ''}`}>
-      <div
-        ref={containerRef}
-        className={cn(
-          inputVariants({
-            size,
-            rounded,
-            variant,
-            state: !isFocused
-              ? variant === 'regular'
-                ? 'focusedRegular'
-                : variant === 'underlined'
-                  ? 'focusedUnderlined'
-                  : variant === 'line'
-                    ? 'focusedLine'
-                    : variant === 'bordered'
-                      ? 'focusedBordered'
-                      : 'default'
-              : 'default',
-            focused: isFocused
-          }),
-          isFullWidth ? 'w-full' : 'w-auto',
-          label ? 'items-end' : 'items-center',
-          hint?.type === 'error' &&
-            '!border-error-light dark:!border-error shadow-[0_0_0_3px_rgba(219,20,60,0.12)] dark:shadow-[0_0_0_3px_rgba(255,0,54,0.15)]',
-          hint?.type === 'warning' &&
-            '!border-warning-light dark:!border-warning shadow-[0_0_0_3px_rgba(251,191,36,0.15)]',
-          hint?.type === 'success' &&
-            '!border-success-light dark:!border-success shadow-[0_0_0_3px_rgba(34,197,94,0.15)]',
-          disabled && 'pointer-events-none opacity-40',
-          className
-        )}
-        onClick={() => {
-          if (
-            ref &&
-            typeof ref === 'object' &&
-            'current' in ref &&
-            ref.current &&
-            document.activeElement !== ref.current &&
-            type !== 'number' &&
-            type !== 'password'
-          ) {
-            ref.current.focus();
-          }
-        }}
-      >
-        <label
-          id={`${id}-label`}
-          htmlFor={id}
-          className={cn(
-            labelVariants({
-              size,
-              state:
-                isFocused || hasValue || placeholder
-                  ? size === 'sm'
-                    ? 'focusedSm'
-                    : size === 'md'
-                      ? 'focusedMd'
-                      : size === 'lg'
-                        ? 'focusedLg'
-                        : 'default'
-                  : 'default'
-            }),
-            startContent || (endContent && 'sr-only')
-          )}
-        >
-          {label}{' '}
-          {isRequired && (
-            <span className='text-color-brand-light' aria-hidden={true}>
-              *
-            </span>
-          )}
-        </label>
-        <div className='flex w-full justify-between gap-4'>
-          {startContent && startContent}
-          <input
-            {...rest}
-            ref={ref}
-            id={id}
-            type={type}
-            placeholder={placeholder}
-            disabled={disabled}
-            aria-disabled={disabled}
-            aria-invalid={hint?.type === 'error' ? 'true' : 'false'}
-            aria-describedby={formatAriaIds(ariaDescribedBy || (hint?.message ? `${id}-hint` : undefined))}
-            aria-labelledby={formatAriaIds(ariaLabelledBy || (label ? `${id}-label` : undefined))}
-            className={cn(
-              'flex-1 outline-none font-medium text-text-light dark:text-text-dark placeholder:text-text-muted-light dark:placeholder:text-text-muted-dark border-none',
-              (type === 'number' || type === 'password') && 'pr-6'
+    <div className={wrapperClassName}>
+      <div {...containerProps}>
+        {hasLabel && (
+          <label {...labelProps}>
+            {label}{' '}
+            {isRequired && (
+              <span className='text-brand-light dark:text-brand-dark' aria-hidden={true}>
+                *
+              </span>
             )}
-            onFocus={handleFocus}
-            onBlur={handleBlur}
-            onKeyDown={handleKeyDown}
-            onChange={handleChange}
-            required={isRequired}
-            aria-required={isRequired}
-            value={value}
-            defaultValue={defaultValue}
-          />
-          {type === 'number' && (
-            <IncrementDecrementButtons ref={ref as RefObject<HTMLInputElement>} setHasValue={setHasValue} />
+          </label>
+        )}
+        <div className={contentClassName}>
+          {startContent && <span className={adornmentClassName}>{startContent}</span>}
+          <input {...inputProps} />
+          {shouldRenderNumberControls && (
+            <div className={stepButtonGroupClassName}>
+              <button {...incrementButtonProps}>
+                <Icon name='chevron-up' tone='default' size={16} decorative={true} />
+              </button>
+              <button {...decrementButtonProps}>
+                <Icon name='chevron-down' tone='default' size={16} decorative={true} />
+              </button>
+            </div>
           )}
-          {type === 'password' && (
-            <PasswordToggleButton showPassword={showPassword} setShowPassword={setShowPassword} />
+          {shouldRenderPasswordToggle && (
+            <div className={toggleButtonGroupClassName}>
+              <button {...passwordButtonProps}>
+                <Icon name={passwordIconName} tone='default' size={20} decorative={true} />
+              </button>
+            </div>
           )}
-          {endContent && endContent}
+          {endContent && <span className={adornmentClassName}>{endContent}</span>}
         </div>
       </div>
-      {hint?.message && (
-        <div id={`${id}-hint`} className='py-0.5 flex items-center gap-2'>
-          {getIconByHintType(hint?.type)}
-          <span
-            className={cn(
-              'fs-small',
-              hint?.type === 'info'
-                ? 'text-color-text-secondary-light dark:text-color-text-secondary-dark'
-                : hint?.type === 'warning'
-                  ? 'text-warning-light dark:text-warning'
-                  : hint?.type === 'error'
-                    ? 'text-error-light dark:text-error'
-                    : hint?.type === 'success'
-                      ? 'text-success-light dark:text-success'
-                      : 'text-color-text-secondary-light dark:text-color-text-secondary-dark'
-            )}
-          >
-            {hint.message}
-          </span>
+      {hasHint && (
+        <div id={`${props.id}-hint`} className='flex items-center gap-2 py-0.5'>
+          {hintIconProps && <Icon {...hintIconProps} decorative={true} />}
+          <span className={hintMessageClassName}>{hintMessage}</span>
         </div>
       )}
     </div>
   );
 };
-
-export default Input;

--- a/src/components/atoms/input/index.ts
+++ b/src/components/atoms/input/index.ts
@@ -1,2 +1,2 @@
-export { default as Input } from './Input';
+export { Input } from './Input';
 export * from './types';

--- a/src/components/atoms/input/types.ts
+++ b/src/components/atoms/input/types.ts
@@ -1,131 +1,220 @@
 import { cva, type VariantProps } from 'class-variance-authority';
-import type { ChangeEvent, ReactNode } from 'react';
+import type { ChangeEvent, ComponentProps, ReactNode } from 'react';
 
 export const inputVariants = cva(
   [
-    'relative overflow-hidden flex py-2 justify-between max-w-full',
-    'border transition-[border-color,box-shadow] duration-200 ease-[ease]'
+    'relative flex max-w-full justify-between overflow-hidden border py-2',
+    'cursor-text transition-[background,border-color,box-shadow] duration-200 ease-[ease]',
+    'focus-within:outline-none',
+    'disabled:pointer-events-none disabled:opacity-40 disabled:cursor-not-allowed'
   ],
   {
     variants: {
       variant: {
-        regular: ['bg-surface-light border-border-light', 'dark:bg-surface-dark dark:border-border-dark'],
-        underlined: ['bg-transparent border-border-light', 'dark:bg-transparent dark:border-border-dark'],
-        line: [
-          'bg-transparent',
-          'border-t-transparent',
-          'border-l-transparent',
-          'border-r-transparent',
-          'rounded-none!',
-          'border-b-border-light',
-          'dark:border-b-border-dark'
+        regular: [
+          'bg-surface-light border-border-light hover:bg-surface-raised-light hover:border-border-strong-light',
+          'dark:bg-surface-dark dark:border-border-dark dark:hover:bg-surface-raised-dark dark:hover:border-border-strong-dark'
         ],
-        bordered: ['bg-surface-light border-border-strong-light', 'dark:bg-surface-dark dark:border-border-strong-dark']
+        underlined: ['bg-transparent border-border-light hover:border-border-strong-light', 'dark:border-border-dark'],
+        line: [
+          'bg-transparent border-t-transparent border-l-transparent border-r-transparent rounded-none!',
+          'border-b-border-light hover:border-b-border-strong-light',
+          'dark:border-b-border-dark dark:hover:border-b-border-strong-dark'
+        ],
+        bordered: [
+          'bg-surface-light border-border-strong-light hover:bg-surface-raised-light',
+          'dark:bg-surface-dark dark:border-border-strong-dark dark:hover:bg-surface-raised-dark'
+        ]
       },
       rounded: {
         true: 'rounded-full',
         false: 'rounded-md'
       },
       size: {
-        sm: 'h-12 px-2 fs-small',
+        sm: 'h-12 px-3 fs-small',
         md: 'h-14 px-4 fs-base',
         lg: 'h-16 px-4 fs-h6'
       },
-      state: {
+      status: {
         default: '',
-        focused: ['outline-none', 'shadow-glow-focus-light dark:shadow-glow-focus-dark'],
-        focusedRegular: [
-          'hover:bg-surface-raised-light hover:border-border-strong-light',
-          'dark:hover:bg-surface-raised-dark dark:hover:border-border-strong-dark'
-        ],
-        focusedUnderlined: ['hover:border-border-strong-light', 'dark:hover:border-border-strong-dark'],
-        focusedLine: ['hover:border-b-border-strong-light', 'dark:hover:border-b-border-strong-dark'],
-        focusedBordered: ['hover:bg-surface-raised-light', 'dark:hover:bg-surface-raised-dark']
+        error:
+          'border-error-light shadow-glow-input-error-light hover:!border-error-light dark:border-error dark:shadow-glow-input-error dark:hover:!border-error',
+        warning:
+          'border-warning-light shadow-glow-input-warning-light hover:!border-warning-light dark:border-warning dark:shadow-glow-input-warning dark:hover:!border-warning',
+        success:
+          'border-success-light shadow-glow-input-success-light hover:!border-success-light dark:border-success dark:shadow-glow-input-success dark:hover:!border-success',
+        info: ''
       },
       focused: {
-        true: ['outline-none', 'shadow-glow-focus-light dark:shadow-glow-focus-dark'],
+        true: '!border-brand-light/50 shadow-glow-input-focus-light dark:!border-brand-dark/50 dark:shadow-glow-input-focus',
         false: ''
+      },
+      fullWidth: {
+        true: 'w-full',
+        false: 'w-auto'
       }
     },
     defaultVariants: {
       variant: 'regular',
       rounded: false,
       size: 'md',
-      state: 'default'
+      status: 'default',
+      focused: false,
+      fullWidth: false
     }
   }
 );
 
 export const labelVariants = cva(
   [
-    'absolute w-auto line-clamp-1 transition-[top,font-size,color] duration-200 ease-[ease] text-text-light dark:text-text-dark pt-0.5'
+    'absolute w-auto line-clamp-1 pt-0.5 text-text-light dark:text-text-dark',
+    'transition-[top,font-size,color] duration-200 ease-[ease]'
   ],
   {
     variants: {
       size: {
-        sm: 'left-2 fs-small',
-        md: 'left-4 fs-base',
-        lg: 'left-4 fs-h6'
+        sm: 'left-3 font-medium',
+        md: 'left-4 font-medium',
+        lg: 'left-4 font-medium'
       },
       state: {
-        default: 'top-1/2 -translate-y-1/2',
-        focusedSm: 'top-1 fs-small font-semibold',
-        focusedMd: 'top-1.5 fs-small font-semibold',
-        focusedLg: 'top-2 fs-small font-semibold',
-        hasValueSm: 'top-1 fs-small font-semibold',
-        hasValueMd: 'top-1.5 fs-small font-semibold',
-        hasValueLg: 'top-2 fs-small font-semibold'
+        resting: 'top-1/2 -translate-y-1/2',
+        floatingSm: 'top-0.5 fs-xs font-semibold',
+        floatingMd: 'top-1.5 fs-small font-semibold',
+        floatingLg: 'top-2 fs-small font-semibold'
       }
     },
+    compoundVariants: [
+      {
+        size: 'sm',
+        state: 'resting',
+        class: 'fs-small'
+      },
+      {
+        size: 'md',
+        state: 'resting',
+        class: 'fs-base'
+      },
+      {
+        size: 'lg',
+        state: 'resting',
+        class: 'fs-h6'
+      }
+    ],
     defaultVariants: {
       size: 'md',
-      state: 'default'
+      state: 'resting'
     }
   }
 );
 
-type InputVariant = VariantProps<typeof inputVariants>['variant'];
-type InputTypeVariant = 'text' | 'email' | 'password' | 'number' | 'tel' | 'url' | 'search' | 'hidden';
-type InputSize = VariantProps<typeof inputVariants>['size'];
+export const nativeInputVariants = cva(
+  [
+    'flex-1 border-none bg-transparent font-medium outline-none',
+    'text-text-light dark:text-text-dark placeholder:text-text-muted-light dark:placeholder:text-text-muted-dark',
+    'disabled:cursor-not-allowed'
+  ],
+  {
+    variants: {
+      hasInlineAction: {
+        true: 'pr-6',
+        false: ''
+      }
+    },
+    defaultVariants: {
+      hasInlineAction: false
+    }
+  }
+);
 
-export type InputProps = {
+export const inputInlineButtonVariants = cva(
+  [
+    'cursor-pointer rounded-sm bg-surface-light px-1 text-text-light hover:bg-surface-raised-light',
+    'dark:bg-surface-dark dark:text-text-dark dark:hover:bg-surface-raised-dark',
+    'focus-visible:outline-none focus-visible:shadow-glow-focus-light dark:focus-visible:shadow-glow-focus-dark',
+    'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-40'
+  ],
+  {
+    variants: {
+      shape: {
+        top: 'rounded-b-none',
+        bottom: 'rounded-t-none',
+        icon: 'rounded-full p-0.5'
+      }
+    },
+    defaultVariants: {
+      shape: 'icon'
+    }
+  }
+);
+
+export const hintMessageVariants = cva('fs-small', {
+  variants: {
+    tone: {
+      info: 'text-text-secondary-light dark:text-text-secondary-dark',
+      warning: 'text-warning-light dark:text-warning',
+      error: 'text-error-light dark:text-error',
+      success: 'text-success-light dark:text-success'
+    }
+  },
+  defaultVariants: {
+    tone: 'info'
+  }
+});
+
+type InputVariantProps = VariantProps<typeof inputVariants>;
+type NativeInputProps = Omit<
+  ComponentProps<'input'>,
+  'children' | 'className' | 'disabled' | 'id' | 'onChange' | 'size' | 'type'
+>;
+
+export type InputHintType = 'error' | 'warning' | 'success' | 'info';
+export type InputTypeVariant = 'text' | 'email' | 'password' | 'number' | 'tel' | 'url' | 'search' | 'hidden';
+export type InputVariant = NonNullable<InputVariantProps['variant']>;
+export type InputSize = NonNullable<InputVariantProps['size']>;
+export type InputHint = {
+  message: string;
+  type: InputHintType;
+};
+
+export type InputProps = NativeInputProps & {
   /** @control text */
   id: string;
   /**
    * @control select
-   * @defaultValue regular
+   * @default regular
    */
   variant?: InputVariant;
   /**
    * @control select
-   * @defaultValue text
+   * @default text
    */
   type?: InputTypeVariant;
   /**
    * @control boolean
-   * @defaultValue false
+   * @default false
    */
   rounded?: boolean;
   /** @control text */
   label?: string;
   /**
    * @control boolean
-   * @defaultValue false
+   * @default false
    */
   isRequired?: boolean;
   /**
    * @control boolean
-   * @defaultValue false
+   * @default false
    */
   disabled?: boolean;
   /**
    * @control select
-   * @defaultValue md
+   * @default md
    */
   size?: InputSize;
   /**
    * @control boolean
-   * @defaultValue false
+   * @default false
    */
   isFullWidth?: boolean;
   /** @control text */
@@ -133,8 +222,14 @@ export type InputProps = {
   /** @control text */
   className?: string;
   /** @control object */
-  hint?: { message: string; type: 'error' | 'warning' | 'success' | 'info' };
+  hint?: InputHint;
+  /** @control object */
   startContent?: ReactNode;
+  /** @control object */
   endContent?: ReactNode;
-  onChange?: (e: ChangeEvent, value: string) => void;
+  /** @control text */
+  ariaDescribedBy?: string | string[];
+  /** @control text */
+  ariaLabelledBy?: string | string[];
+  onChange?: (event: ChangeEvent<HTMLInputElement>, value: string) => void;
 };

--- a/src/components/atoms/input/types.ts
+++ b/src/components/atoms/input/types.ts
@@ -5,8 +5,7 @@ export const inputVariants = cva(
   [
     'relative flex max-w-full justify-between overflow-hidden border py-2',
     'cursor-text transition-[background,border-color,box-shadow] duration-200 ease-[ease]',
-    'focus-within:outline-none',
-    'disabled:pointer-events-none disabled:opacity-40 disabled:cursor-not-allowed'
+    'focus-within:outline-none'
   ],
   {
     variants: {
@@ -54,6 +53,23 @@ export const inputVariants = cva(
         false: 'w-auto'
       }
     },
+    compoundVariants: [
+      {
+        focused: true,
+        status: 'error',
+        class: '!border-error-light dark:!border-error'
+      },
+      {
+        focused: true,
+        status: 'warning',
+        class: '!border-warning-light dark:!border-warning'
+      },
+      {
+        focused: true,
+        status: 'success',
+        class: '!border-success-light dark:!border-success'
+      }
+    ],
     defaultVariants: {
       variant: 'regular',
       rounded: false,

--- a/src/components/atoms/input/useInput.ts
+++ b/src/components/atoms/input/useInput.ts
@@ -1,20 +1,114 @@
-import type { VariantProps } from 'class-variance-authority';
-import {
-  type ChangeEvent,
-  type ComponentProps,
-  type FocusEvent,
-  type KeyboardEvent,
-  useEffect,
-  useRef,
-  useState
-} from 'react';
+import type { ChangeEvent, ComponentProps, FocusEvent, KeyboardEvent } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useRipple } from '@/hooks/useRipple';
-import type { InputProps, inputVariants } from './types';
+import { cn } from '@/lib/utils';
+import type { DynamicIconName } from '@/types';
+import type { IconTone } from '../icon';
+import {
+  hintMessageVariants,
+  type InputHintType,
+  type InputProps,
+  inputInlineButtonVariants,
+  inputVariants,
+  labelVariants,
+  nativeInputVariants
+} from './types';
+
+type InputValue = ComponentProps<'input'>['value'] | ComponentProps<'input'>['defaultValue'];
+
+type HintIconProps = {
+  name: DynamicIconName;
+  tone: IconTone;
+  size: 16;
+};
+
+type UseInputReturn = {
+  adornmentClassName: string;
+  containerProps: ComponentProps<'div'>;
+  contentClassName: string;
+  decrementButtonProps: ComponentProps<'button'>;
+  endContent: InputProps['endContent'];
+  hasHint: boolean;
+  hasLabel: boolean;
+  hintIconProps?: HintIconProps;
+  hintMessage?: string;
+  hintMessageClassName: string;
+  inputProps: ComponentProps<'input'>;
+  isRequired: boolean;
+  label: string;
+  labelProps: ComponentProps<'label'>;
+  passwordButtonProps: ComponentProps<'button'>;
+  passwordIconName: DynamicIconName;
+  shouldRenderNumberControls: boolean;
+  shouldRenderPasswordToggle: boolean;
+  showPassword: boolean;
+  startContent: InputProps['startContent'];
+  stepButtonGroupClassName: string;
+  toggleButtonGroupClassName: string;
+  incrementButtonProps: ComponentProps<'button'>;
+  wrapperClassName: string;
+};
+
+const formatAriaIds = (ids?: string | string[]) => (Array.isArray(ids) ? ids.join(' ') : ids);
+
+const hasInputValue = (value: InputValue) => {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+
+  return value !== undefined && value !== null && String(value).length > 0;
+};
+
+const getFloatingLabelState = ({
+  hasFloatingLabel,
+  size
+}: {
+  hasFloatingLabel: boolean;
+  size: NonNullable<InputProps['size']>;
+}) => {
+  if (!hasFloatingLabel) {
+    return 'resting';
+  }
+
+  if (size === 'sm') {
+    return 'floatingSm';
+  }
+
+  if (size === 'lg') {
+    return 'floatingLg';
+  }
+
+  return 'floatingMd';
+};
+
+const getContentGapClassName = (size: NonNullable<InputProps['size']>) => (size === 'sm' ? 'gap-2' : 'gap-3');
+
+const getAdornmentSizeClassName = (size: NonNullable<InputProps['size']>) => (size === 'lg' ? 'fs-base' : 'fs-small');
+
+const getHintIconProps = (type?: InputHintType): HintIconProps | undefined => {
+  switch (type) {
+    case 'error':
+      return { name: 'circle-alert', tone: 'danger', size: 16 };
+    case 'warning':
+      return { name: 'triangle-alert', tone: 'warning', size: 16 };
+    case 'success':
+      return { name: 'circle-check', tone: 'success', size: 16 };
+    case 'info':
+      return { name: 'info', tone: 'muted', size: 16 };
+    default:
+      return undefined;
+  }
+};
+
+const dispatchNativeInputEvents = (input: HTMLInputElement) => {
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  input.dispatchEvent(new Event('change', { bubbles: true }));
+};
 
 export const useInput = ({
   rounded = false,
   size = 'md',
-  label,
+  label = '',
   placeholder,
   id,
   type = 'text',
@@ -24,6 +118,7 @@ export const useInput = ({
   endContent,
   isFullWidth = false,
   isRequired = false,
+  required = false,
   hint,
   onFocus,
   onBlur,
@@ -34,90 +129,191 @@ export const useInput = ({
   disabled = false,
   ariaDescribedBy,
   ariaLabelledBy,
+  'aria-describedby': nativeAriaDescribedBy,
+  'aria-labelledby': nativeAriaLabelledBy,
+  'aria-label': nativeAriaLabel,
   ...props
-}: Omit<VariantProps<typeof inputVariants>, 'state' | 'focused'> &
-  InputProps &
-  Omit<ComponentProps<'input'>, 'size' | 'id'> & {
-    ariaDescribedBy?: string | string[];
-    ariaLabelledBy?: string | string[];
-  }) => {
-  const formatAriaIds = (ids?: string | string[]) => (Array.isArray(ids) ? ids.join(' ') : ids);
+}: InputProps): UseInputReturn => {
   const [isFocused, setIsFocused] = useState(false);
-  const [hasValue, setHasValue] = useState(false);
+  const [hasValue, setHasValue] = useState(() => hasInputValue(value ?? defaultValue));
   const [showPassword, setShowPassword] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-  const ref = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   useRipple(containerRef);
 
-  useEffect(() => {
-    if (ref.current) {
-      ref.current.type = showPassword ? 'text' : 'password';
+  const inputType = type === 'password' && showPassword ? 'text' : type;
+  const requiredState = isRequired || required;
+  const currentHasValue = value === undefined ? hasValue : hasInputValue(value);
+  const hasAdornment = Boolean(startContent || endContent);
+  const hasFloatingLabel = isFocused || currentHasValue || Boolean(placeholder) || (Boolean(label) && hasAdornment);
+  const labelledBy = formatAriaIds(ariaLabelledBy ?? nativeAriaLabelledBy ?? (label ? `${id}-label` : undefined));
+  const externalDescribedBy = formatAriaIds(ariaDescribedBy ?? nativeAriaDescribedBy);
+  const hintDescribedBy = hint?.message ? `${id}-hint` : undefined;
+  const describedBy = [externalDescribedBy, hintDescribedBy].filter(Boolean).join(' ') || undefined;
+  const hasInlineAction = type === 'number' || type === 'password';
+
+  const containerClassName = cn(
+    inputVariants({
+      size,
+      rounded,
+      variant,
+      status: hint?.type ?? 'default',
+      focused: isFocused,
+      fullWidth: isFullWidth
+    }),
+    label ? 'items-end' : 'items-center',
+    disabled && 'pointer-events-none cursor-not-allowed opacity-40',
+    className
+  );
+
+  const labelClassName = labelVariants({
+    size,
+    state: getFloatingLabelState({ hasFloatingLabel, size })
+  });
+
+  const handleContainerClick = () => {
+    if (type === 'number' || type === 'password') {
+      return;
     }
-  }, [showPassword]);
 
-  const handleFocus = (e: FocusEvent<HTMLInputElement>) => {
+    inputRef.current?.focus();
+  };
+
+  const handleFocus = (event: FocusEvent<HTMLInputElement>) => {
     setIsFocused(true);
-    onFocus?.(e);
+    onFocus?.(event);
   };
 
-  const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
+  const handleBlur = (event: FocusEvent<HTMLInputElement>) => {
     setIsFocused(false);
-    setHasValue(!!e.target.value);
-    onBlur?.(e);
+    setHasValue(hasInputValue(event.target.value));
+    onBlur?.(event);
   };
 
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (['number', 'tel'].includes(type)) {
       const allowedKeys = ['Backspace', 'Tab', 'ArrowLeft', 'ArrowRight', 'Delete', 'Enter', 'Home', 'End', '.'];
-      const isNumberKey = /^[0-9]$/.test(e.key);
+      const isNumberKey = /^[0-9]$/.test(event.key);
 
-      if (!allowedKeys.includes(e.key) && !isNumberKey) {
-        e.preventDefault();
+      if (!allowedKeys.includes(event.key) && !isNumberKey) {
+        event.preventDefault();
       }
-      if (e.key === '.' && e.currentTarget.value.includes('.')) {
-        e.preventDefault();
+
+      if (event.key === '.' && event.currentTarget.value.includes('.')) {
+        event.preventDefault();
       }
     }
-    onKeyDown?.(e);
+
+    onKeyDown?.(event);
   };
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setHasValue(!!e.target.value);
-    onChange?.(e, e.target.value);
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setHasValue(hasInputValue(event.target.value));
+    onChange?.(event, event.target.value);
   };
+
+  const stepNumberValue = (direction: 'up' | 'down') => {
+    const input = inputRef.current;
+
+    if (!input || disabled) {
+      return;
+    }
+
+    if (direction === 'up') {
+      input.stepUp();
+    } else {
+      input.stepDown();
+    }
+
+    setHasValue(hasInputValue(input.value));
+    dispatchNativeInputEvents(input);
+  };
+
+  const hintIconProps = useMemo(() => getHintIconProps(hint?.type), [hint?.type]);
 
   return {
-    containerRef,
-    size,
-    rounded,
-    variant,
-    isFocused,
-    type,
-    isFullWidth,
-    label,
-    hint,
-    disabled,
-    className,
-    ref,
-    id,
-    hasValue,
-    placeholder,
-    startContent,
+    adornmentClassName: cn(
+      'flex shrink-0 items-center font-medium text-text-secondary-light dark:text-text-secondary-dark',
+      getAdornmentSizeClassName(size)
+    ),
+    containerProps: {
+      ref: containerRef,
+      className: containerClassName,
+      onClick: handleContainerClick
+    },
+    contentClassName: cn(
+      'flex w-full items-center justify-between',
+      getContentGapClassName(size),
+      label && startContent && 'translate-y-2'
+    ),
+    decrementButtonProps: {
+      type: 'button',
+      'aria-label': 'Decrease value',
+      'aria-controls': id,
+      className: inputInlineButtonVariants({ shape: 'bottom' }),
+      disabled,
+      onClick: () => stepNumberValue('down')
+    },
     endContent,
-    isRequired,
-    formatAriaIds,
-    ariaDescribedBy,
-    ariaLabelledBy,
-    handleBlur,
-    handleChange,
-    handleFocus,
-    handleKeyDown,
+    hasHint: Boolean(hint?.message),
+    hasLabel: Boolean(label),
+    hintIconProps,
+    hintMessage: hint?.message,
+    hintMessageClassName: hintMessageVariants({ tone: hint?.type ?? 'info' }),
+    inputProps: {
+      ...props,
+      ref: inputRef,
+      id,
+      type: inputType,
+      placeholder,
+      disabled,
+      'aria-disabled': disabled ? true : undefined,
+      'aria-invalid': hint?.type === 'error' ? true : undefined,
+      'aria-describedby': describedBy,
+      'aria-labelledby': labelledBy,
+      'aria-label': nativeAriaLabel ?? (!labelledBy ? placeholder : undefined),
+      className: nativeInputVariants({ hasInlineAction }),
+      onFocus: handleFocus,
+      onBlur: handleBlur,
+      onKeyDown: handleKeyDown,
+      onChange: handleChange,
+      required: requiredState,
+      'aria-required': requiredState ? true : undefined,
+      value,
+      defaultValue
+    },
+    incrementButtonProps: {
+      type: 'button',
+      'aria-label': 'Increase value',
+      'aria-controls': id,
+      className: inputInlineButtonVariants({ shape: 'top' }),
+      disabled,
+      onClick: () => stepNumberValue('up')
+    },
+    isRequired: requiredState,
+    label,
+    labelProps: {
+      id: `${id}-label`,
+      htmlFor: id,
+      className: labelClassName
+    },
+    passwordButtonProps: {
+      type: 'button',
+      'aria-label': showPassword ? 'Hide password' : 'Show password',
+      'aria-controls': id,
+      'aria-pressed': showPassword,
+      className: inputInlineButtonVariants({ shape: 'icon' }),
+      disabled,
+      onClick: () => setShowPassword((current) => !current)
+    },
+    passwordIconName: showPassword ? 'eye-off' : 'eye',
+    shouldRenderNumberControls: type === 'number',
+    shouldRenderPasswordToggle: type === 'password',
     showPassword,
-    value,
-    defaultValue,
-    setHasValue,
-    setShowPassword,
-    ...props
+    startContent,
+    stepButtonGroupClassName: 'absolute right-2 top-0 bottom-0 z-10 flex flex-col items-center justify-center gap-0.5',
+    toggleButtonGroupClassName: 'absolute right-2 top-0 bottom-0 z-10 flex flex-col items-center justify-center',
+    wrapperClassName: cn('flex flex-col gap-2', isFullWidth && 'w-full', type === 'hidden' && 'hidden')
   };
 };

--- a/src/components/atoms/input/useInput.ts
+++ b/src/components/atoms/input/useInput.ts
@@ -105,6 +105,25 @@ const dispatchNativeInputEvents = (input: HTMLInputElement) => {
   input.dispatchEvent(new Event('change', { bubbles: true }));
 };
 
+const parseNumberAttribute = (value: string) => {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const clampNumberValue = (value: number, min?: number, max?: number) =>
+  Math.min(Math.max(value, min ?? value), max ?? value);
+
+const stepNumberValueManually = (input: HTMLInputElement, direction: 'up' | 'down') => {
+  const currentValue = Number.isFinite(input.valueAsNumber) ? input.valueAsNumber : 0;
+  const nextValue = currentValue + (direction === 'up' ? 1 : -1);
+
+  input.value = String(clampNumberValue(nextValue, parseNumberAttribute(input.min), parseNumberAttribute(input.max)));
+};
+
 export const useInput = ({
   rounded = false,
   size = 'md',
@@ -132,6 +151,7 @@ export const useInput = ({
   'aria-describedby': nativeAriaDescribedBy,
   'aria-labelledby': nativeAriaLabelledBy,
   'aria-label': nativeAriaLabel,
+  'aria-invalid': nativeAriaInvalid,
   ...props
 }: InputProps): UseInputReturn => {
   const [isFocused, setIsFocused] = useState(false);
@@ -220,7 +240,9 @@ export const useInput = ({
       return;
     }
 
-    if (direction === 'up') {
+    if (input.step === 'any') {
+      stepNumberValueManually(input, direction);
+    } else if (direction === 'up') {
       input.stepUp();
     } else {
       input.stepDown();
@@ -269,7 +291,7 @@ export const useInput = ({
       placeholder,
       disabled,
       'aria-disabled': disabled ? true : undefined,
-      'aria-invalid': hint?.type === 'error' ? true : undefined,
+      'aria-invalid': hint?.type === 'error' ? true : nativeAriaInvalid,
       'aria-describedby': describedBy,
       'aria-labelledby': labelledBy,
       'aria-label': nativeAriaLabel ?? (!labelledBy ? placeholder : undefined),

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -254,6 +254,24 @@
   --shadow-glow-focus-dark: var(--glow-focus-dark);
   --shadow-glow-focus-light: var(--glow-focus-light);
 
+  /* Glow de input — softer than button focus rings */
+  --glow-input-focus: 0 0 0 3px rgba(255, 0, 54, 0.12);
+  --glow-input-focus-light: 0 0 0 3px rgba(219, 20, 60, 0.15);
+  --glow-input-error: 0 0 0 3px rgba(255, 0, 54, 0.15);
+  --glow-input-error-light: 0 0 0 3px rgba(219, 20, 60, 0.15);
+  --glow-input-warning: 0 0 0 3px rgba(251, 191, 36, 0.12);
+  --glow-input-warning-light: 0 0 0 3px rgba(217, 119, 6, 0.15);
+  --glow-input-success: 0 0 0 3px rgba(34, 197, 94, 0.12);
+  --glow-input-success-light: 0 0 0 3px rgba(22, 163, 74, 0.15);
+  --shadow-glow-input-focus: var(--glow-input-focus);
+  --shadow-glow-input-focus-light: var(--glow-input-focus-light);
+  --shadow-glow-input-error: var(--glow-input-error);
+  --shadow-glow-input-error-light: var(--glow-input-error-light);
+  --shadow-glow-input-warning: var(--glow-input-warning);
+  --shadow-glow-input-warning-light: var(--glow-input-warning-light);
+  --shadow-glow-input-success: var(--glow-input-success);
+  --shadow-glow-input-success-light: var(--glow-input-success-light);
+
   /* Glow ámbar — GitHub stars */
   --glow-amber: 0 0 0 3px rgba(255, 185, 0, 0.12);
 


### PR DESCRIPTION
## Summary

Completes the Input atom review and cleanup.

Closes #131

- Refactors Input into the project 5-file component structure with `types.ts`, `useInput.ts`, presentational `Input.tsx`, barrel export, stories, and tests.
- Fixes ARIA wiring, controlled/floating-label behavior, native number stepping, full-width layout, start/end content spacing, and small-size layout.
- Adds Input-specific focus/status glow tokens and Storybook coverage for variants, states, sizes, types, and adornments.

## Type of change

- [ ] 🧩 New component
- [x] 🐛 Bug fix
- [ ] 🎨 Design tokens
- [ ] ♿ Accessibility
- [ ] 🏗️ Infrastructure
- [ ] 📚 Documentation

## Repository checklist

- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`
- [x] Commit messages follow the same commitlint-enforced format
- [x] PR description links the issue with `Closes #NNN`
- [x] Security checks pass, or any false positives are documented in the PR

## Component checklist (skip if not applicable)

- [x] Follows the 5-file structure (`types.ts`, `use*.ts`, `Component.tsx`, `index.ts`, `*.stories.tsx`)
- [x] CVA variants defined in `types.ts`, not inline
- [x] No hardcoded colors — uses tokens from `theme.css`
- [x] No `any` types — TypeScript strict
- [x] ARIA attributes present and correct
- [x] Keyboard navigable (Tab, Enter, Escape where applicable)
- [x] Dark mode works correctly
- [x] Storybook stories cover: default, variants, states (hover, focus, disabled)
- [x] Tests added or updated

## How to test

1. `pnpm exec biome check src/components/atoms/input/Input.tsx src/components/atoms/input/useInput.ts src/components/atoms/input/types.ts src/components/atoms/input/Input.stories.tsx src/components/atoms/input/Input.test.tsx src/components/atoms/input/index.ts src/styles/theme.css .gitattributes`
2. `pnpm test -- src/components/atoms/input/Input.test.tsx`
3. `pnpm exec tsc --noEmit`
4. `pnpm run build`
5. `pnpm run storybook-build`
6. Open Storybook Input stories and verify focus/status states, sizes, full width, and start/end content spacing.

## Screenshots / recordings (if applicable)

Local visual review screenshots were captured under `.playwright-mcp/` during implementation.

## Notes for reviewer

- Issue #131 is assigned to `egdev6` and has `status:approved`.
- This PR is intentionally scoped to the Input atom review/completion, but it is a larger component cleanup because the existing implementation mixed logic, styles, ARIA behavior, and stories in one place.
- Final user preference for start content spacing: keep label horizontal alignment unchanged and add vertical breathing room by translating the content row down only when `label && startContent`.
