### PR TITLE
docs(github): align templates with workflow gates

### DIFF
--- a/.atl/skills/component-spec-proposer/SKILL.md
+++ b/.atl/skills/component-spec-proposer/SKILL.md
@@ -30,7 +30,7 @@ Do not implement the component. Your job is to turn a vague task into a validate
 | Issue URL missing                            | Produce the proposal only; do not update GitHub.                               |
 | Component tier unclear                       | Ask whether it is atom, molecule, or organism.                                 |
 | Reference implies complex composite behavior | Flag possible molecule/organism mismatch before validation.                    |
-| User approves proposal                       | Add the validated spec to the issue, then set Project Status to `In progress`. |
+| User approves proposal                       | Add the validated spec to the issue; leave Project `In progress` transition to START WORK. |
 | User requests changes                        | Revise the proposal and ask for validation again.                              |
 
 ## Execution Steps
@@ -42,8 +42,8 @@ Do not implement the component. Your job is to turn a vague task into a validate
 5. Include an `Assumptions to validate` section for choices not explicit in the issue/reference.
 6. Ask the user to approve, reject, or edit the proposal. Do not write to GitHub before approval.
 7. After approval, append or update a GitHub issue comment headed `## Validated component spec` using the approved spec.
-8. Locate the Project item for the issue and set Status to `In progress` using the project field IDs from `github-project-tasks`.
-9. Report the issue URL, project item ID, updated status, and next command/action: start `component-contributor`.
+8. If the issue is not on the Project board or Team/Category fields are missing, report the missing setup instead of mutating status.
+9. Report the issue URL, spec comment status, and next command/action: run START WORK via `github-project-tasks`, then start `component-contributor`.
 
 ## Output Contract
 
@@ -70,9 +70,8 @@ After approval and GitHub update, return:
 
 **Issue**: #{number} {title}
 **Spec**: Added to issue as `Validated component spec`
-**Project status**: In progress
-**Project item ID**: {itemId}
-**Next**: Run `component-contributor` for implementation.
+**Project setup**: {team/category present or missing setup}
+**Next**: Run START WORK via `github-project-tasks`, then run `component-contributor` for implementation.
 ```
 
 ## References

--- a/.atl/skills/component-spec-proposer/references/github-project-update.md
+++ b/.atl/skills/component-spec-proposer/references/github-project-update.md
@@ -19,15 +19,8 @@ item_id=$(gh project item-list 1 \
   --jq ".items[] | select(.content.url == \"$issue_url\") | .id")
 ```
 
-Set Project Status to `In progress`:
-
-```bash
-gh project item-edit \
-  --project-id PVT_kwDOEHd14s4BUsw- \
-  --id "$item_id" \
-  --field-id PVTSSF_lADOEHd14s4BUsw-zhCIcdo \
-  --single-select-option-id 47fc9ee4
-```
+Do not move Project Status to `In progress` from `component-spec-proposer`.
+That transition belongs to START WORK in `github-project-tasks`, after spec approval and immediately before implementation.
 
 Add the approved spec to the issue:
 

--- a/.atl/skills/github-project-tasks/SKILL.md
+++ b/.atl/skills/github-project-tasks/SKILL.md
@@ -274,10 +274,16 @@ Check each item:
 | --- | --- |
 | Title format | Starts with an approved prefix. |
 | Body not empty | `content.body` is not empty/null. |
-| Has 6 phases | Body contains the 6 checkbox phases from the template. |
+| Has workflow checklist | Body contains `### Current workflow` and START WORK / END WORK checklist items. |
 | No emoji corruption | Body does not contain `���`. |
-| Has reference section | Body contains `### Referencia`. |
-| Has notes section | Body contains `### Notas adicionales`. |
+| Has reference section | Body contains `### Reference`. |
+| Has spec or plan section | Body contains `### Specification or plan`. |
+| Has accessibility impact section | Body contains `### Accessibility impact`. |
+| Has validation plan | Body contains `### Validation plan`. |
+| Has work start section | Body contains `### Work start state`. |
+| Has PR/completion section | Body contains `### PR and completion evidence`. |
+| Has notes section | Body contains `### Notes`. |
+| Has resources section | Body contains `### Resources`. |
 | Board fields set | status, team, category are present. |
 | In progress has assignee | Items in `In progress` have at least one assignee. |
 | Assigned Todo is intentional | Assigned issues still in `Todo` are flagged for confirmation. |

--- a/.atl/skills/github-project-tasks/references/issue-body-template.md
+++ b/.atl/skills/github-project-tasks/references/issue-body-template.md
@@ -1,54 +1,106 @@
 # GitHub Issue Body Template
 
-Canonical Stack-and-Flow issue body. Keep headings ASCII-only because `gh` CLI output can corrupt emoji/multibyte section markers in Windows PowerShell.
+Canonical Stack-and-Flow issue body for automated issue creation. Keep headings ASCII-only because `gh` CLI output can corrupt emoji or multibyte section markers in Windows PowerShell.
 
 ```markdown
-## Tarea: {ComponentName}
+## Task: {TaskName}
 
-### Referencia:
+### Category
 
-{reference_url}
+{category}
 
-### Fases del desarrollo
+### Team
 
-- [ ] 1. **Research de funcionalidad**
-  Investigar soluciones similares, patrones existentes y necesidades reales. Añadir capturas, enlaces o benchmarks si aplican.
+{team}
 
-- [ ] 2. **Definicion de funcionalidades**
-  Especificar que debe hacer el componente: props, estados, interaccion, accesibilidad, variantes, etc.
+### Reference
 
-- [ ] 3. **Implementacion del componente**
-  Desarrollo del componente en base a la definicion anterior. Incluir historias de Storybook si procede.
+{reference_url_or_not_applicable}
 
-- [ ] 4. **Documentacion del componente**
-  - [ ] Storybook documentado con controles y ejemplos de uso
-  - [ ] Documentacion escrita en JSDoc canonico de Storybook cuando aplique
-  - [ ] Seccion de casos de uso o guidelines
+### Scope
 
-- [ ] 5. **Code review y modificaciones**
-  - [ ] Revision funcional
-  - [ ] Revision visual (alineamiento con el design system)
-  - [ ] Correccion de errores o ajustes sugeridos
+This task is responsible for:
 
-- [ ] 6. **Merge en main**
-  Una vez aprobado, mergear la rama a `main` siguiendo el flujo de PR establecido. (Esta parte me encargo yo)
+- ...
 
----
+Out of scope:
 
-### Notas adicionales
+- ...
 
-_Anotar cualquier comentario, decision tomada o consideraciones especiales. (Nombra a egdev6 para cualquier consulta)_
+### Current workflow
 
----
+- [ ] Issue triaged with Team and Category fields set on the Project board.
+- [ ] Specification or plan recorded in this issue when behavior, API, accessibility, or tokens are affected.
+- [ ] START WORK completed before implementation: assignee set, Project status moved to `In progress`, branch/worktree recorded.
+- [ ] Implementation completed inside the approved scope.
+- [ ] Validation evidence recorded in the PR or issue.
+- [ ] PR opened and linked with `Closes #NNN`.
+- [ ] PR merged or maintainer explicitly approved closure.
+- [ ] END WORK completed: completion evidence added and Project status moved to `Done`.
 
