### PR TITLE
docs: require milestone on task creation

### DIFF
--- a/.atl/skills/github-project-tasks/SKILL.md
+++ b/.atl/skills/github-project-tasks/SKILL.md
@@ -38,6 +38,7 @@ That template is the single source of truth for the issue body. Do not duplicate
 | Status values | `Todo`, `In progress`, `Done` |
 | Team values | `Squad 1`, `Squad 2`, `Squad 3` |
 | Category values | `component`, `fix`, `infra`, `a11y`, `docs`, `tokens` |
+| Milestone values | Query open repo milestones at creation time; current values are `Core`, `MVP`, `V1` |
 
 Field IDs:
 
@@ -69,7 +70,8 @@ Option IDs:
 - Never use emojis in issue body markdown; Windows/PowerShell + `gh` can corrupt them.
 - Avoid accent marks in section headings; body text may use accents.
 - Always write multi-line issue bodies to a temp file and pass `--body-file`.
-- Confirm task name, tier/type, reference URL when applicable, assignee, team, and category before CREATE.
+- Confirm task name, tier/type, reference URL when applicable, assignee, team, category, and milestone before CREATE.
+- Milestone is mandatory for CREATE. If it is missing, ask interactively before creating the issue; do not invent it.
 - Before implementation starts from a GitHub issue, require the exact issue label `status:approved`, then run START WORK: assign the issue to the contributor/user and move the Project item to `In progress`.
 - Before marking a task done, run END WORK: add validation/PR evidence and move the Project item to `Done` only when merged or explicitly approved by the maintainer/user.
 - Do not invent a missing reference URL; ask or research.
@@ -90,17 +92,35 @@ Option IDs:
 ## Mode 1 — CREATE
 
 1. Read the issue body template reference.
-2. Fill placeholders into a temp file.
-3. Create issue:
+2. Collect required fields interactively when missing: task name, tier/type, reference URL when applicable, assignee, Team, Category, and Milestone.
+3. List available open milestones before asking for Milestone:
+
+```bash
+gh api repos/Stack-and-Flow/design-system/milestones --jq '.[].title'
+```
+
+When running inside Pi, present the open milestone titles as an interactive single-select question, the same way Team/Squad is selected. If the user picks a milestone that is not open in GitHub, stop and ask for a valid milestone or maintainer action to create it.
+
+4. Fill placeholders into a temp file.
+5. Create issue with the selected milestone:
 
 ```powershell
 $issueUrl = gh issue create `
   --repo Stack-and-Flow/design-system `
   --title "[ATOMS] {ComponentName}" `
+  --milestone "{milestone}" `
   --body-file "$env:TEMP\issue-body.md"
 ```
 
-4. Add issue to board:
+If the issue already exists or was created without milestone, set it explicitly:
+
+```powershell
+gh issue edit {issue_number} `
+  --repo Stack-and-Flow/design-system `
+  --milestone "{milestone}"
+```
+
+6. Add issue to board:
 
 ```powershell
 $itemId = gh project item-add 1 `
@@ -109,8 +129,8 @@ $itemId = gh project item-add 1 `
   --format json | ConvertFrom-Json | Select-Object -ExpandProperty id
 ```
 
-5. Set Status, Team, and Category with `gh project item-edit` using the field/option IDs above.
-6. Report issue number, URL, board item ID, and fields set.
+7. Set Status, Team, and Category with `gh project item-edit` using the field/option IDs above. The Project Milestone field is derived from the linked issue milestone; do not try to fake it as a single-select field.
+8. Report issue number, URL, board item ID, milestone, and fields set.
 
 ## Mode 2 — START WORK
 
@@ -298,6 +318,7 @@ Check each item:
 | Has notes section | Body contains `### Notes`. |
 | Has resources section | Body contains `### Resources`. |
 | Board fields set | status, team, category are present. |
+| Milestone set | Issue has a GitHub milestone assigned. |
 | In progress has assignee | Items in `In progress` have at least one assignee. |
 | Assigned Todo is intentional | Assigned issues still in `Todo` are flagged for confirmation. |
 | Done has closure evidence | Items in `Done` have a merged PR link or explicit maintainer/user closure note plus validation evidence. |
@@ -314,6 +335,7 @@ For CREATE or AUDIT:
 **Mode**: CREATE / AUDIT
 **Issues touched**: {list}
 **Board fields set**: {status/team/category or "n/a"}
