### PR TITLE
feat(pagination): add molecule component

### DIFF
--- a/src/components/atoms/select/types.ts
+++ b/src/components/atoms/select/types.ts
@@ -282,9 +282,15 @@ export type SelectProps = NativeSelectTriggerProps &
     onOpenChange?: (isOpen: boolean) => void;
     /** @control text */
     ariaLabel?: string;
-    /** @control text */
+    /**
+     * @control text
+     * @default Clear selection
+     */
     clearAriaLabel?: string;
-    /** @control text */
+    /**
+     * @control text
+     * @default Loading options...
+     */
     loadingLabel?: string;
     /** @control text */
     placeholder?: string;

--- a/src/components/molecules/pagination/Pagination.stories.tsx
+++ b/src/components/molecules/pagination/Pagination.stories.tsx
@@ -1,0 +1,300 @@
+import { action } from '@storybook/addon-actions';
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+  PaginationSummary
+} from './Pagination';
+
+/**
+ * ## Description
+ * Pagination renders accessible navigation controls for paged content. It provides a compound API for consumers that already own the page range model.
+ *
+ * ## Usage Guide
+ * Compose `Pagination`, `PaginationContent`, `PaginationItem`, page links, previous/next controls, ellipsis, and optional summary text. Use `href` for anchor navigation or omit it for button-based client-side pagination.
+ */
+const meta: Meta<typeof Pagination> = {
+  title: 'Molecules/Pagination',
+  component: Pagination,
+  parameters: {
+    docs: {
+      autodocs: true
+    }
+  },
+  tags: ['autodocs']
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Pagination>;
+
+/**
+ * Default pagination with previous, numeric pages, current page, and next controls.
+ */
+export const Default: Story = {
+  render: () => (
+    <Pagination aria-label='Results pages'>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href='?page=1' />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink aria-label='Go to page 1' href='?page=1'>
+            1
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink aria-label='Current page, page 2' href='?page=2' isCurrent={true}>
+            2
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink aria-label='Go to page 3' href='?page=3'>
+            3
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href='?page=3' />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  )
+};
+
+/**
+ * Skipped page ranges use a non-interactive ellipsis indicator.
+ */
+export const WithEllipsis: Story = {
+  render: () => (
+    <Pagination aria-label='Results pages'>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href='?page=4' />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href='?page=1'>1</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationEllipsis />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href='?page=5' isCurrent={true}>
+            5
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationEllipsis aria-label='More ending pages' />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href='?page=10'>10</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href='?page=6' />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  )
+};
+
+/**
+ * Summary text can sit beside or above pagination content depending on consumer layout.
+ */
+export const WithSummary: Story = {
+  render: () => (
+    <div className='w-fit max-w-full rounded-md bg-background-light p-4 dark:bg-background-dark'>
+      <Pagination aria-label='Results pages'>
+        <PaginationSummary>Showing 1-10 of 100 results</PaginationSummary>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href='?page=1' />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href='?page=1' isCurrent={true}>
+              1
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href='?page=2'>2</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext href='?page=2' />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </div>
+  )
+};
+
+/**
+ * Simple previous and next controls without numeric pages.
+ */
+export const PreviousNextOnly: Story = {
+  render: () => (
+    <Pagination aria-label='Article pages'>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href='?page=1' />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href='?page=3' />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  )
+};
+
+/**
+ * Boundary controls expose disabled semantics at the first or last page.
+ */
+export const DisabledBoundary: Story = {
+  render: () => (
+    <Pagination aria-label='Results pages'>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious isDisabled={true} />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink isCurrent={true}>1</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink>2</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext onClick={action('next page')} />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  )
+};
+
+/**
+ * Size variants are controlled by the root and propagated to child controls.
+ */
+export const Sizes: Story = {
+  render: () => (
+    <div className='flex w-fit max-w-full flex-col gap-6 rounded-md border border-border-light bg-surface-light p-4 dark:border-border-dark dark:bg-surface-dark'>
+      <div className='flex flex-col gap-2'>
+        <span className='text-sm font-medium text-text-light dark:text-text-dark'>Small</span>
+        <Pagination aria-label='Small results pages' size='sm'>
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious href='?page=1' />
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationLink href='?page=1'>1</PaginationLink>
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationLink href='?page=2' isCurrent={true}>
+                2
+              </PaginationLink>
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationNext href='?page=3' />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      </div>
+
+      <div className='flex flex-col gap-2'>
+        <span className='text-sm font-medium text-text-light dark:text-text-dark'>Medium</span>
+        <Pagination aria-label='Medium results pages' size='md'>
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious href='?page=1' />
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationLink href='?page=1'>1</PaginationLink>
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationLink href='?page=2' isCurrent={true}>
+                2
+              </PaginationLink>
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationNext href='?page=3' />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      </div>
+
+      <div className='flex flex-col gap-2'>
+        <span className='text-sm font-medium text-text-light dark:text-text-dark'>Large</span>
+        <Pagination aria-label='Large results pages' size='lg'>
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious href='?page=1' />
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationLink href='?page=1'>1</PaginationLink>
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationLink href='?page=2' isCurrent={true}>
+                2
+              </PaginationLink>
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationNext href='?page=3' />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      </div>
+    </div>
+  )
+};
+
+/**
+ * Button mode supports client-side state pagination without URLs.
+ */
+export const ButtonMode: Story = {
+  render: () => (
+    <Pagination aria-label='Client-side pages'>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious onClick={action('previous page')} />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink onClick={action('page 1')}>1</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink isCurrent={true} onClick={action('page 2')}>
+            2
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext onClick={action('next page')} />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  )
+};
+
+/**
+ * Anchor mode supports URL-style pagination and browser navigation affordances.
+ */
+export const AnchorMode: Story = {
+  render: () => (
+    <Pagination aria-label='URL pages'>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href='?page=1' />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href='?page=1'>1</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href='?page=2' isCurrent={true}>
+            2
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href='?page=3' />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  )
+};

--- a/src/components/molecules/pagination/Pagination.test.tsx
+++ b/src/components/molecules/pagination/Pagination.test.tsx
@@ -1,0 +1,290 @@
+import { fireEvent, render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { Pagination as PaginationFromIndex } from './index';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+  PaginationSummary
+} from './Pagination';
+import {
+  usePagination,
+  usePaginationControl,
+  usePaginationEllipsis,
+  usePaginationNext,
+  usePaginationPrevious
+} from './usePagination';
+
+describe('usePagination — logic', () => {
+  it('returns the default landmark label and medium size', () => {
+    const { result } = renderHook(() => usePagination({ children: <span>Pages</span> }));
+
+    expect(result.current['aria-label']).toBe('Pagination');
+    expect(result.current.size).toBe('md');
+  });
+
+  it('keeps current page controls interactive in anchor mode', () => {
+    const handleClick = vi.fn();
+    const { result } = renderHook(() =>
+      usePaginationControl({
+        href: '?page=2',
+        isCurrent: true,
+        onClick: handleClick,
+        children: '2'
+      })
+    );
+
+    expect(result.current.isAnchor).toBe(true);
+    expect(result.current.isCurrent).toBe(true);
+    expect(result.current.isDisabled).toBe(false);
+  });
+
+  it('uses accessible defaults for previous, next, and ellipsis', () => {
+    const previous = renderHook(() => usePaginationPrevious({}));
+    const next = renderHook(() => usePaginationNext({}));
+    const ellipsis = renderHook(() => usePaginationEllipsis({}));
+
+    expect(previous.result.current['aria-label']).toBe('Go to previous page');
+    expect(previous.result.current.children).toBe('Previous');
+    expect(next.result.current['aria-label']).toBe('Go to next page');
+    expect(next.result.current.children).toBe('Next');
+    expect(ellipsis.result.current.label).toBe('More pages');
+  });
+});
+
+describe('Pagination — component behavior', () => {
+  it('is exported from the molecule barrel', () => {
+    expect(PaginationFromIndex).toBe(Pagination);
+  });
+
+  it('renders a navigation landmark with the default accessible name', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink>1</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    );
+
+    expect(screen.getByRole('navigation', { name: 'Pagination' })).toBeInTheDocument();
+  });
+
+  it('renders content as list and listitem structure', () => {
+    render(
+      <Pagination aria-label='Results pages'>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink>1</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink>2</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    );
+
+    expect(screen.getByRole('list')).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+  });
+
+  it('marks the current page with aria-current and keeps it clickable', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink
+              href='?page=2'
+              isCurrent={true}
+              onClick={(event) => {
+                event.preventDefault();
+                handleClick(event);
+              }}
+            >
+              2
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    );
+
+    const current = screen.getByRole('link', { name: '2' });
+    expect(current).toHaveAttribute('aria-current', 'page');
+
+    await user.click(current);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders previous and next controls with accessible labels', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href='?page=1' />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext href='?page=3' />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    );
+
+    expect(screen.getByRole('link', { name: 'Go to previous page' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Go to next page' })).toBeInTheDocument();
+  });
+
+  it('renders ellipsis as non-interactive text with screen-reader text', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationEllipsis />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    );
+
+    expect(screen.getByText('More pages')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'More pages' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'More pages' })).not.toBeInTheDocument();
+  });
+
+  it('disabled button controls cannot be activated', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink isDisabled={true} onClick={handleClick}>
+              1
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    );
+
+    const button = screen.getByRole('button', { name: '1' });
+    expect(button).toBeDisabled();
+
+    await user.click(button);
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('disabled anchor controls expose disabled semantics and block handlers', () => {
+    const handleClick = vi.fn();
+
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationNext href='?page=3' isDisabled={true} onClick={handleClick} />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    );
+
+    const link = screen.getByRole('link', { name: 'Go to next page' });
+    expect(link).toHaveAttribute('aria-disabled', 'true');
+    expect(link).toHaveAttribute('tabindex', '-1');
+
+    fireEvent.click(link);
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('anchor mode renders valid href links', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href='?page=4'>4</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    );
+
+    expect(screen.getByRole('link', { name: '4' })).toHaveAttribute('href', '?page=4');
+  });
+
+  it('button mode calls onClick', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink onClick={handleClick}>5</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    );
+
+    await user.click(screen.getByRole('button', { name: '5' }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves semantic rendering across size variants', () => {
+    render(
+      <div>
+        <Pagination aria-label='Small pages' size='sm'>
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationLink>1</PaginationLink>
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+        <Pagination aria-label='Large pages' size='lg'>
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationLink href='?page=2'>2</PaginationLink>
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      </div>
+    );
+
+    expect(screen.getByRole('navigation', { name: 'Small pages' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
+    expect(screen.getByRole('navigation', { name: 'Large pages' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '2' })).toBeInTheDocument();
+  });
+
+  it('allows keyboard focus to reach enabled controls in DOM order', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Pagination>
+        <PaginationSummary>Showing 1-10 of 100 results</PaginationSummary>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink>1</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    );
+
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Go to previous page' })).toHaveFocus();
+    await user.tab();
+    expect(screen.getByRole('button', { name: '1' })).toHaveFocus();
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Go to next page' })).toHaveFocus();
+  });
+});