-### Recursos relacionados
+### Specification or plan
 
-_Nombrar cualquier recurso externo_
+For component work, paste or link the approved `## Validated component spec` from `component-spec-proposer` before implementation starts.
+
+For non-component work, record:
+
+- Expected behavior/change:
+- Public API or consumer impact:
+- Accessibility impact:
+- Compatibility or migration notes:
+- Non-goals:
+
+### Accessibility impact
+
+- Pattern or standard: native / Radix / WAI-ARIA APG / WCAG / not applicable
+- Keyboard impact:
+- Screen reader impact:
+- Focus impact:
+- Contrast or reduced-motion impact:
+- Required accessibility validation:
+
+### Validation plan
+
+- TypeScript:
+- Unit tests:
+- Build/package:
+- Storybook or visual check:
+- Accessibility check:
+- Security/dependency check:
+
+### Work start state
+
+Filled during START WORK:
+
+- Assignee:
+- Branch:
+- Worktree:
+- Project item ID:
+- Project status: In progress
+
+### PR and completion evidence
+
+Filled during PR review or END WORK:
+
+- PR:
+- Validation evidence:
+- Component audit:
+- Visual review:
+- Follow-up issues:
+- Closure basis: merged PR / explicit maintainer approval
+
+### Notes
+
+Add decisions, tradeoffs, constraints, or maintainer guidance here.
+
+### Resources
+
+Add related links, Figma references, docs, logs, screenshots, or prior art here.
 ```
 
 ## Rules
 
 - Do not add emoji to section headings.
 - Avoid accent marks in headings; body text may use accents.
-- Replace `{ComponentName}` and `{reference_url}` before creating the issue.
+- Replace `{TaskName}`, `{category}`, `{team}`, and `{reference_url_or_not_applicable}` before creating the issue.
 - Write this body to a temp file and pass it with `--body-file`; do not pass multi-line markdown directly through `--body`.

--- a/.github/ISSUE_TEMPLATE/a11y.yml
+++ b/.github/ISSUE_TEMPLATE/a11y.yml
@@ -1,74 +1,111 @@
-﻿name: "â™¿ Accessibility"
-description: Fix or improve accessibility in a component or the design system overall
-title: "[A11Y] ComponentName â€” short description"
+name: "Accessibility"
+description: Fix or improve accessibility in a component, pattern, token, or workflow
+title: "[FIX] a11y - short description"
 labels: ["accessibility", "a11y"]
 body:
   - type: markdown
     attributes:
       value: |
-        ## â™¿ Accessibility Task
-        Use this for WCAG compliance, ARIA improvements, keyboard navigation, or screen reader support.
+        ## Accessibility Task
+        Use this for WCAG, ARIA, keyboard navigation, focus management, screen reader behavior, or contrast issues.
+
+        Current flow: reproduce/audit -> define expected accessible behavior -> START WORK Project gate -> implement -> keyboard/screen reader/axe evidence -> PR -> END WORK after merge or maintainer approval.
+
+        Use `[FIX]` for accessibility defects and `[UPDATE]` for intentional accessibility improvements.
 
   - type: input
-    id: affected-component
+    id: affected-area
     attributes:
-      label: Affected component / area
-      placeholder: e.g. Switch, Modal, Color tokens â€” contrast ratios
+      label: Affected component or area
+      placeholder: e.g. Select, Modal focus restore, color tokens contrast
+    validations:
+      required: true
+
+  - type: dropdown
+    id: team
+    attributes:
+      label: Team
+      options:
+        - Squad 1
+        - Squad 2
+        - Squad 3
     validations:
       required: true
 
   - type: dropdown
     id: wcag-level
     attributes:
-      label: WCAG level targeted
+      label: WCAG target
       options:
-        - A (minimum)
-        - AA (standard â€” our baseline)
-        - AAA (enhanced)
+        - A
+        - AA (baseline)
+        - AAA
         - Not WCAG-specific
     validations:
       required: true
 
   - type: textarea
-    id: issue-description
+    id: current-problem
     attributes:
-      label: Accessibility issue
-      description: What is the current problem? How was it detected?
+      label: Current accessibility problem
+      description: What happens today? How was it detected?
       placeholder: |
-        The Switch component uses `aria-label` on the wrapper `<div>` instead of the `<input>`.
-        Screen readers announce the label but don't associate it correctly with the control.
-        Detected via: axe DevTools / manual VoiceOver testing / automated audit.
+        Current behavior:
+        Expected behavior:
+        Detected with: keyboard / VoiceOver / NVDA / axe / Storybook / code review
     validations:
       required: true
 
   - type: textarea
-    id: proposed-fix
+    id: expected-contract
     attributes:
-      label: Proposed fix
+      label: Expected accessibility contract
+      description: Define the target pattern before implementation.
       placeholder: |
-        Move `aria-label` to the `<input type="checkbox">` element.
-        Add `aria-describedby` linking to the helper text if present.
+        Pattern reference: native / Radix / WAI-ARIA APG
+        Roles and accessible name:
+        Keyboard behavior:
+        Focus lifecycle:
+        State announcements:
+        WCAG criterion, if known:
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction or audit evidence
+      placeholder: Steps, screenshots, axe output, screen reader notes, failing test, or Storybook URL.
 
   - type: checkboxes
-    id: phases
+    id: validation
     attributes:
-      label: "âœ… Implementation phases"
+      label: Required validation
       options:
-        - label: "1. **Audit** â€” reproduce the issue with a screen reader or axe tool. Document findings."
-        - label: "2. **Specification** â€” define the correct ARIA pattern and keyboard behavior."
-        - label: "3. **Implementation** â€” apply the fix following WCAG guidelines."
-        - label: "4. **Test** â€” verify with axe-core, keyboard navigation, and screen reader (VoiceOver / NVDA)."
-        - label: "5. **Storybook** â€” add or update a11y notes in docs."
-        - label: "6. **Merge to main** â€” project lead merges the PR."
+        - label: Role/name semantics verified.
+        - label: Keyboard-only flow verified.
+        - label: Focus lifecycle verified.
+        - label: Screen reader or axe/manual evidence included where applicable.
+        - label: Regression test added or updated.
+        - label: Storybook notes or examples updated when user-facing behavior changes.
+
+  - type: checkboxes
+    id: workflow-gates
+    attributes:
+      label: Workflow gates
+      options:
+        - label: START WORK must assign the issue, move Project status to `In progress`, and record branch/worktree before implementation.
+        - label: PR must link this issue and include validation evidence.
+        - label: END WORK moves the Project item to `Done` only after merge or explicit maintainer approval.
 
   - type: textarea
     id: notes
     attributes:
-      label: "ðŸ“Ž Additional notes"
-      placeholder: Screen reader tested, tools used, WCAG criterion reference. Tag @Stack-and-Flow/maintainers for questions.
+      label: Additional notes
+      placeholder: Related issues, constraints, or maintainer decisions.
 
   - type: textarea
     id: resources
     attributes:
-      label: "ðŸ”— Related resources"
-      placeholder: WCAG docs, ARIA authoring practices, axe report, related issues.
+      label: Related resources
+      placeholder: WCAG, APG, axe report, browser/screen-reader matrix, related PRs.

--- a/.github/ISSUE_TEMPLATE/ci.yml
+++ b/.github/ISSUE_TEMPLATE/ci.yml
@@ -1,27 +1,40 @@
-﻿name: "âš™ï¸ CI / Tooling"
-description: Add or improve GitHub Actions workflows, build tooling, or dev infrastructure
-title: "[CI] Short description"
-labels: ["ci", "tooling"]
+name: "Infrastructure / Tooling"
+description: Add or improve CI, build tooling, project automation, or development infrastructure
+title: "[INFRA] Short description"
+labels: ["ci", "tooling", "infra"]
 body:
   - type: markdown
     attributes:
       value: |
-        ## âš™ï¸ CI / Tooling Task
-        Use this for GitHub Actions, Vite config, Biome, Lefthook, Storybook build, or other dev tooling.
+        ## Infrastructure Task
+        Use this for GitHub Actions, Vite, Biome, Lefthook, Storybook build, tests, release automation, or project tooling.
+
+        Current flow: define problem and risk -> plan exact config change -> START WORK Project gate -> implement -> verify with local command or workflow run -> PR -> END WORK after merge or maintainer approval.
 
   - type: dropdown
     id: area
     attributes:
       label: Area
       options:
-        - GitHub Actions (CI/CD)
+        - GitHub Actions / CI
         - Vite / build config
-        - Biome (linting / formatting)
-        - Lefthook (git hooks)
+        - Biome / formatting
+        - Lefthook / git hooks
         - Storybook build / deployment
-        - Testing infrastructure (Vitest)
+        - Testing infrastructure
         - Release / versioning
         - Other tooling
+    validations:
+      required: true
+
+  - type: dropdown
+    id: team
+    attributes:
+      label: Team
+      options:
+        - Squad 1
+        - Squad 2
+        - Squad 3
     validations:
       required: true
 
@@ -30,9 +43,7 @@ body:
     attributes:
       label: Motivation
       description: What problem does this solve or what capability does it add?
-      placeholder: |
-        Currently there is no automated test run on PRs. Contributors can merge code
-        that breaks existing tests without noticing until after merge.
+      placeholder: Describe the current limitation, failure mode, or missing automation.
     validations:
       required: true
 
@@ -42,33 +53,42 @@ body:
       label: Proposed change
       description: What exactly needs to be added or changed?
       placeholder: |
-        Add a GitHub Actions workflow `.github/workflows/ci.yml` that:
-        - Runs on every PR targeting `main`
-        - Executes `pnpm test` and reports results
-        - Blocks merge if tests fail
+        Files/config affected:
+        Expected behavior:
+        Secrets or environment assumptions:
+        Rollback plan:
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation plan
+      description: How should this be verified before PR review?
+      placeholder: |
+        Local commands:
+        Workflow run URL or draft PR check:
+        Failure/rollback check:
     validations:
       required: true
 
   - type: checkboxes
-    id: phases
+    id: workflow-gates
     attributes:
-      label: "âœ… Implementation phases"
+      label: Workflow gates
       options:
-        - label: "1. **Research** â€” investigate the right approach, existing examples, constraints."
-        - label: "2. **Specification** â€” define the exact configuration. Document in this issue."
-        - label: "3. **Implementation** â€” write the workflow / config."
-        - label: "4. **Verify** â€” test locally or on a draft PR."
-        - label: "5. **Code review** â€” review by egdev6."
-        - label: "6. **Merge to main** â€” project lead merges the PR."
+        - label: START WORK must assign the issue, move Project status to `In progress`, and record branch/worktree before implementation.
+        - label: PR must link this issue and include validation evidence.
+        - label: END WORK moves the Project item to `Done` only after merge or explicit maintainer approval.
 
   - type: textarea
     id: notes
     attributes:
-      label: "ðŸ“Ž Additional notes"
-      placeholder: Any constraints, secrets needed, or related issues. Tag @Stack-and-Flow/maintainers for questions.
+      label: Additional notes
+      placeholder: Constraints, secrets, compatibility risks, or related decisions.
 
   - type: textarea
     id: resources
     attributes:
-      label: "ðŸ”— Related resources"
-      placeholder: GitHub Actions docs, existing workflow references, related issues.
+      label: Related resources
+      placeholder: GitHub Actions docs, workflow runs, logs, examples, related issues.

--- a/.github/ISSUE_TEMPLATE/component.yml
+++ b/.github/ISSUE_TEMPLATE/component.yml
@@ -1,5 +1,5 @@
 name: "New Component"
-description: Create a new component for the design system (atom, molecule, or organism)
+description: Propose and implement a new design-system component through the current spec-first workflow
 title: "[ATOMS] ComponentName"
 labels: ["component"]
 body:
@@ -7,13 +7,17 @@ body:
     attributes:
       value: |
         ## New Component Task
-        Follow all 6 phases in order. The contributor handles phases 1-5; egdev6 handles the merge in phase 6.
+        Use this for atoms, molecules, and organisms. New components must go through `component-spec-proposer` before implementation.
+
+        Current flow: reference and context -> validated component spec -> START WORK Project gate -> implementation -> component audit, visual review, accessibility evidence -> PR -> END WORK after merge or maintainer approval.
+
+        Set the title prefix to `[ATOMS]`, `[MOLECULES]`, or `[ORGANISMS]` based on the selected level.
 
   - type: input
     id: component-name
     attributes:
       label: Component name
-      placeholder: e.g. Autocomplete, DatePicker, Modal
+      placeholder: e.g. Select, Autocomplete, DatePicker, Modal
     validations:
       required: true
 
@@ -21,11 +25,24 @@ body:
     id: atomic-level
     attributes:
       label: Atomic level
-      description: Where does this component live in the atomic design hierarchy?
+      description: Where should this component live?
       options:
         - Atom
         - Molecule
         - Organism
+        - Needs proposal
+    validations:
+      required: true
+
+  - type: dropdown
+    id: team
+    attributes:
+      label: Team
+      description: Project board team field.
+      options:
+        - Squad 1
+        - Squad 2
+        - Squad 3
     validations:
       required: true
 
@@ -33,60 +50,59 @@ body:
     id: reference
     attributes:
       label: Reference URL
-      description: Link to the relevant primitive/spec reference (for example Radix UI, MDN, or WAI-ARIA APG)
-      placeholder: https://www.radix-ui.com/primitives/docs/components/...
+      description: Required before spec proposal. Use HeroUI, Radix, MDN, WAI-ARIA APG, or another source of behavior.
+      placeholder: https://www.heroui.com/docs/components/select
+    validations:
+      required: true
 
   - type: textarea
     id: context
     attributes:
-      label: Context / motivation
-      description: Why does this component need to exist? What problem does it solve?
-      placeholder: Brief description of the use case and why it belongs in the design system.
-
-  - type: checkboxes
-    id: phases
-    attributes:
-      label: "Development phases"
-      options:
-        - label: "1. **Research** - investigate similar solutions, existing patterns, real use cases. Add screenshots, links, or benchmarks if applicable."
-        - label: "2. **Specification** - define props, states, interaction, accessibility, variants, and Storybook coverage. Document the validated spec in this issue."
-        - label: "3. **Implementation** - build the component based on the spec. Follow the 6-file pattern: types, hook, component, tests, stories, index."
-        - label: "4. **Storybook** - document with args, controls, JSDoc above `const meta`, and JSDoc above every story export."
-        - label: "5. **Code review** - functional review, component audit, visual review, accessibility review, and fix suggestions."
-        - label: "6. **Merge to main** - once approved, project lead merges the PR."
+      label: Context and motivation
+      description: What problem does this component solve? Who needs it?
+      placeholder: Describe the product/design-system need and any known constraints.
+    validations:
+      required: true
 
   - type: textarea
-    id: spec
+    id: validated-spec
     attributes:
-      label: "Specification (fill after phase 2)"
-      description: Props, variants, states, interactions, a11y requirements. This is what the AI agent will use to implement.
+      label: Validated component spec
+      description: Fill this after `component-spec-proposer` and maintainer validation. Do not implement from an unvalidated spec.
       placeholder: |
-        ### Props
-        - `variant`: 'default' | 'outlined' | 'ghost'
-        - `size`: 'sm' | 'md' | 'lg'
-        - `disabled`: boolean
+        Paste the `## Validated component spec` output here after approval.
 