+**Milestone**: {milestone or "missing"}
 **Violations**: {list or "None"}
 **Needs human input**: {list or "None"}
 ```

--- a/.atl/skills/github-project-tasks/references/issue-body-template.md
+++ b/.atl/skills/github-project-tasks/references/issue-body-template.md
@@ -13,6 +13,10 @@ Canonical Stack-and-Flow issue body for automated issue creation. Keep headings 
 
 {team}
 
+### Milestone
+
+{milestone}
+
 ### Reference
 
 {reference_url_or_not_applicable}
@@ -29,7 +33,7 @@ Out of scope:
 
 ### Current workflow
 
-- [ ] Issue triaged with Team and Category fields set on the Project board.
+- [ ] Issue triaged with Team and Category fields set on the Project board, and GitHub milestone assigned.
 - [ ] Specification or plan recorded in this issue when behavior, API, accessibility, or tokens are affected.
 - [ ] Validated spec reviewed and linked issue labeled `status:approved` before implementation starts.
 - [ ] START WORK completed after label `status:approved`: assignee set, Project status moved to `In progress`, branch/worktree recorded.
@@ -104,5 +108,6 @@ Add related links, Figma references, docs, logs, screenshots, or prior art here.
 
 - Do not add emoji to section headings.
 - Avoid accent marks in headings; body text may use accents.
-- Replace `{TaskName}`, `{category}`, `{team}`, and `{reference_url_or_not_applicable}` before creating the issue.
+- Replace `{TaskName}`, `{category}`, `{team}`, `{milestone}`, and `{reference_url_or_not_applicable}` before creating the issue.
+- The selected milestone must also be assigned as the GitHub issue milestone; body text alone is not enough.
 - Write this body to a temp file and pass it with `--body-file`; do not pass multi-line markdown directly through `--body`.

--- a/.github/ISSUE_TEMPLATE/a11y.yml
+++ b/.github/ISSUE_TEMPLATE/a11y.yml
@@ -32,6 +32,18 @@ body:
     validations:
       required: true
 
+
+  - type: dropdown
+    id: milestone
+    attributes:
+      label: Milestone
+      description: Required for issue creation. The agent must also set the GitHub issue milestone to this value.
+      options:
+        - Core
+        - MVP
+        - V1
+    validations:
+      required: true
   - type: dropdown
     id: wcag-level
     attributes:

--- a/.github/ISSUE_TEMPLATE/ci.yml
+++ b/.github/ISSUE_TEMPLATE/ci.yml
@@ -38,6 +38,18 @@ body:
     validations:
       required: true
 
+
+  - type: dropdown
+    id: milestone
+    attributes:
+      label: Milestone
+      description: Required for issue creation. The agent must also set the GitHub issue milestone to this value.
+      options:
+        - Core
+        - MVP
+        - V1
+    validations:
+      required: true
   - type: textarea
     id: motivation
     attributes:

--- a/.github/ISSUE_TEMPLATE/component.yml
+++ b/.github/ISSUE_TEMPLATE/component.yml
@@ -46,6 +46,18 @@ body:
     validations:
       required: true
 
+
+  - type: dropdown
+    id: milestone
+    attributes:
+      label: Milestone
+      description: Required for issue creation. The agent must also set the GitHub issue milestone to this value.
+      options:
+        - Core
+        - MVP
+        - V1
+    validations:
+      required: true
   - type: input
     id: reference
     attributes:

--- a/.github/ISSUE_TEMPLATE/fix.yml
+++ b/.github/ISSUE_TEMPLATE/fix.yml
@@ -30,6 +30,18 @@ body:
     validations:
       required: true
 
+
+  - type: dropdown
+    id: milestone
+    attributes:
+      label: Milestone
+      description: Required for issue creation. The agent must also set the GitHub issue milestone to this value.
+      options:
+        - Core
+        - MVP
+        - V1
+    validations:
+      required: true
   - type: textarea
     id: behavior
     attributes:

--- a/.github/ISSUE_TEMPLATE/npm.yml
+++ b/.github/ISSUE_TEMPLATE/npm.yml
@@ -36,6 +36,18 @@ body:
     validations:
       required: true
 
+
+  - type: dropdown
+    id: milestone
+    attributes:
+      label: Milestone
+      description: Required for issue creation. The agent must also set the GitHub issue milestone to this value.
+      options:
+        - Core
+        - MVP
+        - V1
+    validations:
+      required: true
   - type: textarea
     id: packages
     attributes:

--- a/.github/ISSUE_TEMPLATE/storybook.yml
+++ b/.github/ISSUE_TEMPLATE/storybook.yml
@@ -44,6 +44,18 @@ body:
     validations:
       required: true
 
+
+  - type: dropdown
+    id: milestone
+    attributes:
+      label: Milestone
+      description: Required for issue creation. The agent must also set the GitHub issue milestone to this value.
+      options:
+        - Core
+        - MVP
+        - V1
+    validations:
+      required: true
   - type: textarea
     id: scope
     attributes:

--- a/.github/ISSUE_TEMPLATE/tokens.yml
+++ b/.github/ISSUE_TEMPLATE/tokens.yml
@@ -37,6 +37,18 @@ body:
     validations:
       required: true
 
+
+  - type: dropdown
+    id: milestone
+    attributes:
+      label: Milestone
+      description: Required for issue creation. The agent must also set the GitHub issue milestone to this value.
+      options:
+        - Core
+        - MVP
+        - V1
+    validations:
+      required: true
   - type: textarea
     id: motivation
     attributes:

--- a/.github/ISSUE_TEMPLATE/update.yml
+++ b/.github/ISSUE_TEMPLATE/update.yml
@@ -30,6 +30,18 @@ body:
     validations:
       required: true
 
+
+  - type: dropdown
+    id: milestone
+    attributes:
+      label: Milestone
+      description: Required for issue creation. The agent must also set the GitHub issue milestone to this value.
+      options:
+        - Core
+        - MVP
+        - V1
+    validations:
+      required: true
   - type: dropdown
     id: board-category
     attributes:


### PR DESCRIPTION
## Summary

- Makes Milestone mandatory when creating tasks through the GitHub task workflow.
- Adds required Milestone dropdowns to all issue forms using the current open milestones: Core, MVP, V1.
- Updates `github-project-tasks` so the selected milestone is applied to the actual GitHub issue, not just written in the body.

Closes #240

## Review scope

- Primary files/areas:
  - `.atl/skills/github-project-tasks/SKILL.md`
  - `.atl/skills/github-project-tasks/references/issue-body-template.md`
  - `.github/ISSUE_TEMPLATE/*.yml`
- Out of scope:
  - component source changes
  - creating/renaming GitHub milestones
- Review workload: small/medium; templates and task workflow docs only.

## Type of change

- [ ] New component
- [ ] Existing component update/refactor
- [ ] Bug fix
- [ ] Accessibility
- [ ] Design tokens
- [x] Storybook/docs
- [ ] Infrastructure/tooling
- [ ] NPM/dependencies

## Workflow gates

- [x] Linked issue is present with `Closes #NNN` or maintainer approved an exception.
- [x] Linked issue has label `status:approved` before implementation starts.
- [x] Work was started through the Project flow: assignee set, Project status `In progress`, branch/worktree recorded.
- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`.
- [x] Commits follow the same commitlint-enforced format.
- [x] Diff is focused; unrelated work is called out in Review scope.
- [x] MCP/runtime artifacts are absent: `.playwright-mcp`, `page-*.png`, `page-*.jpeg`, `*.md.playwright-output`.

## Component evidence (required for component changes)

N/A — documentation/templates/skills only.

## Accessibility evidence

N/A — no interactive component behavior changed.

## Validation evidence

- TypeScript: pre-commit hook ran typecheck successfully during commit.
- Unit tests: pre-push hook ran `vitest run`: 24 files passed, 371 tests passed.
- Build/package: not applicable.
- Storybook or visual check: not applicable.
- Accessibility check: not applicable.
- Security/dependency check: not applicable.
- YAML/templates: parsed all `.github/ISSUE_TEMPLATE/*.yml` successfully with Python YAML.
- Docs/whitespace: `git diff --check` passed.
- Review: fresh reviewer subagent found no blockers.

## Screenshots or recordings

N/A — docs/templates/skills only.

## Notes for reviewer

The repo currently has open milestones `Core`, `MVP`, and `V1`; templates use those static dropdown options, while the agent workflow also queries open milestones before asking interactively.

Untracked local files `context.md` and `research.md` exist in the working tree but were intentionally not staged or committed.