--- a/src/components/molecules/pagination/Pagination.test.tsx
+++ b/src/components/molecules/pagination/Pagination.test.tsx
@@ -12,6 +12,7 @@ import {
   PaginationPrevious,
   PaginationSummary
 } from './Pagination';
+import type { PaginationControlClickHandler } from './types';
 import {
   usePagination,
   usePaginationControl,
@@ -231,6 +232,56 @@ describe('Pagination — component behavior', () => {
     );
 
     await user.click(screen.getByRole('button', { name: '5' }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('activates button mode with Enter and Space', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink onClick={handleClick}>5</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    );
+
+    const button = screen.getByRole('button', { name: '5' });
+    button.focus();
+
+    await user.keyboard('{Enter}');
+    expect(handleClick).toHaveBeenCalledTimes(1);
+
+    await user.keyboard(' ');
+    expect(handleClick).toHaveBeenCalledTimes(2);
+  });
+
+  it('activates anchor mode with Enter', async () => {
+    const user = userEvent.setup();
+    const handleClick: PaginationControlClickHandler = vi.fn((event) => {
+      event.preventDefault();
+    });
+
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href='?page=6' onClick={handleClick}>
+              6
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    );
+
+    const link = screen.getByRole('link', { name: '6' });
+    link.focus();
+
+    await user.keyboard('{Enter}');
+
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
 

--- a/src/components/molecules/pagination/Pagination.tsx
+++ b/src/components/molecules/pagination/Pagination.tsx
@@ -1,0 +1,183 @@
+import type { FC } from 'react';
+import type {
+  PaginationContentProps,
+  PaginationEllipsisProps,
+  PaginationItemProps,
+  PaginationLinkProps,
+  PaginationNextProps,
+  PaginationPreviousProps,
+  PaginationProps,
+  PaginationSummaryProps
+} from './types';
+import {
+  PaginationSizeProvider,
+  usePagination,
+  usePaginationContent,
+  usePaginationControl,
+  usePaginationEllipsis,
+  usePaginationItem,
+  usePaginationNext,
+  usePaginationPrevious,
+  usePaginationSummary
+} from './usePagination';
+
+export const Pagination: FC<PaginationProps> = (props) => {
+  const { children, className, size, ...navProps } = usePagination(props);
+
+  return (
+    <PaginationSizeProvider value={size}>
+      <nav {...navProps} className={className}>
+        {children}
+      </nav>
+    </PaginationSizeProvider>
+  );
+};
+
+export const PaginationSummary: FC<PaginationSummaryProps> = (props) => {
+  const { children, className, ...summaryProps } = usePaginationSummary(props);
+
+  return (
+    <p {...summaryProps} className={className}>
+      {children}
+    </p>
+  );
+};
+
+export const PaginationContent: FC<PaginationContentProps> = (props) => {
+  const { children, className, ...contentProps } = usePaginationContent(props);
+
+  return (
+    <ul {...contentProps} className={className}>
+      {children}
+    </ul>
+  );
+};
+
+export const PaginationItem: FC<PaginationItemProps> = (props) => {
+  const { children, className, ...itemProps } = usePaginationItem(props);
+
+  return (
+    <li {...itemProps} className={className}>
+      {children}
+    </li>
+  );
+};
+
+export const PaginationLink: FC<PaginationLinkProps> = (props) => {
+  const control = usePaginationControl(props);
+
+  if ('href' in props && typeof props.href === 'string') {
+    const { children, className, isCurrent, isDisabled, onClick, ...anchorProps } = props;
+
+    return (
+      <a
+        {...anchorProps}
+        className={control.className}
+        aria-current={control.isCurrent ? 'page' : undefined}
+        aria-disabled={control.isDisabled ? true : undefined}
+        tabIndex={control.isDisabled ? -1 : anchorProps.tabIndex}
+        onClick={control.onClick}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  const { children, className, isCurrent, isDisabled, onClick, ...buttonProps } = props;
+
+  return (
+    <button
+      {...buttonProps}
+      type='button'
+      className={control.className}
+      aria-current={control.isCurrent ? 'page' : undefined}
+      disabled={control.isDisabled}
+      onClick={control.onClick}
+    >
+      {children}
+    </button>
+  );
+};
+
+export const PaginationPrevious: FC<PaginationPreviousProps> = (props) => {
+  const control = usePaginationPrevious(props);
+
+  if ('href' in props && typeof props.href === 'string') {
+    const { children, className, isDisabled, onClick, ...anchorProps } = props;
+
+    return (
+      <a
+        {...anchorProps}
+        className={control.className}
+        aria-label={control['aria-label']}
+        aria-disabled={control.isDisabled ? true : undefined}
+        tabIndex={control.isDisabled ? -1 : anchorProps.tabIndex}
+        onClick={control.onClick}
+      >
+        {control.children}
+      </a>
+    );
+  }
+
+  const { children, className, isDisabled, onClick, ...buttonProps } = props;
+
+  return (
+    <button
+      {...buttonProps}
+      type='button'
+      className={control.className}
+      aria-label={control['aria-label']}
+      disabled={control.isDisabled}
+      onClick={control.onClick}
+    >
+      {control.children}
+    </button>
+  );
+};
+
+export const PaginationNext: FC<PaginationNextProps> = (props) => {
+  const control = usePaginationNext(props);
+
+  if ('href' in props && typeof props.href === 'string') {
+    const { children, className, isDisabled, onClick, ...anchorProps } = props;
+
+    return (
+      <a
+        {...anchorProps}
+        className={control.className}
+        aria-label={control['aria-label']}
+        aria-disabled={control.isDisabled ? true : undefined}
+        tabIndex={control.isDisabled ? -1 : anchorProps.tabIndex}
+        onClick={control.onClick}
+      >
+        {control.children}
+      </a>
+    );
+  }
+
+  const { children, className, isDisabled, onClick, ...buttonProps } = props;
+
+  return (
+    <button
+      {...buttonProps}
+      type='button'
+      className={control.className}
+      aria-label={control['aria-label']}
+      disabled={control.isDisabled}
+      onClick={control.onClick}
+    >
+      {control.children}
+    </button>
+  );
+};
+
+export const PaginationEllipsis: FC<PaginationEllipsisProps> = (props) => {
+  const { className, label, ...ellipsisProps } = usePaginationEllipsis(props);
+
+  return (
+    <span {...ellipsisProps} className={className}>
+      <span aria-hidden='true'>…</span>
+      <span className='sr-only'>{label}</span>
+    </span>
+  );
+};

--- a/src/components/molecules/pagination/index.ts
+++ b/src/components/molecules/pagination/index.ts
@@ -1,0 +1,11 @@
+export {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+  PaginationSummary
+} from './Pagination';
+export type * from './types';

--- a/src/components/molecules/pagination/types.ts
+++ b/src/components/molecules/pagination/types.ts
@@ -1,0 +1,207 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { ComponentProps, HTMLAttributeAnchorTarget, MouseEvent, ReactNode } from 'react';
+
+export const paginationRootVariants = cva('flex flex-col gap-3 bg-transparent font-sans', {
+  variants: {
+    size: {
+      sm: 'fs-small',
+      md: 'fs-base',
+      lg: 'fs-h6'
+    }
+  },
+  defaultVariants: {
+    size: 'md'
+  }
+});
+
+export const paginationContentVariants = cva('flex list-none flex-row flex-wrap items-center gap-1 p-0 m-0', {
+  variants: {
+    size: {
+      sm: 'gap-1',
+      md: 'gap-1.5',
+      lg: 'gap-2'
+    }
+  },
+  defaultVariants: {
+    size: 'md'
+  }
+});
+
+export const paginationItemVariants = cva('flex items-center');
+
+export const paginationSummaryVariants = cva('m-0 text-text-secondary-light dark:text-text-secondary-dark', {
+  variants: {
+    size: {
+      sm: 'fs-small',
+      md: 'fs-base',
+      lg: 'fs-h6'
+    }
+  },
+  defaultVariants: {
+    size: 'md'
+  }
+});
+
+export const paginationControlVariants = cva(
+  [
+    'inline-flex min-h-11 min-w-11 items-center justify-center gap-1 rounded-md border font-semibold no-underline',
+    'border-border-light bg-background-light text-text-light dark:border-border-dark dark:bg-surface-dark dark:text-text-dark',
+    'transition-[background-color,border-color,color,box-shadow,transform,opacity] duration-200 ease-out',
+    'hover:border-brand-light-darkest hover:bg-red-tint-subtle hover:text-brand-light-darkest hover:no-underline',
+    'dark:hover:border-brand-dark-light dark:hover:bg-red-tint-subtle dark:hover:text-brand-dark-light',
+    'active:scale-[0.98]',
+    'focus-visible:outline-none focus-visible:shadow-glow-focus-light dark:focus-visible:shadow-glow-focus-dark'
+  ],
+  {
+    variants: {
+      size: {
+        sm: 'px-2 fs-small',
+        md: 'px-3 fs-base',
+        lg: 'px-4 fs-h6'
+      },
+      isCurrent: {
+        true: [
+          'border-brand-light-darkest bg-brand-light-darkest text-white',
+          'hover:border-brand-light-darkest hover:bg-brand-light-darkest hover:text-white',
+          'dark:border-brand-light-darkest dark:bg-brand-light-darkest dark:text-white',
+          'dark:hover:border-brand-light-darkest dark:hover:bg-brand-light-darkest dark:hover:text-white'
+        ],
+        false: ''
+      },
+      isDisabled: {
+        true: 'pointer-events-none cursor-not-allowed opacity-40',
+        false: 'cursor-pointer'
+      }
+    },
+    defaultVariants: {
+      size: 'md',
+      isCurrent: false,
+      isDisabled: false
+    }
+  }
+);
+
+export const paginationEllipsisVariants = cva(
+  'inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-text-secondary-light dark:text-text-secondary-dark',
+  {
+    variants: {
+      size: {
+        sm: 'px-2 fs-small',
+        md: 'px-3 fs-base',
+        lg: 'px-4 fs-h6'
+      }
+    },
+    defaultVariants: {
+      size: 'md'
+    }
+  }
+);
+
+export type PaginationVariants = VariantProps<typeof paginationRootVariants>;
+export type PaginationSize = NonNullable<PaginationVariants['size']>;
+export type PaginationControlClickHandler = (event: MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => void;
+
+export type PaginationProps = Omit<ComponentProps<'nav'>, 'children'> & {
+  /** @control object */
+  children: ReactNode;
+  /**
+   * @control select
+   * @default md
+   */
+  size?: PaginationSize;
+  /**
+   * @control text
+   * @default Pagination
+   */
+  'aria-label'?: string;
+  /** @control text */
+  className?: string;
+};
+
+export type PaginationSummaryProps = ComponentProps<'p'>;
+export type PaginationContentProps = ComponentProps<'ul'>;
+export type PaginationItemProps = ComponentProps<'li'>;
+
+export type PaginationControlOwnProps = {
+  /**
+   * @control boolean
+   * @default false
+   */
+  isCurrent?: boolean;
+  /**
+   * @control boolean
+   * @default false
+   */
+  isDisabled?: boolean;
+  /** @control text */
+  className?: string;
+};
+
+export type PaginationAnchorControlProps = Omit<
+  ComponentProps<'a'>,
+  'aria-current' | 'children' | 'className' | 'href' | 'onClick' | 'ref'
+> &
+  PaginationControlOwnProps & {
+    /** @control object */
+    children: ReactNode;
+    /** @control text */
+    href: string;
+    /** @control text */
+    target?: HTMLAttributeAnchorTarget;
+    /** @control text */
+    rel?: string;
+    onClick?: PaginationControlClickHandler;
+  };
+
+export type PaginationButtonControlProps = Omit<
+  ComponentProps<'button'>,
+  'aria-current' | 'children' | 'className' | 'disabled' | 'href' | 'onClick' | 'ref' | 'type'
+> &
+  PaginationControlOwnProps & {
+    /** @control object */
+    children: ReactNode;
+    href?: undefined;
+    onClick?: PaginationControlClickHandler;
+  };
+
+export type PaginationLinkProps = PaginationAnchorControlProps | PaginationButtonControlProps;
+
+type PaginationDirectionalAnchorProps = Omit<PaginationAnchorControlProps, 'aria-label' | 'children' | 'isCurrent'>;
+
+type PaginationDirectionalButtonProps = Omit<PaginationButtonControlProps, 'aria-label' | 'children' | 'isCurrent'>;
+
+export type PaginationPreviousProps = (PaginationDirectionalAnchorProps | PaginationDirectionalButtonProps) & {
+  /**
+   * @control object
+   * @default Previous
+   */
+  children?: ReactNode;
+  /**
+   * @control text
+   * @default Go to previous page
+   */
+  'aria-label'?: string;
+};
+
+export type PaginationNextProps = (PaginationDirectionalAnchorProps | PaginationDirectionalButtonProps) & {
+  /**
+   * @control object
+   * @default Next
+   */
+  children?: ReactNode;
+  /**
+   * @control text
+   * @default Go to next page
+   */
+  'aria-label'?: string;
+};
+
+export type PaginationEllipsisProps = Omit<ComponentProps<'span'>, 'children'> & {
+  /**
+   * @control text
+   * @default More pages
+   */
+  'aria-label'?: string;
+  /** @control text */
+  className?: string;
+};

--- a/src/components/molecules/pagination/usePagination.ts
+++ b/src/components/molecules/pagination/usePagination.ts
@@ -1,0 +1,193 @@
+import type { MouseEvent } from 'react';
+import { createContext, useContext } from 'react';
+import { cn } from '@/lib/utils';
+import {
+  type PaginationContentProps,
+  type PaginationControlClickHandler,
+  type PaginationEllipsisProps,
+  type PaginationItemProps,
+  type PaginationLinkProps,
+  type PaginationNextProps,
+  type PaginationPreviousProps,
+  type PaginationProps,
+  type PaginationSize,
+  type PaginationSummaryProps,
+  paginationContentVariants,
+  paginationControlVariants,
+  paginationEllipsisVariants,
+  paginationItemVariants,
+  paginationRootVariants,
+  paginationSummaryVariants
+} from './types';
+
+const PaginationSizeContext = createContext<PaginationSize>('md');
+
+export const PaginationSizeProvider = PaginationSizeContext.Provider;
+
+export const usePaginationSize = (): PaginationSize => useContext(PaginationSizeContext);
+
+type UsePaginationReturn = Omit<PaginationProps, 'size' | 'className'> & {
+  className: string;
+  size: PaginationSize;
+};
+
+export const usePagination = ({
+  className,
+  size = 'md',
+  'aria-label': ariaLabel,
+  ...props
+}: PaginationProps): UsePaginationReturn => ({
+  ...props,
+  'aria-label': ariaLabel ?? 'Pagination',
+  className: cn(paginationRootVariants({ size }), className),
+  size
+});
+
+type UsePaginationContentReturn = PaginationContentProps & {
+  className: string;
+};
+
+export const usePaginationContent = ({ className, ...props }: PaginationContentProps): UsePaginationContentReturn => {
+  const size = usePaginationSize();
+
+  return {
+    ...props,
+    className: cn(paginationContentVariants({ size }), className)
+  };
+};
+
+type UsePaginationItemReturn = PaginationItemProps & {
+  className: string;
+};
+
+export const usePaginationItem = ({ className, ...props }: PaginationItemProps): UsePaginationItemReturn => ({
+  ...props,
+  className: cn(paginationItemVariants(), className)
+});
+
+type UsePaginationSummaryReturn = PaginationSummaryProps & {
+  className: string;
+};
+
+export const usePaginationSummary = ({ className, ...props }: PaginationSummaryProps): UsePaginationSummaryReturn => {
+  const size = usePaginationSize();
+
+  return {
+    ...props,
+    className: cn(paginationSummaryVariants({ size }), className)
+  };
+};
+
+type UsePaginationControlReturn = {
+  className: string;
+  isAnchor: boolean;
+  isCurrent: boolean;
+  isDisabled: boolean;
+  onClick: (event: MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => void;
+};
+
+export const usePaginationControl = ({
+  className,
+  isCurrent = false,
+  isDisabled = false,
+  onClick,
+  ...props
+}: PaginationLinkProps): UsePaginationControlReturn => {
+  const size = usePaginationSize();
+
+  return {
+    className: cn(paginationControlVariants({ size, isCurrent, isDisabled }), className),
+    isAnchor: 'href' in props && typeof props.href === 'string',
+    isCurrent,
+    isDisabled,
+    onClick: getControlClickHandler(isDisabled, onClick)
+  };
+};
+
+type UsePaginationDirectionalControlReturn = {
+  'aria-label': string;
+  children: PaginationPreviousProps['children'];
+  className: string;
+  isAnchor: boolean;
+  isDisabled: boolean;
+  onClick: (event: MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => void;
+};
+
+export const usePaginationPrevious = ({
+  children = 'Previous',
+  'aria-label': ariaLabel,
+  ...props
+}: PaginationPreviousProps): UsePaginationDirectionalControlReturn => {
+  const control = useDirectionalControl(props);
+
+  return {
+    ...control,
+    'aria-label': ariaLabel ?? 'Go to previous page',
+    children
+  };
+};
+
+export const usePaginationNext = ({
+  children = 'Next',
+  'aria-label': ariaLabel,
+  ...props
+}: PaginationNextProps): UsePaginationDirectionalControlReturn => {
+  const control = useDirectionalControl(props);
+
+  return {
+    ...control,
+    'aria-label': ariaLabel ?? 'Go to next page',
+    children
+  };
+};
+
+type UsePaginationEllipsisReturn = PaginationEllipsisProps & {
+  className: string;
+  label: string;
+};
+
+export const usePaginationEllipsis = ({
+  className,
+  'aria-label': ariaLabel,
+  ...props
+}: PaginationEllipsisProps): UsePaginationEllipsisReturn => {
+  const size = usePaginationSize();
+  const label = ariaLabel ?? 'More pages';
+
+  return {
+    ...props,
+    className: cn(paginationEllipsisVariants({ size }), className),
+    label
+  };
+};
+
+const useDirectionalControl = ({
+  className,
+  isDisabled = false,
+  onClick,
+  ...props
+}: Omit<PaginationPreviousProps, 'aria-label' | 'children'>): Omit<
+  UsePaginationDirectionalControlReturn,
+  'aria-label' | 'children'
+> => {
+  const size = usePaginationSize();
+
+  return {
+    className: cn(paginationControlVariants({ size, isDisabled, isCurrent: false }), className),
+    isAnchor: 'href' in props && typeof props.href === 'string',
+    isDisabled,
+    onClick: getControlClickHandler(isDisabled, onClick)
+  };
+};
+
+const getControlClickHandler = (isDisabled: boolean, onClick?: PaginationControlClickHandler) => {
+  return (event: MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => {
+    if (isDisabled) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    onClick?.(event);
+  };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,16 @@ export { Tooltip } from './components/atoms/tooltip';
 // ─── Molecules ───────────────────────────────────────────────────────────────
 export { Accordion } from './components/molecules/accordion';
 export { Breadcrumb } from './components/molecules/breadcrumb';
+export {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+  PaginationSummary
+} from './components/molecules/pagination';
 export { Snippet } from './components/molecules/snippet';
 
 // ─── Organisms ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #25

- Adds the new `Pagination` molecule with compound named exports for root, content, item, link, previous, next, ellipsis, and summary.
- Supports anchor and button navigation modes, current-page semantics, disabled controls, root-driven sizes, and accessible ellipsis text.
- Includes tests, Storybook examples, dark-mode accessibility fixes, and a small Select prop-doc hygiene fix required by the existing pre-commit gate.

## Review scope

- Primary files/areas:
  - `src/components/molecules/pagination/*`
  - `src/index.ts`
  - `src/components/atoms/select/types.ts` default-doc hygiene only
- Out of scope:
  - Data-driven page calculation, automatic page ranges, compact/select/flyout pagination, first/last buttons, rows-per-page selector.
- Review workload: large; size:exception explicitly approved by maintainer in implementation thread because this is one cohesive new component and tests/stories belong with the component.

## Type of change

- [x] New component
- [ ] Existing component update/refactor
- [ ] Bug fix
- [ ] Accessibility
- [ ] Design tokens
- [ ] Storybook/docs
- [ ] Infrastructure/tooling
- [ ] NPM/dependencies

## Workflow gates

- [x] Linked issue is present with `Closes #NNN` or maintainer approved an exception.
- [x] Linked issue has label `status:approved` before implementation starts.
- [x] Work was started through the Project flow: assignee set, Project status `In progress`, branch/worktree recorded.
- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`.
- [x] Commits follow the same commitlint-enforced format.
- [x] Diff is focused; unrelated work is called out in Review scope.
- [x] MCP/runtime artifacts are absent: `.playwright-mcp`, `page-*.png`, `page-*.jpeg`, `*.md.playwright-output`.

## Component evidence (required for component changes)

- [x] Validated component spec is linked or quoted in the issue.
- [x] Accessibility contract from the spec was implemented or deviations are explained below.
- [x] Follows the 6-file pattern: `types.ts`, `use*.ts`, `Component.tsx`, `Component.test.tsx`, `Component.stories.tsx`, `index.ts`.
- [x] CVA variants live in `types.ts`; JSX component has no state, CVA calls, or business logic.
- [x] Public props with runtime defaults have matching `@default` JSDoc in `types.ts` (`node scripts/verify-prop-default-docs.mjs`).
- [x] Uses design tokens from `theme.css`; no hardcoded colors or arbitrary color utilities.
- [x] Storybook covers default, variants, documented states, edge cases, and dark mode when visually different.
- [x] Component audit result is PASS or accepted PASS WITH WARNINGS.
- [x] Visual review result is included when visuals changed.

## Accessibility evidence

- [x] Role/name semantics verified with Testing Library queries or equivalent.
- [x] Keyboard-only behavior verified: Tab / Shift+Tab, Enter / Space, Arrow keys, Escape, Home / End / typeahead where applicable.
- [x] Focus lifecycle verified: native browser focus order; no roving tabindex, focus trap, or portal.
- [x] Disabled, required, invalid/error, loading, and empty states expose the expected semantics where applicable.
- [x] Reduced motion behavior is respected where motion changed.
- [x] Screen reader or axe/manual evidence is included below when applicable.

## Validation evidence

- TypeScript: `pnpm exec tsc --noEmit` passed.
- Unit tests: `pnpm test` passed, 30 files / 536 tests.
- Build/package: `pnpm run build` passed.
- Storybook or visual check: Storybook examples cover Default, WithEllipsis, WithSummary, PreviousNextOnly, DisabledBoundary, Sizes, ButtonMode, and AnchorMode. Sizes uses explicit titled sections.
- Accessibility check: Playwright + Storybook axe in dark mode for all Pagination stories reported 0 violations / 0 incomplete. Ellipsis uses SR-only text without invalid `aria-label` on a plain `span`; current-page contrast uses darker brand token in both themes.
- Security/dependency check: no new runtime dependency added.

Additional review evidence:
- Judgment Day Round 1 found two real warnings; both fixed.
- Judgment Day Round 2: Judge A clean, Judge B clean.

## Screenshots or recordings

<img width="377" height="98" alt="image" src="https://github.com/user-attachments/assets/a1f4b2e0-beb1-4a6a-910a-2f3bd53bfe8b" />

<img width="467" height="110" alt="image" src="https://github.com/user-attachments/assets/a8f505f4-f2b0-49f9-9d94-173e1867203c" />

<img width="326" height="149" alt="image" src="https://github.com/user-attachments/assets/27dec05e-50f0-4e4c-a23d-f80072063c77" />

<img width="200" height="105" alt="image" src="https://github.com/user-attachments/assets/d05e20c0-bb5d-4f19-b953-30d53811c2e8" />

<img width="297" height="95" alt="image" src="https://github.com/user-attachments/assets/60ce04ef-536c-4874-9751-3f3d6c20564d" />

<img width="366" height="347" alt="image" src="https://github.com/user-attachments/assets/1f19b585-b231-4c9e-964d-4da67e963bf0" />


## Notes for reviewer

- `PaginationLink` intentionally remains interactive when current; `isCurrent` only adds `aria-current="page"` and selected styling, per approved spec.
- Page range calculation is intentionally owned by consumers for MVP.
- `src/components/atoms/select/types.ts` only adds missing `@default` docs for existing runtime defaults so the repository prop-doc gate passes.