-        ### States
-        - default, hover, focus, active, disabled, loading
+        Must include scope, API props, CVA variants, states, accessibility contract, accessibility acceptance criteria, stories, design notes, reference behavior, and expected tests.
 
-        ### Accessibility
-        - aria-label required when no visible label
-        - keyboard navigable (Tab, Enter, Escape where applicable)
-        - visible focus ring and reduced-motion behavior
+  - type: checkboxes
+    id: accessibility-gate
+    attributes:
+      label: Accessibility gate for interactive or composite components
+      options:
+        - label: "Pattern reference is named: native, Radix primitive, or WAI-ARIA APG pattern."
+        - label: "Roles, accessible name, ARIA relationships, keyboard matrix, and focus lifecycle are specified."
+        - label: "Disabled, required, invalid/error, loading, and empty states have expected semantics where applicable."
+        - label: "Expected tests include role/name queries, keyboard behavior, focus behavior, and ARIA state transitions where applicable."
 
-        ### Notes
-        - Uses Radix UI primitive under the hood when a primitive is needed
-        - CVA for variant management
-        - Named component export plus type exports from `index.ts`
+  - type: checkboxes
+    id: workflow-gates
+    attributes:
+      label: Workflow gates
+      options:
+        - label: Spec proposal must be approved before implementation starts.
+        - label: START WORK must assign the issue, move Project status to `In progress`, and record branch/worktree.
+        - label: Implementation must follow the 6-file component pattern.
+        - label: Component audit, visual review, accessibility evidence, and focused tests are required before PR review.
+        - label: END WORK moves the Project item to `Done` only after merge or explicit maintainer approval.
 
   - type: textarea
     id: notes
     attributes:
