### PR TITLE
docs(component-spec): require accessibility contracts

### DIFF
--- a/.atl/skills/component-spec-proposer/SKILL.md
+++ b/.atl/skills/component-spec-proposer/SKILL.md
@@ -4,7 +4,7 @@ description: "Trigger: HeroUI reference, component spec proposal, prepare compon
 license: Apache-2.0
 metadata:
   author: stack-and-flow
-  version: "1.0"
+  version: "1.1"
 ---
 
 ## Activation Contract
@@ -18,6 +18,9 @@ Do not implement the component. Your job is to turn a vague task into a validate
 - Treat the reference as inspiration, not source of truth. Adapt to Stack-and-Flow tokens, 6-file pattern, accessibility rules, and Storybook conventions.
 - Never mark the task ready until the user explicitly validates the proposed spec.
 - Do not invent irreversible product decisions. Flag assumptions and ask for confirmation.
+- For interactive or composite components, the proposal must include a concrete accessibility contract: pattern reference, roles, accessible names, keyboard matrix, focus lifecycle, state announcements, and expected tests.
+- Do not accept vague accessibility placeholders such as "supports keyboard" or "uses ARIA". If behavior is unknown, ask before approval.
+- Prefer native semantics first; when using Radix or WAI-ARIA APG patterns, name the chosen pattern and document any intentional deviation.
 - Keep issue/project writes single-threaded: update the issue first, then the GitHub Project item.
 - Use ASCII-safe headings in GitHub comments and issue edits. No emojis in issue body or generated comments.
 - If `gh` lacks `read:project` or `project` scope, stop and ask the user to run `gh auth refresh -s read:project,project`.
@@ -30,6 +33,9 @@ Do not implement the component. Your job is to turn a vague task into a validate
 | Issue URL missing                            | Produce the proposal only; do not update GitHub.                               |
 | Component tier unclear                       | Ask whether it is atom, molecule, or organism.                                 |
 | Reference implies complex composite behavior | Flag possible molecule/organism mismatch before validation.                    |
+| Accessibility contract is vague or missing   | Stop and ask; do not produce a ready-to-approve spec.                           |
+| Composite keyboard/focus behavior unclear    | Ask for the intended pattern before validation.                                 |
+| Expected a11y tests are missing              | Add them before asking for approval.                                            |
 | User approves proposal                       | Add the validated spec to the issue, then set Project Status to `In progress`. |
 | User requests changes                        | Revise the proposal and ask for validation again.                              |
 
@@ -37,13 +43,14 @@ Do not implement the component. Your job is to turn a vague task into a validate
 
 1. Read the GitHub issue, if provided: title, body, comments, assignees, and URL. If the rendered issue page does not expose the comment thread, fetch the issue comments via the GitHub API (`/repos/{owner}/{repo}/issues/{number}/comments`) or `gh api` before continuing.
 2. Fetch and study the reference URL. Extract behavior, states, accessibility, anatomy, and examples.
-3. Compare against project rules from `component-contributor`, especially Phase 1 requirements.
-4. Present a proposed spec using `references/spec-template.md`.
-5. Include an `Assumptions to validate` section for choices not explicit in the issue/reference.
-6. Ask the user to approve, reject, or edit the proposal. Do not write to GitHub before approval.
-7. After approval, append or update a GitHub issue comment headed `## Validated component spec` using the approved spec.
-8. Locate the Project item for the issue and set Status to `In progress` using the project field IDs from `github-project-tasks`.
-9. Report the issue URL, project item ID, updated status, and next command/action: start `component-contributor`.
+3. Identify the semantic pattern: native element, Radix primitive, or WAI-ARIA/APG pattern. For composites, define roles, relationships, keyboard behavior, focus lifecycle, and announced states before proposing API details.
+4. Compare against project rules from `component-contributor`, especially Phase 1 requirements.
+5. Present a proposed spec using `references/spec-template.md` with concrete accessibility acceptance criteria and expected tests.
+6. Include an `Assumptions to validate` section for choices not explicit in the issue/reference, especially screen reader, focus, or keyboard decisions.
+7. Ask the user to approve, reject, or edit the proposal. Do not write to GitHub before approval.
+8. After approval, append or update a GitHub issue comment headed `## Validated component spec` using the approved spec.
+9. Locate the Project item for the issue and set Status to `In progress` using the project field IDs from `github-project-tasks`.
+10. Report the issue URL, project item ID, updated status, and next command/action: start `component-contributor`.
 
 ## Output Contract
 

--- a/.atl/skills/component-spec-proposer/references/spec-template.md
+++ b/.atl/skills/component-spec-proposer/references/spec-template.md
@@ -48,14 +48,43 @@ Out of scope:
 - error:
 - empty:
 
-### Accessibility
+### Accessibility contract
 
