### PR TITLE
fix(input): address follow-up review

### DIFF
--- a/src/components/atoms/input/Input.test.tsx
+++ b/src/components/atoms/input/Input.test.tsx
@@ -1,4 +1,4 @@
-import { render, renderHook, screen } from '@testing-library/react';
+import { fireEvent, render, renderHook, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -90,6 +90,20 @@ describe('useInput — logic', () => {
     expect(result.current.containerProps.className).toContain('px-3');
     expect(result.current.contentClassName).toContain('gap-2');
     expect(result.current.adornmentClassName).toContain('fs-small');
+  });
+
+  it('keeps dark hover styling for the underlined variant', () => {
+    const { result } = renderHook(() => useInput({ id: 'email', label: 'Email', variant: 'underlined' }));
+
+    expect(result.current.containerProps.className).toContain('dark:hover:border-border-strong-dark');
+  });
+
+  it('reserves inline-action space when end content is present', () => {
+    const { result } = renderHook(() =>
+      useInput({ id: 'password', label: 'Password', type: 'password', endContent: '.com' })
+    );
+
+    expect(result.current.contentClassName).toContain('pr-8');
   });
 });
 
@@ -218,6 +232,22 @@ describe('Input — component behavior', () => {
 
     await user.click(decrease);
     expect(input).toHaveValue(0);
+  });
+
+  it('does not cancel number key input so the browser controls number editing', () => {
+    render(<Input id='temperature' label='Temperature' type='number' min={-10} defaultValue={12} />);
+    const input = screen.getByRole('spinbutton', { name: 'Temperature' });
+
+    expect(fireEvent.keyDown(input, { key: '-' })).toBe(true);
+    expect(fireEvent.keyDown(input, { key: 'a' })).toBe(true);
+  });
+
+  it('allows leading plus signs for tel inputs while blocking invalid tel letters', () => {
+    render(<Input id='phone' label='Phone' type='tel' />);
+    const input = screen.getByRole('textbox', { name: 'Phone' });
+
+    expect(fireEvent.keyDown(input, { key: '+' })).toBe(true);
+    expect(fireEvent.keyDown(input, { key: 'a' })).toBe(false);
   });
 
   it('falls back to manual number controls when step is any', async () => {

--- a/src/components/atoms/input/Input.test.tsx
+++ b/src/components/atoms/input/Input.test.tsx
@@ -250,6 +250,14 @@ describe('Input — component behavior', () => {
     expect(fireEvent.keyDown(input, { key: 'a' })).toBe(false);
   });
 
+  it('preserves native clipboard shortcuts for tel inputs', () => {
+    render(<Input id='phone' label='Phone' type='tel' />);
+    const input = screen.getByRole('textbox', { name: 'Phone' });
+
+    expect(fireEvent.keyDown(input, { key: 'v', ctrlKey: true })).toBe(true);
+    expect(fireEvent.keyDown(input, { key: 'a', metaKey: true })).toBe(true);
+  });
+
   it('falls back to manual number controls when step is any', async () => {
     const user = userEvent.setup();
     render(<Input id='quantity' label='Quantity' type='number' defaultValue={1} min={0} max={2} step='any' />);

--- a/src/components/atoms/input/types.ts
+++ b/src/components/atoms/input/types.ts
@@ -14,7 +14,10 @@ export const inputVariants = cva(
           'bg-surface-light border-border-light hover:bg-surface-raised-light hover:border-border-strong-light',
           'dark:bg-surface-dark dark:border-border-dark dark:hover:bg-surface-raised-dark dark:hover:border-border-strong-dark'
         ],
-        underlined: ['bg-transparent border-border-light hover:border-border-strong-light', 'dark:border-border-dark'],
+        underlined: [
+          'bg-transparent border-border-light hover:border-border-strong-light',
+          'dark:border-border-dark dark:hover:border-border-strong-dark'
+        ],
         line: [
           'bg-transparent border-t-transparent border-l-transparent border-r-transparent rounded-none!',
           'border-b-border-light hover:border-b-border-strong-light',

--- a/src/components/atoms/input/useInput.ts
+++ b/src/components/atoms/input/useInput.ts
@@ -124,6 +124,28 @@ const stepNumberValueManually = (input: HTMLInputElement, direction: 'up' | 'dow
   input.value = String(clampNumberValue(nextValue, parseNumberAttribute(input.min), parseNumberAttribute(input.max)));
 };
 
+const canTypeLeadingSign = (input: HTMLInputElement, key: string) => {
+  if (!['+', '-'].includes(key)) {
+    return false;
+  }
+
+  if (input.type === 'tel' && key !== '+') {
+    return false;
+  }
+
+  const selectionStart = input.selectionStart;
+
+  if (selectionStart === null) {
+    return false;
+  }
+
+  const selectionEnd = input.selectionEnd ?? selectionStart;
+  const hasLeadingSign = /^[+-]/.test(input.value);
+  const replacesLeadingSign = selectionStart === 0 && selectionEnd > 0 && hasLeadingSign;
+
+  return selectionStart === 0 && (!hasLeadingSign || replacesLeadingSign);
+};
+
 export const useInput = ({
   rounded = false,
   size = 'md',
@@ -212,15 +234,12 @@ export const useInput = ({
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (['number', 'tel'].includes(type)) {
-      const allowedKeys = ['Backspace', 'Tab', 'ArrowLeft', 'ArrowRight', 'Delete', 'Enter', 'Home', 'End', '.'];
+    if (type === 'tel') {
+      const allowedKeys = ['Backspace', 'Tab', 'ArrowLeft', 'ArrowRight', 'Delete', 'Enter', 'Home', 'End'];
       const isNumberKey = /^[0-9]$/.test(event.key);
+      const isAllowedSign = canTypeLeadingSign(event.currentTarget, event.key);
 
-      if (!allowedKeys.includes(event.key) && !isNumberKey) {
-        event.preventDefault();
-      }
-
-      if (event.key === '.' && event.currentTarget.value.includes('.')) {
+      if (!allowedKeys.includes(event.key) && !isNumberKey && !isAllowedSign) {
         event.preventDefault();
       }
     }
@@ -267,7 +286,8 @@ export const useInput = ({
     contentClassName: cn(
       'flex w-full items-center justify-between',
       getContentGapClassName(size),
-      label && startContent && 'translate-y-2'
+      label && startContent && 'translate-y-2',
+      hasInlineAction && endContent && 'pr-8'
     ),
     decrementButtonProps: {
       type: 'button',

--- a/src/components/atoms/input/useInput.ts
+++ b/src/components/atoms/input/useInput.ts
@@ -234,7 +234,7 @@ export const useInput = ({
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (type === 'tel') {
+    if (type === 'tel' && !event.ctrlKey && !event.metaKey) {
       const allowedKeys = ['Backspace', 'Tab', 'ArrowLeft', 'ArrowRight', 'Delete', 'Enter', 'Home', 'End'];
       const isNumberKey = /^[0-9]$/.test(event.key);
       const isAllowedSign = canTypeLeadingSign(event.currentTarget, event.key);


### PR DESCRIPTION
## Summary

Follow-up fixes for review comments left on the merged Input PR.

Closes #131

- Adds missing dark hover affordance for the underlined Input variant.
- Leaves native number input key editing to the browser and scopes custom sign filtering to tel inputs.
- Reserves right-side content space when `endContent` is combined with password/number inline controls.

## Type of change

- [ ] 🧩 New component
- [x] 🐛 Bug fix
- [ ] 🎨 Design tokens
- [ ] ♿ Accessibility
- [ ] 🏗️ Infrastructure
- [ ] 📚 Documentation

## Repository checklist

- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`
- [x] Commit messages follow the same commitlint-enforced format
- [x] PR description links the issue with `Closes #NNN`
- [x] Security checks pass, or any false positives are documented in the PR

## Component checklist (skip if not applicable)

- [x] Follows the 5-file structure (`types.ts`, `use*.ts`, `Component.tsx`, `index.ts`, `*.stories.tsx`)
- [x] CVA variants defined in `types.ts`, not inline
- [x] No hardcoded colors — uses tokens from `theme.css`
- [x] No `any` types — TypeScript strict
- [x] ARIA attributes present and correct
- [x] Keyboard navigable (Tab, Enter, Escape where applicable)
- [x] Dark mode works correctly
- [x] Storybook stories cover: default, variants, states (hover, focus, disabled)
- [x] Tests added or updated

## How to test

1. `pnpm test -- src/components/atoms/input/Input.test.tsx`
2. `pnpm exec tsc --noEmit`
3. `pnpm run build`
4. `pnpm run storybook-build`

## Screenshots / recordings (if applicable)

N/A

## Notes for reviewer

- Follow-up to merged PR #218.
- This keeps the diff scoped to second-round review comments only.