-      label: "Additional notes"
-      placeholder: Any comments, decisions made, or special considerations. Tag @Stack-and-Flow/maintainers for questions.
+      label: Additional notes
+      placeholder: Open questions, tradeoffs, expected non-goals, or related decisions.
 
   - type: textarea
     id: resources
     attributes:
-      label: "Related resources"
-      placeholder: External links, Figma files, prior art, etc.
+      label: Related resources
+      placeholder: Figma, examples, APG links, related issues, screenshots, or prior art.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
-﻿blank_issues_enabled: false
+blank_issues_enabled: false
 contact_links:
-  - name: ðŸ’¬ Ask a question
+  - name: Ask a question
     url: https://github.com/orgs/Stack-and-Flow/discussions
     about: For general questions, use GitHub Discussions instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/fix.yml
+++ b/.github/ISSUE_TEMPLATE/fix.yml
@@ -1,30 +1,43 @@
-﻿name: "ðŸ› Bug Fix"
-description: Report and fix a bug in an existing component or utility
+name: "Bug Fix"
+description: Report and fix a bug in an existing component, utility, workflow, or package behavior
 title: "[FIX] Short description of the bug"
 labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        ## ðŸ› Bug Fix Task
-        Describe the bug clearly so the fix can be implemented without ambiguity.
+        ## Bug Fix Task
+        Use this when existing behavior is wrong or regressed.
+
+        Current flow: reproduce with evidence -> identify root cause -> START WORK Project gate -> fix with regression test -> focused validation -> PR -> END WORK after merge or maintainer approval.
 
   - type: input
-    id: affected-component
+    id: affected-area
     attributes:
-      label: Affected component / file
-      placeholder: e.g. Button, Switch, src/components/atoms/switch/Switch.tsx
+      label: Affected component, file, or workflow
+      placeholder: e.g. Button, Select keyboard behavior, src/components/atoms/select/Select.tsx
+    validations:
+      required: true
+
+  - type: dropdown
+    id: team
+    attributes:
+      label: Team
+      options:
+        - Squad 1
+        - Squad 2
+        - Squad 3
     validations:
       required: true
 
   - type: textarea
-    id: description
+    id: behavior
     attributes:
-      label: Bug description
-      description: What is happening? What should be happening instead?
+      label: Current and expected behavior
       placeholder: |
-        **Current behavior:** ...
-        **Expected behavior:** ...
+        Current behavior:
+        Expected behavior:
+        User impact:
     validations:
       required: true
 
@@ -33,32 +46,41 @@ body:
     attributes:
       label: Steps to reproduce
       placeholder: |
-        1. Render `<Switch label="test" />`
-        2. Inspect the DOM
-        3. Notice `aria-label` is missing on the `<input>` element
+        1. Render or open ...
+        2. Perform ...
+        3. Observe ...
     validations:
       required: true
 
   - type: textarea
-    id: context
+    id: root-cause
     attributes:
-      label: Context / root cause (if known)
-      placeholder: Optional â€” share any investigation or hypothesis about why this happens.
+      label: Root cause or investigation notes
+      description: Optional when opening; required before implementation handoff if known.
+      placeholder: Failing test, suspect file, previous PR, browser/device, or logs.
 
   - type: checkboxes
-    id: phases
+    id: validation
     attributes:
-      label: "âœ… Fix phases"
+      label: Fix validation
       options:
-        - label: "1. **Reproduce** â€” confirm the bug locally with a test case."
-        - label: "2. **Root cause** â€” identify why it happens. Document in this issue."
-        - label: "3. **Fix** â€” implement the correction following project conventions."
-        - label: "4. **Test** â€” add or update tests that cover this case."
-        - label: "5. **Code review** â€” functional + visual review."
-        - label: "6. **Merge to main** â€” project lead merges the PR."
+        - label: Regression test added or updated.
+        - label: Focused affected tests pass.
+        - label: TypeScript/build impact checked when source or exports changed.
+        - label: Storybook/manual reproduction checked when UI behavior changed.
+        - label: Accessibility evidence included when the bug affects semantics, keyboard, focus, or contrast.
+
+  - type: checkboxes
+    id: workflow-gates
+    attributes:
+      label: Workflow gates
+      options:
+        - label: START WORK must assign the issue, move Project status to `In progress`, and record branch/worktree before implementation.
+        - label: PR must link this issue and include validation evidence.
+        - label: END WORK moves the Project item to `Done` only after merge or explicit maintainer approval.
 
   - type: textarea
     id: notes
     attributes:
-      label: "ðŸ“Ž Additional notes"
-      placeholder: Any edge cases, related issues, or decisions. Tag @Stack-and-Flow/maintainers for questions.
+      label: Additional notes
+      placeholder: Edge cases, related issues, known limitations, or maintainer decisions.

--- a/.github/ISSUE_TEMPLATE/npm.yml
+++ b/.github/ISSUE_TEMPLATE/npm.yml
@@ -1,13 +1,15 @@
-﻿name: "ðŸ“¦ NPM / Dependencies"
-description: Update, add or remove npm packages
-title: "[NPM] Package name â€” short description"
-labels: ["dependencies"]
+name: "NPM / Dependencies"
+description: Update, add, remove, or audit npm packages and package metadata
+title: "[INFRA] dependency update - package name"
+labels: ["dependencies", "infra"]
 body:
   - type: markdown
     attributes:
       value: |
-        ## ðŸ“¦ NPM / Dependencies Task
-        Use this for dependency updates, security fixes, or adding/removing packages.
+        ## NPM / Dependencies Task
+        Use this for dependency updates, security fixes, peer dependency changes, package metadata, or dependency removals.
+
+        Current flow: research changelog and risk -> define update plan -> START WORK Project gate -> update -> verify build/tests/package consumption -> PR -> END WORK after merge or maintainer approval.
 
   - type: dropdown
     id: change-type
@@ -15,62 +17,79 @@ body:
       label: Type of change
       options:
         - Update existing dependency (minor/patch)
-        - Update existing dependency (major â€” breaking)
+        - Update existing dependency (major or breaking)
         - Add new dependency
         - Remove dependency
         - Security fix
+        - Package metadata or exports change
+    validations:
+      required: true
+
+  - type: dropdown
+    id: team
+    attributes:
+      label: Team
+      options:
+        - Squad 1
+        - Squad 2
+        - Squad 3
     validations:
       required: true
 
   - type: textarea
     id: packages
     attributes:
-      label: Package(s) affected
+      label: Package or metadata affected
       placeholder: |
-        - `vitest`: 1.6.0 â†’ 2.1.0
-        - `@testing-library/react`: 14.x â†’ 16.x
+        - `vitest`: 1.x -> 2.x
+        - `package.json` exports map
+        - `pnpm-lock.yaml`
     validations:
       required: true
 
   - type: textarea
     id: motivation
     attributes:
-      label: Motivation
-      description: Why is this change needed?
+      label: Motivation and risk
       placeholder: |
-        vitest 2.x improves workspace support and fixes a memory leak in watch mode.
-        The update also resolves 2 moderate security advisories.
+        Why this is needed:
+        Security/advisory link:
+        Breaking changes:
+        Peer dependency or consumer impact:
     validations:
       required: true
 
   - type: textarea
-    id: breaking-changes
+    id: validation
     attributes:
-      label: Known breaking changes / migration notes
+      label: Validation plan
+      description: Include package consumption checks when package output or exports change.
       placeholder: |
-        vitest 2.x removes the `globals` option in tsconfig â€” must use `/// <reference types="vitest" />` instead.
-        Reference: https://vitest.dev/guide/migration.html
+        Commands/checks:
+        - pnpm test
+        - pnpm run build
+        - pnpm run verify:package, if package output changed
+        Rollback plan:
+    validations:
+      required: true
 
   - type: checkboxes
-    id: phases
+    id: workflow-gates
     attributes:
-      label: "âœ… Implementation phases"
+      label: Workflow gates
       options:
-        - label: "1. **Research** â€” read changelogs, identify breaking changes, check peer dependency conflicts."
-        - label: "2. **Update** â€” run `pnpm update` and resolve any conflicts."
-        - label: "3. **Verify** â€” run `pnpm test`, `pnpm build`, `pnpm storybook` to confirm nothing is broken."
-        - label: "4. **Document** â€” note any config changes needed in PR description."
-        - label: "5. **Code review** â€” review by egdev6."
-        - label: "6. **Merge to main** â€” project lead merges the PR."
+        - label: START WORK must assign the issue, move Project status to `In progress`, and record branch/worktree before implementation.
+        - label: PR must link this issue and include validation evidence.
+        - label: END WORK moves the Project item to `Done` only after merge or explicit maintainer approval.
 
   - type: textarea
     id: notes
     attributes:
-      label: "ðŸ“Ž Additional notes"
-      placeholder: Any edge cases or special considerations. Tag @Stack-and-Flow/maintainers for questions.
+      label: Additional notes
+      placeholder: Migration notes, lockfile concerns, rollback notes, related issues, or maintainer decisions.
 
   - type: textarea
     id: resources
     attributes:
-      label: "ðŸ”— Related resources"
-      placeholder: Changelog URLs, migration guides, related security advisories.
+      label: Related resources
+      placeholder: Changelog, migration guide, advisory, package docs, related PRs.

--- a/.github/ISSUE_TEMPLATE/storybook.yml
+++ b/.github/ISSUE_TEMPLATE/storybook.yml
@@ -1,61 +1,93 @@
-﻿name: "ðŸ“– Storybook"
-description: Add or improve stories, MDX documentation, or Storybook configuration
-title: "[STORYBOOK] ComponentName â€” short description"
+name: "Storybook / Docs"
+description: Add or improve stories, MDX documentation, usage guidelines, or Storybook configuration
+title: "[DOCS] ComponentName - storybook update"
 labels: ["documentation", "storybook"]
 body:
   - type: markdown
     attributes:
       value: |
-        ## ðŸ“– Storybook Task
-        Use this for stories, MDX docs, argTypes, controls, or Storybook config improvements.
+        ## Storybook / Docs Task
+        Use this for stories, MDX docs, controls, usage guidelines, visual examples, or Storybook configuration.
+
+        Current flow: identify documentation gap -> define required stories/docs -> START WORK Project gate -> implement -> Storybook/manual visual evidence -> PR -> END WORK after merge or maintainer approval.
 
   - type: input
