### PR TITLE
feat(discord): add merge notification workflow

### DIFF
--- a/.github/workflows/discord-merge-notify.yml
+++ b/.github/workflows/discord-merge-notify.yml
@@ -1,0 +1,126 @@
+name: Discord Merge Notification
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  notify:
+    name: Notify Discord
+    runs-on: ubuntu-latest
+    env:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      STORYBOOK_URL: https://sf-design-system.netlify.app/
+
+    steps:
+      - name: Skip when Discord webhook is not configured
+        if: ${{ env.DISCORD_WEBHOOK_URL == '' }}
+        run: echo "DISCORD_WEBHOOK_URL is not configured; skipping Discord notification."
+
+      - name: Send merge summary to Discord
+        if: ${{ env.DISCORD_WEBHOOK_URL != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const webhookUrl = process.env.DISCORD_WEBHOOK_URL;
+            const storybookUrl = process.env.STORYBOOK_URL;
+            const { owner, repo } = context.repo;
+            const commitSha = context.sha;
+            const shortSha = commitSha.slice(0, 7);
+            const headCommit = context.payload.head_commit;
+
+            const associatedPulls = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner,
+              repo,
+              commit_sha: commitSha,
+            });
+            const pullRequest = associatedPulls.data[0];
+
+            let changedFiles = [];
+            if (pullRequest) {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number: pullRequest.number,
+                per_page: 100,
+              });
+              changedFiles = files.map((file) => file.filename);
+            } else if (headCommit) {
+              changedFiles = [
+                ...(headCommit.added ?? []),
+                ...(headCommit.modified ?? []),
+                ...(headCommit.removed ?? []),
+              ];
+            }
+
+            const componentPaths = changedFiles
+              .map((file) => file.match(/^src\/components\/(atoms|molecules|organisms)\/([^/]+)/)?.[2])
+              .filter(Boolean);
+            const components = [...new Set(componentPaths)]
+              .map((component) => component.replace(/(^|-)(\w)/g, (_, prefix, letter) => letter.toUpperCase()))
+              .slice(0, 8);
+
+            const docsChanged = changedFiles.some((file) => file.startsWith('docs/') || file.includes('.stories.'));
+            const testsChanged = changedFiles.some((file) => file.endsWith('.test.ts') || file.endsWith('.test.tsx'));
+            const workflowsChanged = changedFiles.some((file) => file.startsWith('.github/workflows/'));
+
+            const changeTags = [
+              components.length > 0 ? `Componentes: ${components.join(', ')}` : null,
+              docsChanged ? 'Docs/Storybook' : null,
+              testsChanged ? 'Tests' : null,
+              workflowsChanged ? 'CI' : null,
+            ].filter(Boolean);
+
+            const title = pullRequest
+              ? `${pullRequest.title} (#${pullRequest.number})`
+              : headCommit?.message?.split('\n')[0] ?? `Merge en main (${shortSha})`;
+            const url = pullRequest?.html_url ?? headCommit?.url ?? `https://github.com/${owner}/${repo}/commit/${commitSha}`;
+            const author = pullRequest?.user?.login ?? headCommit?.author?.name ?? context.actor;
+            const summarySource = pullRequest?.body?.trim() || headCommit?.message || 'Sin descripción disponible.';
+            const summary = summarySource
+              .split('\n')
+              .map((line) => line.trim())
+              .filter(Boolean)
+              .find((line) => !line.startsWith('Closes #')) ?? summarySource.split('\n')[0];
+
+            const fileSummary = changedFiles.length > 0
+              ? `${changedFiles.length} archivo${changedFiles.length === 1 ? '' : 's'} cambiado${changedFiles.length === 1 ? '' : 's'}`
+              : 'Cambios detectados en main';
+
+            const fields = [
+              { name: 'Autor', value: author, inline: true },
+              { name: 'Commit', value: `[${shortSha}](https://github.com/${owner}/${repo}/commit/${commitSha})`, inline: true },
+              { name: 'Alcance', value: changeTags.length > 0 ? changeTags.join(' · ') : fileSummary, inline: false },
+              { name: 'Storybook', value: storybookUrl, inline: false },
+            ];
+
+            const payload = {
+              username: 'Stack-and-Flow Bot',
+              embeds: [
+                {
+                  title: `🚀 Merge en main: ${title}`.slice(0, 256),
+                  url,
+                  description: summary.slice(0, 4096),
+                  color: 0xdb143c,
+                  fields,
+                  footer: { text: `${owner}/${repo}` },
+                  timestamp: new Date().toISOString(),
+                },
+              ],
+            };
+
+            const response = await fetch(webhookUrl, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(payload),
+            });
+
+            if (!response.ok) {
+              const body = await response.text();
+              throw new Error(`Discord webhook failed with ${response.status}: ${body}`);
+            }


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that posts a Discord embed when changes land on `main`.
- Summarizes the associated PR/commit, author, component scope, docs/tests/CI tags, and Storybook link.
- Skips safely when `DISCORD_WEBHOOK_URL` is not configured.

Closes #245

## Review scope

- Primary files/areas:
  - `.github/workflows/discord-merge-notify.yml`
- Out of scope:
  - Discord server setup and the actual webhook secret value.
  - Component/runtime code changes.
- Review workload: small — one new workflow file.

## Type of change

- [ ] New component
- [ ] Existing component update/refactor
- [ ] Bug fix
- [ ] Accessibility
- [ ] Design tokens
- [ ] Storybook/docs
- [x] Infrastructure/tooling
- [ ] NPM/dependencies

## Workflow gates

- [x] Linked issue is present with `Closes #NNN` or maintainer approved an exception.
- [x] Linked issue has label `status:approved` before implementation starts.
- [x] Work was started through the Project flow: assignee set, Project status `In progress`, branch/worktree recorded.
- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`.
- [x] Commits follow the same commitlint-enforced format.
- [x] Diff is focused; unrelated work is called out in Review scope.
- [x] MCP/runtime artifacts are absent: `.playwright-mcp`, `page-*.png`, `page-*.jpeg`, `*.md.playwright-output`.

## Component evidence (required for component changes)

N/A — infrastructure-only workflow change.

## Accessibility evidence

N/A — no UI/runtime component behavior changed.

## Validation evidence

- TypeScript: `pnpm exec tsc --noEmit` passed via lefthook pre-commit.
- Unit tests: `pnpm test` passed via lefthook pre-push — 28 files, 440 tests.
- Build/package: N/A — workflow-only change.
- Storybook or visual check: N/A — no Storybook/component changes.
- Accessibility check: N/A — no UI changes.
- Security/dependency check:
  - Workflow reads `DISCORD_WEBHOOK_URL` from GitHub Actions secrets only.
  - The secret is never printed or included in the Discord payload.
  - Workflow skips safely when the secret is absent.
- Workflow syntax:
  - Python YAML parse passed locally.
  - `git diff --check` passed.
  - Fresh reviewer extracted the `github-script` body and `node --check` passed.
  - `actionlint` was unavailable locally.

## Screenshots or recordings

N/A — Discord webhook requires repository secret configuration and runs on push to `main`.

## Notes for reviewer

To enable notifications after merge, add repository secret:

```text
DISCORD_WEBHOOK_URL=<Discord channel webhook URL>
```