-- Role:
-- ARIA:
-- Keyboard behavior:
-- Focus behavior:
-- Touch target:
+For non-interactive display components, state: `Native/static semantics only; custom keyboard, focus, and state announcements are not applicable.`
+
+For interactive or composite components, complete:
+
+- Pattern reference: native / Radix / WAI-ARIA APG pattern name
+- Roles: root, trigger, popup/list, option/item, label/description/error when applicable
+- Accessible name: visible label, `aria-label`, or `aria-labelledby` source
+- ARIA relationships: `aria-controls`, `aria-expanded`, `aria-activedescendant`, `aria-describedby`, `aria-invalid`, etc. when applicable
+- Keyboard matrix:
+  - Tab / Shift+Tab:
+  - Enter / Space:
+  - Arrow keys:
+  - Escape:
+  - Home / End / typeahead, if applicable:
+- Focus lifecycle: initial focus, roving/active descendant, focus restore, trap/portal behavior if applicable
+- State announcements:
+  - disabled:
+  - required:
+  - invalid/error:
+  - loading:
+  - empty/no results:
+- Touch target: default and compact exceptions
 - Reduced motion:
+
+### Accessibility acceptance criteria
+
+For non-interactive display components, include the role/name or semantic rendering check only.
+
+For interactive or composite components, complete:
+
+- Keyboard-only user can:
+- Screen reader user hears:
+- Focus is managed by:
+- Disabled/invalid/loading/empty states expose:
+- Automated/manual checks required:
 
 ### Storybook stories required
 
@@ -96,13 +125,20 @@ Do not implement:
 - Required token modules:
 - Required reference modules:
 - Expected tests:
+  - Role/name or semantic rendering queries:
+  - Keyboard behavior, if interactive:
+  - Focus behavior, if interactive:
+  - ARIA state transitions, if applicable:
+  - Disabled/invalid/loading/empty states, if applicable:
+  - Axe/Storybook/manual notes:
 ```
 
 ## Proposal guidance
 
 - For simple display components, keep props minimal and composable.
-- For interactive components, specify keyboard behavior and focus states before approval.
-- For composite components such as Autocomplete, Select, DatePicker, Drawer, Accordion, or Toast, explicitly decide whether the component remains an atom or should become a molecule/organism.
+- For interactive components, specify the full accessibility contract before approval; vague ARIA or keyboard notes are not enough.
+- For composite components such as Autocomplete, Select, DatePicker, Drawer, Accordion, or Toast, explicitly decide whether the component remains an atom or should become a molecule/organism, and name the native/Radix/WAI-ARIA pattern being followed.
 - Prefer controlled/uncontrolled API decisions only when the reference behavior requires them.
 - Include `className` only as an extension point, never as a substitute for missing variants.
 - Mention if a dependency or token change would be required, but do not approve it implicitly.
+- Include at least one acceptance criterion for keyboard-only use and one for screen reader semantics when the component is interactive.


### PR DESCRIPTION
## Summary

Hardens the component spec proposal flow so interactive/composite components require a concrete accessibility contract before implementation.

Closes #233

## Review scope

- Primary files/areas: `component-spec-proposer` skill and spec template
- Out of scope: GitHub issue/PR templates, runtime components
- Review workload: small

## Type of change

- [ ] New component
- [ ] Existing component update/refactor
- [ ] Bug fix
- [x] Accessibility
- [ ] Design tokens
- [ ] Storybook/docs
- [ ] Infrastructure/tooling
- [ ] NPM/dependencies

## Workflow gates

- [x] Linked issue is present with `Closes #NNN` or maintainer approved an exception.
- [x] Work was started through the Project flow: assignee set, Project status `In progress`, branch/worktree recorded.
- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`.
- [x] Commits follow the same commitlint-enforced format.
- [x] Diff is focused; unrelated work is called out in Review scope.
- [x] MCP/runtime artifacts are absent.

## Component evidence (required for component changes)

N/A; this changes proposal workflow docs only.

## Accessibility evidence

- [x] Role/name semantics verified with Testing Library queries or equivalent. N/A for docs.
- [x] Keyboard-only behavior verified where applicable. This PR requires specs to define it before implementation.
- [x] Focus lifecycle verified where applicable. This PR requires specs to define it before implementation.
- [x] Disabled, required, invalid/error, loading, and empty states expose the expected semantics where applicable. This PR adds those fields to the spec template.
- [x] Reduced motion behavior is respected where motion changed. This PR preserves reduced-motion as a spec field.
- [x] Screen reader or axe/manual evidence is included below when applicable. This PR requires expected screen reader behavior in future interactive specs.

## Validation evidence

- TypeScript: pre-commit typecheck passed.
- Unit tests: full pre-push `pnpm test` passed, 371 tests.
- Build/package: not applicable.
- Storybook or visual check: not applicable.
- Accessibility check: fresh reviewer found no blockers; simple display components have an explicit native/static carve-out.
- Security/dependency check: not applicable.

## Screenshots or recordings

N/A.

## Notes for reviewer

This PR intentionally only changes the component spec proposer and template. It does not include GitHub template/workflow alignment from #234.