-    id: component
+    id: affected-area
     attributes:
-      label: Component / section
-      placeholder: e.g. Button, Typography, Design Tokens â€” Colors
+      label: Component or documentation area
+      placeholder: e.g. Button, Select, Design Tokens - Colors
     validations:
       required: true
 
   - type: dropdown
     id: task-type
     attributes:
-      label: Type of Storybook work
+      label: Type of work
       options:
         - Add missing stories
-        - Improve existing stories (controls, args, decorators)
+        - Improve stories or controls
         - Write MDX documentation
-        - Add usage guidelines / design notes
+        - Add usage guidelines or design notes
         - Fix broken stories
         - Storybook configuration
     validations:
       required: true
 
-  - type: textarea
-    id: description
+  - type: dropdown
+    id: team
     attributes:
-      label: What needs to be done
-      description: Be specific â€” which stories are missing, what controls are broken, what docs are incomplete.
+      label: Team
+      options:
+        - Squad 1
+        - Squad 2
+        - Squad 3
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Which stories, docs pages, controls, or examples need work?
       placeholder: |
-        The Button component is missing stories for the `ghost` and `link` variants.
-        The `size` control is not connected to argTypes, so it doesn't appear in the Controls panel.
+        Current gap:
+        Required stories/docs:
+        Out of scope:
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation plan
+      placeholder: |
+        Storybook command/check:
+        Manual visual review notes:
+        Accessibility notes for interactive examples:
     validations:
       required: true
 
   - type: checkboxes
-    id: phases
+    id: docs-gates
     attributes:
-      label: "âœ… Implementation phases"
+      label: Storybook/docs gates
       options:
-        - label: "1. **Research** â€” review current stories and identify gaps or issues."
-        - label: "2. **Specification** â€” list all stories / docs to add or fix."
-        - label: "3. **Implementation** â€” write stories and/or MDX following project conventions."
-        - label: "4. **Visual review** â€” verify stories render correctly in Storybook locally."
-        - label: "5. **Code review** â€” review by egdev6 or another contributor."
-        - label: "6. **Merge to main** â€” project lead merges the PR."
+        - label: Stories follow project conventions and do not use Storybook `play` functions.
+        - label: Controls and args reflect the public API.
+        - label: Visual states and edge cases are represented when relevant.
+        - label: Accessibility notes are included for interactive examples when relevant.
+
+  - type: checkboxes
+    id: workflow-gates
+    attributes:
+      label: Workflow gates
+      options:
+        - label: START WORK must assign the issue, move Project status to `In progress`, and record branch/worktree before implementation.
+        - label: PR must link this issue and include validation evidence.
+        - label: END WORK moves the Project item to `Done` only after merge or explicit maintainer approval.
 
   - type: textarea
     id: notes
     attributes:
-      label: "ðŸ“Ž Additional notes"
-      placeholder: Any context, Figma references, or design guidelines. Tag @Stack-and-Flow/maintainers for questions.
+      label: Additional notes
+      placeholder: Figma references, guidelines, examples, related issues, or maintainer decisions.

--- a/.github/ISSUE_TEMPLATE/tokens.yml
+++ b/.github/ISSUE_TEMPLATE/tokens.yml
@@ -1,13 +1,15 @@
-﻿name: "ðŸŽ¨ Design Tokens"
-description: Add, update or review design tokens (colors, spacing, typography, shadows, etc.)
-title: "[TOKENS] Short description"
+name: "Design Tokens"
+description: Add, update, audit, or deprecate design tokens
+title: "[UPDATE] token area - short description"
 labels: ["tokens", "design"]
 body:
   - type: markdown
     attributes:
       value: |
-        ## ðŸŽ¨ Design Tokens Task
-        Use this for changes to CSS custom properties, Tailwind theme config, or color/typography systems.
+        ## Design Tokens Task
+        Use this for CSS custom properties, Tailwind token utilities, color, typography, spacing, radius, shadow, motion, or token documentation.
+
+        Current flow: audit token need and consumers -> define token/spec impact -> START WORK Project gate -> implement -> contrast/visual/docs evidence -> PR -> END WORK after merge or maintainer approval.
 
   - type: dropdown
     id: token-type
@@ -15,12 +17,23 @@ body:
       label: Token category
       options:
         - Colors
-        - Typography (fonts, sizes, weights, line-heights)
+        - Typography
         - Spacing / sizing
         - Shadows / elevation
         - Border radius
         - Animation / transitions
         - Multiple categories
+    validations:
+      required: true
+
+  - type: dropdown
+    id: team
+    attributes:
+      label: Team
+      options:
+        - Squad 1
+        - Squad 2
+        - Squad 3
     validations:
       required: true
 
@@ -30,49 +43,62 @@ body:
       label: Motivation
       description: Why do these tokens need to change or be added?
       placeholder: |
-        Current red tokens fail WCAG AA contrast on light backgrounds.
-        We need accessible red variants that still align with brand identity.
+        Current limitation:
+        Design-system need:
+        Accessibility/contrast impact:
     validations:
       required: true
 
   - type: textarea
     id: proposed-tokens
     attributes:
-      label: Proposed tokens / values
-      description: List the new or updated token names and values (or describe the intent if values are TBD).
+      label: Proposed token changes
+      description: List token names/values when known, or describe the intended semantic role.
       placeholder: |
-        --color-primary-accessible: #c0392b  (replaces --color-primary in text contexts)
-        --color-primary-subtle: #f5b7b1      (backgrounds, low-emphasis uses)
+        Add/update/deprecate:
+        Consumers/components impacted:
+        Storybook/docs impact:
+    validations:
+      required: true
 
   - type: checkboxes
-    id: backward-compat
+    id: compatibility
     attributes:
-      label: Backward compatibility
+      label: Compatibility
       options:
-        - label: "Keep existing tokens and add new ones (no breaking change)"
-        - label: "Deprecate existing tokens (mark as deprecated in Storybook)"
-        - label: "Remove existing tokens (breaking â€” requires component migration)"
+        - label: Existing tokens remain compatible.
+        - label: Existing tokens are deprecated and migration notes are required.
+        - label: Existing tokens are removed or renamed and this is breaking.
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation plan
+      placeholder: |
+        Contrast checks:
+        Component/story visual checks:
+        Build/test commands:
+        Documentation updates:
+    validations:
+      required: true
 
   - type: checkboxes
-    id: phases
+    id: workflow-gates
     attributes:
-      label: "âœ… Implementation phases"
+      label: Workflow gates
       options:
-        - label: "1. **Research** â€” audit current token usage, contrast ratios, brand constraints."
-        - label: "2. **Specification** â€” define new token names, values and rationale. Document in this issue."
-        - label: "3. **Implementation** â€” update `theme.css` / Tailwind config."
-        - label: "4. **Storybook** â€” update color/token pages, mark deprecated tokens."
-        - label: "5. **Code review** â€” visual + accessibility review."
-        - label: "6. **Merge to main** â€” project lead merges the PR."
+        - label: START WORK must assign the issue, move Project status to `In progress`, and record branch/worktree before implementation.
+        - label: PR must link this issue and include validation evidence.
+        - label: END WORK moves the Project item to `Done` only after merge or explicit maintainer approval.
 
   - type: textarea
     id: notes
     attributes:
-      label: "ðŸ“Ž Additional notes"
-      placeholder: Figma references, contrast tool links, accessibility requirements. Tag @Stack-and-Flow/maintainers for questions.
+      label: Additional notes
+      placeholder: Figma references, contrast tools, migration notes, related issues, or maintainer decisions.
 
   - type: textarea
     id: resources
     attributes:
-      label: "ðŸ”— Related resources"
-      placeholder: Figma, Coolors, accessibility checker, related issues.
+      label: Related resources
+      placeholder: Figma, accessibility checker, token references, screenshots, related issues.

--- a/.github/ISSUE_TEMPLATE/update.yml
+++ b/.github/ISSUE_TEMPLATE/update.yml
@@ -1,19 +1,46 @@
-﻿name: "ðŸ”„ Update / Refactor"
-description: Improve, refactor or extend an existing component or feature
+name: "Update or Refactor"
+description: Improve, refactor, or extend an existing component or system behavior
 title: "[UPDATE] Short description of the change"
 labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        ## ðŸ”„ Update / Refactor Task
-        Use this for improvements, refactors, or extensions to existing functionality.
+        ## Update or Refactor Task
+        Use this for behavior extensions, API changes, refactors, and quality improvements that are not simple bug fixes.
+
+        Current flow: define motivation and scope -> approve spec/plan when behavior changes -> START WORK Project gate -> implement -> validation and audit evidence -> PR -> END WORK after merge or maintainer approval.
 
   - type: input
-    id: affected-component
+    id: affected-area
     attributes:
-      label: Affected component / area
-      placeholder: e.g. Button variants, Modal controlled pattern, token system
+      label: Affected component or area
+      placeholder: e.g. Modal controlled pattern, Table sorting, token system
+    validations:
+      required: true
+
+  - type: dropdown
+    id: team
+    attributes:
+      label: Team
+      options:
+        - Squad 1
+        - Squad 2
+        - Squad 3
+    validations:
+      required: true
+
+  - type: dropdown
+    id: board-category
+    attributes:
+      label: Board category
+      description: Choose the Project board category this update belongs to.
+      options:
+        - component
+        - infra
+        - a11y
+        - docs
+        - tokens
     validations:
       required: true
 
@@ -21,10 +48,8 @@ body:
     id: motivation
     attributes:
       label: Motivation
-      description: Why is this change needed? What problem or limitation does it solve?
-      placeholder: |
-        The current Modal only works as uncontrolled. We need a controlled mode
-        so consumers can manage open/close state externally.
+      description: Why is this change needed? What limitation does it solve?
+      placeholder: Describe the current limitation, desired outcome, and user impact.
     validations:
       required: true
 
@@ -32,39 +57,78 @@ body:
     id: proposed-change
     attributes:
       label: Proposed change
-      description: What exactly needs to change? Be specific about props, API, behavior.
+      description: Define the API, behavior, migration, and non-goals before implementation.
       placeholder: |
-        Add `open` and `onOpenChange` props following the controlled/uncontrolled pattern.
-        Keep backward compatibility â€” if `open` is not provided, it stays uncontrolled.
+        Proposed behavior/API:
+        Non-goals:
+        Backward compatibility:
+        Migration notes:
+    validations:
+      required: true
+
+  - type: textarea
+    id: accessibility-impact
+    attributes:
+      label: Accessibility impact
+      description: State `Not applicable` only when interaction, semantics, focus, contrast, and motion are unaffected.
+      placeholder: |
+        Pattern or standard:
+        Keyboard impact:
+        Screen reader impact:
+        Focus impact:
+        Contrast or reduced-motion impact:
+        Required accessibility validation:
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation-plan
+    attributes:
+      label: Validation plan
+      placeholder: |
+        TypeScript:
+        Unit tests:
+        Build/package:
+        Storybook or visual check:
+        Accessibility check:
+    validations:
+      required: true
 
   - type: checkboxes
-    id: phases
+    id: behavior-gates
     attributes:
-      label: "âœ… Implementation phases"
+      label: Behavior and accessibility gates
       options:
-        - label: "1. **Research** â€” review current implementation and identify impact surface."
-        - label: "2. **Specification** â€” define the new API / behavior. Document in this issue."
-        - label: "3. **Implementation** â€” apply the change following project conventions."
-        - label: "4. **Storybook** â€” update or add stories to reflect the new behavior."
-        - label: "5. **Code review** â€” functional + visual review + migration notes if breaking."
-        - label: "6. **Merge to main** â€” project lead merges the PR."
+        - label: Public API changes are intentional and documented.
+        - label: Accessibility contract is updated when interaction, focus, semantics, or state announcements change.
+        - label: Storybook stories/docs are updated when user-facing behavior changes.
+        - label: Tests cover the changed behavior and old behavior that must remain compatible.
 
   - type: checkboxes
     id: breaking
     attributes:
-      label: Breaking change?
+      label: Breaking change
       options:
-        - label: "Yes â€” this change breaks existing consumers (describe migration in notes)"
-        - label: "No â€” fully backward compatible"
+        - label: This change is backward compatible.
+        - label: This change breaks existing consumers and requires migration notes.
+
+  - type: checkboxes
+    id: workflow-gates
+    attributes:
+      label: Workflow gates
+      options:
+        - label: START WORK must assign the issue, move Project status to `In progress`, and record branch/worktree before implementation.
+        - label: PR must link this issue and include validation evidence.
+        - label: END WORK moves the Project item to `Done` only after merge or explicit maintainer approval.
 
   - type: textarea
     id: notes
     attributes:
-      label: "ðŸ“Ž Additional notes"
-      placeholder: Migration guide, deprecation notices, related issues. Tag @Stack-and-Flow/maintainers for questions.
+      label: Additional notes
+      placeholder: Migration guide, deprecation plan, related issues, or maintainer decisions.
 
   - type: textarea
     id: resources
     attributes:
-      label: "ðŸ”— Related resources"
-      placeholder: Issues, PRs, documentation links.
+      label: Related resources
+      placeholder: Issues, PRs, docs, references, examples, or design notes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,51 +1,74 @@
 ## Summary
 
-<!-- What does this PR do? One or two sentences. -->
+<!-- What changed, who it helps, and why it matters. Keep it short. -->
 
 Closes #<!-- issue number -->
+
+## Review scope
+
+<!-- Tell reviewers what to inspect first and what is intentionally out of scope. -->
+
+- Primary files/areas:
+- Out of scope:
+- Review workload: <!-- small / medium / large; explain if >400 changed lines -->
 
 ## Type of change
 
 - [ ] New component
+- [ ] Existing component update/refactor
 - [ ] Bug fix
-- [ ] Design tokens
 - [ ] Accessibility
-- [ ] Infrastructure
-- [ ] Documentation
+- [ ] Design tokens
+- [ ] Storybook/docs
+- [ ] Infrastructure/tooling
+- [ ] NPM/dependencies
 
-## Repository checklist
+## Workflow gates
 
-- [ ] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`
-- [ ] Commit messages follow the same commitlint-enforced format
-- [ ] PR description links the issue with `Closes #NNN`
-- [ ] Security checks pass, or any false positives are documented in the PR
-- [ ] MCP/runtime artifacts are absent: `.playwright-mcp`, `page-*.png`, `page-*.jpeg`, `*.md.playwright-output`
+- [ ] Linked issue is present with `Closes #NNN` or maintainer approved an exception.
+- [ ] Work was started through the Project flow: assignee set, Project status `In progress`, branch/worktree recorded.
+- [ ] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`.
+- [ ] Commits follow the same commitlint-enforced format.
+- [ ] Diff is focused; unrelated work is called out in Review scope.
+- [ ] MCP/runtime artifacts are absent: `.playwright-mcp`, `page-*.png`, `page-*.jpeg`, `*.md.playwright-output`.
 
-## Component checklist (skip if not applicable)
+## Component evidence (required for component changes)
 
-- [ ] Follows the 6-file pattern (`types.ts`, `use*.ts`, `Component.tsx`, `Component.test.tsx`, `Component.stories.tsx`, `index.ts`)
-- [ ] Uses named component exports plus type exports
-- [ ] CVA variants defined in `types.ts`, not inline
-- [ ] No hardcoded colors — uses tokens from `theme.css`
-- [ ] No `any` types — TypeScript strict
-- [ ] ARIA attributes present and correct
-- [ ] Keyboard navigable (Tab, Enter, Escape where applicable)
-- [ ] Dark mode works correctly
-- [ ] Storybook stories cover default, variants, and states; docs use JSDoc above `const meta` and each story export
-- [ ] Tests added or updated
+- [ ] Validated component spec is linked or quoted in the issue.
+- [ ] Accessibility contract from the spec was implemented or deviations are explained below.
+- [ ] Follows the 6-file pattern: `types.ts`, `use*.ts`, `Component.tsx`, `Component.test.tsx`, `Component.stories.tsx`, `index.ts`.
+- [ ] CVA variants live in `types.ts`; JSX component has no state, CVA calls, or business logic.
+- [ ] Uses design tokens from `theme.css`; no hardcoded colors or arbitrary color utilities.
+- [ ] Storybook covers default, variants, documented states, edge cases, and dark mode when visually different.
+- [ ] Component audit result is PASS or accepted PASS WITH WARNINGS.
+- [ ] Visual review result is included when visuals changed.
 
-## How to test
+## Accessibility evidence
 
-<!-- Steps to verify this works locally -->
+<!-- Required for interactive components and a11y changes. Use N/A only for static display changes. -->
 
-1. `pnpm run storybook`
-2. Navigate to `...`
-3. Verify that `...`
+- [ ] Role/name semantics verified with Testing Library queries or equivalent.
+- [ ] Keyboard-only behavior verified: Tab / Shift+Tab, Enter / Space, Arrow keys, Escape, Home / End / typeahead where applicable.
+- [ ] Focus lifecycle verified: initial focus, roving/active descendant, focus restore, trap/portal behavior where applicable.
+- [ ] Disabled, required, invalid/error, loading, and empty states expose the expected semantics where applicable.
+- [ ] Reduced motion behavior is respected where motion changed.
+- [ ] Screen reader or axe/manual evidence is included below when applicable.
 
-## Screenshots / recordings (if applicable)
+## Validation evidence
 
-<!-- Drag and drop images or screen recordings here -->
+<!-- Paste commands and results. If a check was skipped, explain why. -->
+
+- TypeScript:
+- Unit tests:
+- Build/package:
+- Storybook or visual check:
+- Accessibility check:
+- Security/dependency check:
+
+## Screenshots or recordings
+
+<!-- Required for visual changes when possible. Drag and drop images or recordings here. -->
 
 ## Notes for reviewer
 
-<!-- Anything the reviewer should know: tradeoffs, known limitations, follow-up issues -->
+<!-- Tradeoffs, known limitations, follow-up issues, spec deviations, or maintainer decisions. -->


### PR DESCRIPTION
## Summary

Aligns GitHub issue/PR templates and task workflow references with the current Stack-and-Flow START WORK / END WORK process.

Closes #234

## Review scope

- Primary files/areas: `.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/*.yml`, `github-project-tasks` references, and the spec-proposer Project-status handoff helper
- Out of scope: spinner runtime changes (#232), accessibility spec hardening (#233)
- Review workload: large; user explicitly requested this as block 3 of 3, so this PR keeps the template/workflow unit together despite exceeding 400 changed lines.

## Type of change

- [ ] New component
- [ ] Existing component update/refactor
- [ ] Bug fix
- [ ] Accessibility
- [ ] Design tokens
- [x] Storybook/docs
- [x] Infrastructure/tooling
- [ ] NPM/dependencies

## Workflow gates

- [x] Linked issue is present with `Closes #NNN` or maintainer approved an exception.
- [x] Work was started through the Project flow: assignee set, Project status `In progress`, branch/worktree recorded.
- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`.
- [x] Commits follow the same commitlint-enforced format.
- [x] Diff is focused; unrelated work is called out in Review scope.
- [x] MCP/runtime artifacts are absent.

## Component evidence (required for component changes)

N/A; workflow/template docs only.

## Accessibility evidence

- [x] Role/name semantics verified with Testing Library queries or equivalent. N/A for template docs.
- [x] Keyboard-only behavior verified where applicable. Templates now ask for keyboard evidence when relevant.
- [x] Focus lifecycle verified where applicable. Templates now ask for focus evidence when relevant.
- [x] Disabled, required, invalid/error, loading, and empty states expose the expected semantics where applicable. Templates now ask for state evidence when relevant.
- [x] Reduced motion behavior is respected where motion changed. Templates now ask for motion evidence when relevant.
- [x] Screen reader or axe/manual evidence is included below when applicable. Templates now ask for this evidence when relevant.

## Validation evidence

- TypeScript: pre-commit typecheck passed.
- Unit tests: full pre-push `pnpm test` passed, 371 tests.
- Build/package: not applicable.
- Storybook or visual check: not applicable.
- Accessibility check: fresh reviewer re-check passed with no blockers after fixing a11y/update template gaps.
- Security/dependency check: not applicable.
- Template parsing: `python3`/PyYAML parsed all `.github/ISSUE_TEMPLATE/*.yml`; `git diff --check` passed.

## Screenshots or recordings

N/A.

## Notes for reviewer

This PR intentionally includes the workflow-status fix that makes `component-spec-proposer` add the validated spec but leave `In progress` transition to START WORK. It does not include the separate accessibility hardening from #233.

All three split PRs target `main` by request. If #233 lands first, this PR may need a small rebase around `.atl/skills/component-spec-proposer/SKILL.md`.
