### PR TITLE
feat(drawer): add organism component

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -925,7 +925,36 @@ box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
 
 ---
 
-### 3.16 Announcement Bar / Version Banner
+### 3.16 Drawer
+
+Drawer is a Radix Dialog-backed off-canvas dialog. It uses the approved compound anatomy: `Drawer.Trigger`, `Drawer.Content`, `Drawer.Header`, `Drawer.Title`, `Drawer.Description`, `Drawer.Body`, `Drawer.Footer`, and `Drawer.Close`. `Portal`, `Overlay`, and `Backdrop` remain internal to `Drawer.Content`.
+
+**Accessibility and anatomy:**
+
+- `Drawer.Title` is required so the dialog has an accessible name.
+- `Drawer.Description` is optional and should explain context when the title alone is not enough.
+- Built-in icon-only `Drawer.Close` is named `Close drawer`; custom close controls must provide visible text or their own accessible label.
+- Header and footer are non-scrolling; `Drawer.Body` is the internal scroll region for long content.
+
+**Placement and responsive behavior:**
+
+- `placement="start" | "end" | "top" | "bottom"`; default is `end`.
+- `start` and `end` are logical placements. On `md+`, LTR maps start/end to left/right and RTL maps start/end to right/left.
+- Below `md`, side placements adapt to effective bottom sheet layout.
+- Side sizes reuse `max-w-modal-*`; top, bottom, and mobile bottom layouts use `max-h-drawer-*` utilities based on `--size-drawer-block-viewport`.
+- Bottom and mobile-adapted drawers use safe-area padding for footer actions.
+
+**Dismissal and motion:**
+
+- `dismissible` controls outside/backdrop dismissal only.
+- `closeOnEscape` controls Escape-key dismissal only.
+- Explicit close controls remain available for non-dismissible drawers.
+- Overlay fades and panel slides by effective placement using `opacity` and `transform`; never use `transition: all`.
+- `motion-reduce` removes drawer entrance/exit motion while preserving focus management.
+
+---
+
+### 3.17 Announcement Bar / Version Banner
 
 **Announcement bar (Docusaurus global bar — full width above navbar):**
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -318,6 +318,16 @@ font-size: 93%; /* --ifm-code-font-size */
 ```
 Highlighted line: `rgba(219,20,60,0.10)` (light) / `rgba(255,0,54,0.15)` (dark).
 
+### Drawer
+
+Drawer es una superficie flotante tipo dialog para tareas suplementarias, navegación, formularios y contenido largo. Usa el mismo overlay que Modal (`opacity`, `blur` o `transparent`) y un panel opaco `surface` con borde, sombra de modal y movimiento por `opacity` + `transform` solamente.
+
+- `start` y `end` son placements lógicos: en `md+` respetan LTR/RTL; en mobile se adaptan a bottom sheet.
+- `top`, `bottom` y el bottom sheet mobile usan utilidades `max-h-drawer-*` basadas en `--size-drawer-block-viewport`.
+- Los footers de bottom/mobile drawers usan safe area para no colisionar con home indicators.
+- Header y footer permanecen visibles; `Drawer.Body` es la región con scroll interno.
+- `prefers-reduced-motion` elimina las transiciones de entrada/salida sin cambiar semántica ni foco.
+
 ### Glow del GitHub Stars badge
 
 Patrón reutilizable para cualquier badge con métrica numérica:

--- a/src/components/organisms/drawer/Drawer.stories.tsx
+++ b/src/components/organisms/drawer/Drawer.stories.tsx
@@ -1,0 +1,351 @@
+import { Button } from '@atoms/button';
+import { Input } from '@atoms/input';
+import { action } from '@storybook/addon-actions';
+import type { Meta, StoryObj } from '@storybook/react';
+import { type ReactNode, useState } from 'react';
+import { Drawer } from './Drawer';
+import type { DrawerBackdrop, DrawerPlacement, DrawerSize } from './types';
+
+const DrawerExample = ({
+  backdrop,
+  buttonText = 'Open drawer',
+  children,
+  closeText = 'Done',
+  description = 'Review supporting information without losing the current page context.',
+  dismissible,
+  placement,
+  size,
+  title = 'Project details'
+}: {
+  backdrop?: DrawerBackdrop;
+  buttonText?: string;
+  children?: ReactNode;
+  closeText?: string;
+  description?: string;
+  dismissible?: boolean;
+  placement?: DrawerPlacement;
+  size?: DrawerSize;
+  title?: string;
+}) => (
+  <Drawer onOpenChange={action(`${title} open change`)}>
+    <Drawer.Trigger asChild={true}>
+      <Button
+        className='bg-background-light text-brand-light hover:bg-surface-light dark:bg-surface-dark dark:text-brand-dark dark:hover:bg-surface-raised-dark'
+        emphasis='flat'
+        text={buttonText}
+        variant='secondary'
+      />
+    </Drawer.Trigger>
+    <Drawer.Content backdrop={backdrop} dismissible={dismissible} placement={placement} size={size}>
+      <Drawer.Header>
+        <Drawer.Title>{title}</Drawer.Title>
+        <Drawer.Description>{description}</Drawer.Description>
+      </Drawer.Header>
+      <Drawer.Body>{children ?? <p>Drawer content is placed in the internal scroll region.</p>}</Drawer.Body>
+      <Drawer.Footer>
+        <Drawer.Close>{closeText}</Drawer.Close>
+      </Drawer.Footer>
+    </Drawer.Content>
+  </Drawer>
+);
+
+/**
+ * ## Description
+ * Drawer presents supplemental tasks, navigation, forms, and long content in a Radix Dialog-backed off-canvas layer.
+ *
+ * ## Dependencies
+ * Uses Radix Dialog internally for modal semantics and focus management. These stories use `Button` and `Input` to demonstrate supported trigger, action, and form composition.
+ *
+ * ## Usage Guide
+ * Compose the approved public API only: `Drawer`, `Drawer.Trigger`, `Drawer.Content`, `Drawer.Header`, `Drawer.Title`, `Drawer.Description`, `Drawer.Body`, `Drawer.Footer`, and `Drawer.Close`.
+ * `Drawer.Title` is required for an accessible dialog name. `dismissible` controls outside dismissal, while `closeOnEscape` controls Escape-key dismissal.
+ */
+const meta: Meta<typeof Drawer> = {
+  title: 'Organisms/Drawer',
+  component: Drawer,
+  parameters: {
+    docs: {
+      autodocs: true
+    }
+  },
+  tags: ['autodocs']
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Drawer>;
+
+/**
+ * Shows the default end placement, medium size, opacity backdrop, and accessible title/description anatomy.
+ */
+export const Default: Story = {
+  render: () => <DrawerExample />
+};
+
+/**
+ * Shows controlled open state owned by the consumer.
+ */
+export const Controlled: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <Drawer open={open} onOpenChange={setOpen}>
+        <Drawer.Trigger asChild={true}>
+          <Button text={open ? 'Drawer is open' : 'Open controlled drawer'} variant='secondary' />
+        </Drawer.Trigger>
+        <Drawer.Content>
+          <Drawer.Header>
+            <Drawer.Title>Controlled drawer</Drawer.Title>
+            <Drawer.Description>
+              The application owns the open state and receives every open-change request.
+            </Drawer.Description>
+          </Drawer.Header>
+          <Drawer.Body>
+            Use controlled mode when route state, command palettes, or app workflows own visibility.
+          </Drawer.Body>
+          <Drawer.Footer>
+            <Drawer.Close>Close controlled drawer</Drawer.Close>
+          </Drawer.Footer>
+        </Drawer.Content>
+      </Drawer>
+    );
+  }
+};
+
+/**
+ * Shows all supported logical placements. `start` and `end` adapt to mobile bottom layout below `md`.
+ */
+export const Placements: Story = {
+  render: () => (
+    <div className='flex flex-wrap items-center justify-center gap-4 p-6'>
+      <DrawerExample buttonText='start' placement='start' title='start drawer' />
+      <DrawerExample buttonText='end' placement='end' title='end drawer' />
+      <DrawerExample buttonText='top' placement='top' title='top drawer' />
+      <DrawerExample buttonText='bottom' placement='bottom' title='bottom drawer' />
+    </div>
+  )
+};
+
+/**
+ * Documents the mobile behavior: side placements use an effective bottom sheet below the project `md` breakpoint.
+ */
+export const ResponsiveMobile: Story = {
+  render: () => (
+    <DrawerExample
+      buttonText='Open mobile-adaptive drawer'
+      description='On narrow viewports this side drawer becomes a bottom sheet while preserving the requested logical placement for md and wider viewports.'
+      placement='end'
+      title='Responsive mobile drawer'
+    />
+  )
+};
+
+/**
+ * Documents the mobile safe-area expectation for bottom and mobile-adapted side drawers.
+ */
+export const MobileSafeArea: Story = {
+  render: () => (
+    <DrawerExample
+      buttonText='Open safe-area drawer'
+      description='The footer uses the drawer safe-area utility so explicit close actions remain clear of mobile home indicators.'
+      placement='bottom'
+      title='Safe-area drawer'
+    />
+  )
+};
+
+/**
+ * Shows the supported size scale. Side placements use modal width utilities; block placements use drawer max-height utilities.
+ */
+export const Sizes: Story = {
+  render: () => (
+    <div className='flex flex-wrap items-center justify-center gap-4 p-6'>
+      <DrawerExample buttonText='XS' size='xs' title='xs drawer' />
+      <DrawerExample buttonText='SM' size='sm' title='sm drawer' />
+      <DrawerExample buttonText='MD' size='md' title='md drawer' />
+      <DrawerExample buttonText='LG' size='lg' title='lg drawer' />
+      <DrawerExample buttonText='XL' size='xl' title='xl drawer' />
+      <DrawerExample buttonText='FULL' size='full' title='full drawer' />
+    </div>
+  )
+};
+
+/**
+ * Shows the approved backdrop variants aligned with Modal overlay conventions.
+ */
+export const BackdropVariants: Story = {
+  render: () => (
+    <div className='flex flex-wrap items-center justify-center gap-4 p-6'>
+      <DrawerExample backdrop='opacity' buttonText='opacity' title='opacity backdrop' />
+      <DrawerExample backdrop='blur' buttonText='blur' title='blur backdrop' />
+      <DrawerExample backdrop='transparent' buttonText='transparent' title='transparent backdrop' />
+    </div>
+  )
+};
+
+/**
+ * Shows outside dismissal disabled while keeping the explicit close path visible.
+ */
+export const NonDismissible: Story = {
+  render: () => (
+    <DrawerExample
+      buttonText='Open non-dismissible drawer'
+      closeText='I understand'
+      description='Backdrop and outside interactions stay disabled; the explicit close control remains available.'
+      dismissible={false}
+      title='Non-dismissible workflow'
+    />
+  )
+};
+
+/**
+ * Shows long content inside the internal body scroll region while header and footer remain visible.
+ */
+export const ScrollableContent: Story = {
+  render: () => (
+    <Drawer onOpenChange={action('Scrollable content drawer open change')}>
+      <Drawer.Trigger asChild={true}>
+        <Button emphasis='flat' text='Open long content' variant='secondary' />
+      </Drawer.Trigger>
+      <Drawer.Content>
+        <Drawer.Header>
+          <Drawer.Title>Scrollable content drawer</Drawer.Title>
+          <Drawer.Description>
+            This uses the same default end placement as the default story while the body content scrolls internally.
+          </Drawer.Description>
+        </Drawer.Header>
+        <Drawer.Body>
+          <div className='grid gap-3'>
+            <p>Section 1: long drawer content scrolls inside `Drawer.Body` rather than moving the header or footer.</p>
+            <p>Section 2: long drawer content scrolls inside `Drawer.Body` rather than moving the header or footer.</p>
+            <p>Section 3: long drawer content scrolls inside `Drawer.Body` rather than moving the header or footer.</p>
+            <p>Section 4: long drawer content scrolls inside `Drawer.Body` rather than moving the header or footer.</p>
+            <p>Section 5: long drawer content scrolls inside `Drawer.Body` rather than moving the header or footer.</p>
+            <p>Section 6: long drawer content scrolls inside `Drawer.Body` rather than moving the header or footer.</p>
+            <p>Section 7: long drawer content scrolls inside `Drawer.Body` rather than moving the header or footer.</p>
+            <p>Section 8: long drawer content scrolls inside `Drawer.Body` rather than moving the header or footer.</p>
+            <p>Section 9: long drawer content scrolls inside `Drawer.Body` rather than moving the header or footer.</p>
+            <p>Section 10: long drawer content scrolls inside `Drawer.Body` rather than moving the header or footer.</p>
+            <p>Section 11: long drawer content scrolls inside `Drawer.Body` rather than moving the header or footer.</p>
+            <p>Section 12: long drawer content scrolls inside `Drawer.Body` rather than moving the header or footer.</p>
+          </div>
+        </Drawer.Body>
+        <Drawer.Footer>
+          <Drawer.Close>Cancel</Drawer.Close>
+          <Button onClick={action('Scrollable content save click')} text='Save changes' />
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer>
+  )
+};
+
+/**
+ * Shows custom header, body, and footer composition with only public Drawer slots.
+ */
+export const CustomHeaderBodyFooter: Story = {
+  render: () => (
+    <Drawer>
+      <Drawer.Trigger asChild={true}>
+        <Button text='Open custom layout' variant='secondary' />
+      </Drawer.Trigger>
+      <Drawer.Content size='lg'>
+        <Drawer.Header className='bg-surface-raised-light dark:bg-surface-raised-dark'>
+          <Drawer.Title>Custom layout drawer</Drawer.Title>
+          <Drawer.Description>
+            Slots accept layout classes without exposing Portal, Overlay, or Backdrop APIs.
+          </Drawer.Description>
+        </Drawer.Header>
+        <Drawer.Body className='grid gap-4'>
+          <div className='rounded-md border border-border-light bg-surface-light p-4 dark:border-border-dark dark:bg-surface-dark'>
+            Custom body content can combine cards, summaries, and status messages.
+          </div>
+        </Drawer.Body>
+        <Drawer.Footer className='justify-between'>
+          <span className='text-sm text-text-secondary-light dark:text-text-secondary-dark'>Autosaved</span>
+          <Drawer.Close>Finish</Drawer.Close>
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer>
+  )
+};
+
+/**
+ * Shows form content with visible labels and explicit submit/cancel actions.
+ */
+export const FormDrawer: Story = {
+  render: () => (
+    <DrawerExample buttonText='Edit project' size='lg' title='Edit project'>
+      <form className='grid gap-4' onSubmit={action('drawer form submit')}>
+        <Input id='drawer-project-name' isFullWidth={true} label='Project name' placeholder='Stack-and-Flow' />
+        <Input id='drawer-project-owner' isFullWidth={true} label='Owner' placeholder='Design Systems' />
+        <Button onClick={action('drawer save click')} text='Save changes' type='submit' />
+      </form>
+    </DrawerExample>
+  )
+};
+
+/**
+ * Shows navigation content using drawer semantics for mobile or secondary navigation.
+ */
+export const NavigationDrawer: Story = {
+  render: () => (
+    <DrawerExample buttonText='Open navigation' placement='start' title='Navigation drawer'>
+      <nav aria-label='Drawer navigation' className='grid gap-2'>
+        <a
+          className='rounded-md px-4 py-3 text-text-secondary-light no-underline hover:bg-black-tint-low hover:text-text-light dark:text-text-secondary-dark dark:hover:bg-white-tint-faint dark:hover:text-text-dark'
+          href='#'
+        >
+          Overview
+        </a>
+        <a
+          className='rounded-md px-4 py-3 text-text-secondary-light no-underline hover:bg-black-tint-low hover:text-text-light dark:text-text-secondary-dark dark:hover:bg-white-tint-faint dark:hover:text-text-dark'
+          href='#'
+        >
+          Tokens
+        </a>
+        <a
+          className='rounded-md px-4 py-3 text-text-secondary-light no-underline hover:bg-black-tint-low hover:text-text-light dark:text-text-secondary-dark dark:hover:bg-white-tint-faint dark:hover:text-text-dark'
+          href='#'
+        >
+          Components
+        </a>
+        <a
+          className='rounded-md px-4 py-3 text-text-secondary-light no-underline hover:bg-black-tint-low hover:text-text-light dark:text-text-secondary-dark dark:hover:bg-white-tint-faint dark:hover:text-text-dark'
+          href='#'
+        >
+          Patterns
+        </a>
+      </nav>
+    </DrawerExample>
+  )
+};
+
+/**
+ * Documents reduced-motion expectations: overlay fade and panel slide are removed by the shared `motion-reduce` seams.
+ */
+export const ReducedMotionNotes: Story = {
+  render: () => (
+    <DrawerExample
+      buttonText='Open reduced-motion drawer'
+      description='When users prefer reduced motion, drawer animations are suppressed through motion-reduce utilities while dialog behavior remains unchanged.'
+      title='Reduced-motion drawer'
+    />
+  )
+};
+
+/**
+ * Documents RTL behavior: logical `start` maps to the right side on md and wider viewports, while mobile still adapts to bottom.
+ */
+export const RTL: Story = {
+  render: () => (
+    <div dir='rtl'>
+      <DrawerExample
+        buttonText='فتح الدرج'
+        description='Logical placement seams preserve RTL start/end behavior without changing the public API.'
+        placement='start'
+        title='RTL logical drawer'
+      />
+    </div>
+  )
+};

--- a/src/components/organisms/drawer/Drawer.test.tsx
+++ b/src/components/organisms/drawer/Drawer.test.tsx
@@ -1,0 +1,562 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('lucide-react/dynamic.js', () => ({
+  // biome-ignore lint/style/useNamingConvention: must match library export name
+  DynamicIcon: () => null
+}));
+
+vi.mock('spinners-react', () => ({
+  // biome-ignore lint/style/useNamingConvention: must match library export name
+  SpinnerCircular: () => <span data-testid='button-spinner' />
+}));
+
+import { Button } from '@atoms/button';
+import { Drawer as RootDrawer } from '@/index';
+import { Drawer } from './Drawer';
+import { Drawer as BarrelDrawer } from './index';
+
+const drawerMemberNames = ['Trigger', 'Content', 'Header', 'Title', 'Description', 'Body', 'Footer', 'Close'];
+
+const BasicDrawer = ({ dismissible, closeOnEscape }: { dismissible?: boolean; closeOnEscape?: boolean }) => (
+  <Drawer>
+    <Drawer.Trigger>Open drawer</Drawer.Trigger>
+    <Drawer.Content dismissible={dismissible} closeOnEscape={closeOnEscape}>
+      <Drawer.Header>
+        <Drawer.Title>Account settings</Drawer.Title>
+        <Drawer.Description>Update your profile details.</Drawer.Description>
+      </Drawer.Header>
+      <Drawer.Body>Drawer body</Drawer.Body>
+      <Drawer.Footer>
+        <Drawer.Close>Done</Drawer.Close>
+      </Drawer.Footer>
+    </Drawer.Content>
+  </Drawer>
+);
+
+describe('Drawer — public API', () => {
+  it('exposes exactly the approved compound members', () => {
+    for (const memberName of drawerMemberNames) {
+      expect(Drawer).toHaveProperty(memberName);
+    }
+
+    expect(Drawer).not.toHaveProperty('Portal');
+    expect(Drawer).not.toHaveProperty('Overlay');
+    expect(Drawer).not.toHaveProperty('Backdrop');
+    expect(
+      Object.keys(Drawer)
+        .filter((key) => /^[A-Z]/.test(key))
+        .sort()
+    ).toEqual([...drawerMemberNames].sort());
+  });
+
+  it('is exported from the drawer barrel and package root', () => {
+    expect(BarrelDrawer).toBe(Drawer);
+    expect(RootDrawer).toBe(Drawer);
+  });
+});
+
+describe('Drawer — dialog behavior and accessibility', () => {
+  it('renders a named dialog with optional description from Drawer.Title and Drawer.Description', async () => {
+    render(<BasicDrawer />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open drawer' }));
+
+    const dialog = screen.getByRole('dialog', { name: 'Account settings' });
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAccessibleDescription('Update your profile details.');
+  });
+
+  it('renders the native trigger fallback as button type=button and opens uncontrolled content', async () => {
+    render(<BasicDrawer />);
+
+    const trigger = screen.getByRole('button', { name: 'Open drawer' });
+    expect(trigger).toHaveAttribute('type', 'button');
+
+    await userEvent.click(trigger);
+
+    expect(screen.getByRole('dialog', { name: 'Account settings' })).toBeInTheDocument();
+  });
+
+  it('only links aria-controls while the dialog content is mounted', async () => {
+    render(<BasicDrawer />);
+
+    const trigger = screen.getByRole('button', { name: 'Open drawer' });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).not.toHaveAttribute('aria-controls');
+
+    await userEvent.click(trigger);
+
+    const controlsId = trigger.getAttribute('aria-controls');
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(controlsId).toBeTruthy();
+    expect(document.getElementById(controlsId as string)).toBe(
+      screen.getByRole('dialog', { name: 'Account settings' })
+    );
+  });
+
+  it('requests controlled state changes without owning controlled open state', async () => {
+    const user = userEvent.setup();
+    const handleOpenChange = vi.fn();
+
+    const { rerender } = render(
+      <Drawer open={false} onOpenChange={handleOpenChange}>
+        <Drawer.Trigger>Open controlled drawer</Drawer.Trigger>
+        <Drawer.Content>
+          <Drawer.Title>Controlled drawer</Drawer.Title>
+          <Drawer.Body>Controlled body</Drawer.Body>
+        </Drawer.Content>
+      </Drawer>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open controlled drawer' }));
+
+    expect(handleOpenChange).toHaveBeenCalledWith(true);
+    expect(screen.queryByRole('dialog', { name: 'Controlled drawer' })).not.toBeInTheDocument();
+
+    rerender(
+      <Drawer open={true} onOpenChange={handleOpenChange}>
+        <Drawer.Trigger>Open controlled drawer</Drawer.Trigger>
+        <Drawer.Content>
+          <Drawer.Title>Controlled drawer</Drawer.Title>
+          <Drawer.Body>Controlled body</Drawer.Body>
+          <Drawer.Close>Close controlled drawer</Drawer.Close>
+        </Drawer.Content>
+      </Drawer>
+    );
+
+    expect(screen.getByRole('dialog', { name: 'Controlled drawer' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Close controlled drawer' }));
+
+    expect(handleOpenChange).toHaveBeenCalledWith(false);
+    expect(screen.getByRole('dialog', { name: 'Controlled drawer' })).toBeInTheDocument();
+  });
+
+  it('closes uncontrolled content through Drawer.Close', async () => {
+    render(<BasicDrawer />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open drawer' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Done' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Account settings' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('throws in test runtime when Drawer.Content is missing Drawer.Title', () => {
+    expect(() =>
+      render(
+        <Drawer defaultOpen={true}>
+          <Drawer.Content>
+            <Drawer.Body>Missing title</Drawer.Body>
+          </Drawer.Content>
+        </Drawer>
+      )
+    ).toThrow(/Drawer\.Content requires a Drawer\.Title/i);
+  });
+
+  it('gives the built-in icon-only close control the accessible name Close drawer', async () => {
+    render(
+      <Drawer defaultOpen={true}>
+        <Drawer.Content>
+          <Drawer.Title>Closable drawer</Drawer.Title>
+          <Drawer.Body>Body</Drawer.Body>
+          <Drawer.Close />
+        </Drawer.Content>
+      </Drawer>
+    );
+
+    expect(screen.getByRole('button', { name: 'Close drawer' })).toBeInTheDocument();
+  });
+
+  it('keeps outside dismissal and Escape dismissal independent', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<BasicDrawer dismissible={false} closeOnEscape={true} />);
+
+    await user.click(screen.getByRole('button', { name: 'Open drawer' }));
+    fireEvent.pointerDown(document.body);
+    expect(screen.getByRole('dialog', { name: 'Account settings' })).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Account settings' })).not.toBeInTheDocument();
+    });
+
+    rerender(<BasicDrawer dismissible={true} closeOnEscape={false} />);
+
+    await user.click(screen.getByRole('button', { name: 'Open drawer' }));
+    await user.keyboard('{Escape}');
+    expect(screen.getByRole('dialog', { name: 'Account settings' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Done' }));
+  });
+
+  it('restores focus to the recorded native trigger after close', async () => {
+    const user = userEvent.setup();
+    render(<BasicDrawer />);
+
+    const trigger = screen.getByRole('button', { name: 'Open drawer' });
+    await user.click(trigger);
+    await user.click(screen.getByRole('button', { name: 'Done' }));
+
+    await waitFor(() => {
+      expect(trigger).toHaveFocus();
+    });
+  });
+
+  it('restores focus to an asChild project Button trigger', async () => {
+    const user = userEvent.setup();
+    render(
+      <Drawer>
+        <Drawer.Trigger asChild={true}>
+          <Button text='Open with Button' variant='secondary' />
+        </Drawer.Trigger>
+        <Drawer.Content>
+          <Drawer.Title>Button trigger drawer</Drawer.Title>
+          <Drawer.Body>Body</Drawer.Body>
+          <Drawer.Close>Close Button drawer</Drawer.Close>
+        </Drawer.Content>
+      </Drawer>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open with Button' });
+    await user.click(trigger);
+    await user.click(screen.getByRole('button', { name: 'Close Button drawer' }));
+
+    await waitFor(() => {
+      expect(trigger).toHaveFocus();
+    });
+  });
+
+  it.each([
+    ['Enter', '{Enter}'],
+    ['Space', ' ']
+  ] as const)('opens asChild project Button triggers once with %s', async (_label, key) => {
+    const user = userEvent.setup();
+    const handleOpenChange = vi.fn();
+
+    render(
+      <Drawer open={false} onOpenChange={handleOpenChange}>
+        <Drawer.Trigger asChild={true}>
+          <Button text='Keyboard Button trigger' variant='secondary' />
+        </Drawer.Trigger>
+        <Drawer.Content>
+          <Drawer.Title>Keyboard Button drawer</Drawer.Title>
+          <Drawer.Body>Body</Drawer.Body>
+        </Drawer.Content>
+      </Drawer>
+    );
+
+    screen.getByRole('button', { name: 'Keyboard Button trigger' }).focus();
+    await user.keyboard(key);
+
+    expect(handleOpenChange).toHaveBeenCalledTimes(1);
+    expect(handleOpenChange).toHaveBeenCalledWith(true);
+  });
+
+  it('does not open or request state changes from a disabled trigger', async () => {
+    const user = userEvent.setup();
+    const handleOpenChange = vi.fn();
+
+    render(
+      <Drawer onOpenChange={handleOpenChange}>
+        <Drawer.Trigger disabled={true}>Disabled drawer trigger</Drawer.Trigger>
+        <Drawer.Content>
+          <Drawer.Title>Disabled trigger drawer</Drawer.Title>
+          <Drawer.Body>Body</Drawer.Body>
+        </Drawer.Content>
+      </Drawer>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Disabled drawer trigger' }));
+
+    expect(handleOpenChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole('dialog', { name: 'Disabled trigger drawer' })).not.toBeInTheDocument();
+  });
+});
+
+const OpenLayoutDrawer = ({
+  backdrop,
+  placement,
+  size
+}: {
+  backdrop?: 'opacity' | 'blur' | 'transparent';
+  placement?: 'start' | 'end' | 'top' | 'bottom';
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
+}) => (
+  <Drawer defaultOpen={true}>
+    <Drawer.Content backdrop={backdrop} placement={placement} size={size}>
+      <Drawer.Header>
+        <Drawer.Title>Layout drawer</Drawer.Title>
+      </Drawer.Header>
+      <Drawer.Body>Scrollable drawer body</Drawer.Body>
+      <Drawer.Footer>
+        <Drawer.Close>Close layout drawer</Drawer.Close>
+      </Drawer.Footer>
+    </Drawer.Content>
+  </Drawer>
+);
+
+describe('Drawer — layout, placement, and visual seams', () => {
+  it('defaults to preferred end placement with mobile bottom adaptation seams', () => {
+    render(<OpenLayoutDrawer />);
+
+    const dialog = screen.getByRole('dialog', { name: 'Layout drawer' });
+    expect(dialog).toHaveAttribute('data-placement', 'end');
+    expect(dialog).toHaveAttribute('data-effective-placement', 'end');
+    expect(dialog).toHaveAttribute('data-mobile-placement', 'bottom');
+    expect(dialog).toHaveAttribute('data-placement-axis', 'inline');
+  });
+
+  it.each(['start', 'end', 'top', 'bottom'] as const)('supports placement %s through semantic seams', (placement) => {
+    render(<OpenLayoutDrawer placement={placement} />);
+
+    const dialog = screen.getByRole('dialog', { name: 'Layout drawer' });
+    expect(dialog).toHaveAttribute('data-placement', placement);
+    expect(dialog).toHaveAttribute('data-effective-placement', placement);
+    expect(dialog).toHaveAttribute(
+      'data-placement-axis',
+      placement === 'start' || placement === 'end' ? 'inline' : 'block'
+    );
+  });
+
+  it('exposes RTL logical mapping seams for inline placements on md and wider viewports', () => {
+    render(<OpenLayoutDrawer placement='start' />);
+
+    const dialog = screen.getByRole('dialog', { name: 'Layout drawer' });
+    expect(dialog).toHaveAttribute('data-logical-placement', 'inline-start');
+    expect(dialog).toHaveAttribute('data-rtl-placement', 'right');
+    expect(dialog).toHaveAttribute('data-ltr-placement', 'left');
+  });
+
+  it.each(['xs', 'sm', 'md', 'lg', 'xl', 'full'] as const)('supports size %s with sizing utility evidence', (size) => {
+    render(<OpenLayoutDrawer placement='bottom' size={size} />);
+
+    const dialog = screen.getByRole('dialog', { name: 'Layout drawer' });
+    expect(dialog).toHaveAttribute('data-size', size);
+    expect(dialog).toHaveAttribute('data-block-size-utility', `max-h-drawer-${size}`);
+  });
+
+  it('maps side placement sizes to modal width utilities and mobile block-height utilities', () => {
+    render(<OpenLayoutDrawer placement='end' size='lg' />);
+
+    const dialog = screen.getByRole('dialog', { name: 'Layout drawer' });
+    expect(dialog).toHaveAttribute('data-size-mode', 'responsive-inline');
+    expect(dialog).toHaveAttribute('data-inline-size-utility', 'max-w-modal-lg');
+    expect(dialog).toHaveAttribute('data-block-size-utility', 'max-h-drawer-lg');
+  });
+
+  it.each(['opacity', 'blur', 'transparent'] as const)('supports backdrop variant %s', (backdrop) => {
+    render(<OpenLayoutDrawer backdrop={backdrop} />);
+
+    expect(screen.getByRole('dialog', { name: 'Layout drawer' })).toHaveAttribute('data-backdrop', backdrop);
+    expect(document.querySelector('[data-slot="drawer-overlay"]')).toHaveAttribute('data-backdrop', backdrop);
+  });
+
+  it('keeps header and footer static while body is the internal scroll region', () => {
+    render(<OpenLayoutDrawer />);
+
+    expect(document.querySelector('[data-slot="drawer-header"]')).toHaveAttribute('data-scroll-lock', 'static');
+    expect(document.querySelector('[data-slot="drawer-body"]')).toHaveAttribute('data-scroll-region', 'internal');
+    expect(document.querySelector('[data-slot="drawer-footer"]')).toHaveAttribute('data-scroll-lock', 'static');
+  });
+
+  it('exposes safe-area and reduced-motion seams without transition-all', () => {
+    render(<OpenLayoutDrawer placement='bottom' />);
+
+    const dialog = screen.getByRole('dialog', { name: 'Layout drawer' });
+    expect(dialog).toHaveAttribute('data-safe-area', 'block-end');
+    expect(dialog).toHaveAttribute('data-motion', 'placement-slide');
+    expect(dialog).toHaveAttribute('data-reduced-motion', 'supported');
+  });
+});
+
+describe('Drawer — layout cross-product regressions', () => {
+  it('combines start placement with RTL logical placement seams', () => {
+    render(<OpenLayoutDrawer placement='start' size='sm' />);
+
+    const dialog = screen.getByRole('dialog', { name: 'Layout drawer' });
+    expect(dialog).toHaveAttribute('data-logical-placement', 'inline-start');
+    expect(dialog).toHaveAttribute('data-rtl-placement', 'right');
+    expect(dialog).toHaveAttribute('data-inline-size-utility', 'max-w-modal-sm');
+  });
+
+  it('combines end placement with mobile effective bottom seams', () => {
+    render(<OpenLayoutDrawer placement='end' size='xl' />);
+
+    const dialog = screen.getByRole('dialog', { name: 'Layout drawer' });
+    expect(dialog).toHaveAttribute('data-mobile-placement', 'bottom');
+    expect(dialog).toHaveAttribute('data-logical-placement', 'inline-end');
+    expect(dialog).toHaveAttribute('data-block-size-utility', 'max-h-drawer-xl');
+  });
+
+  it('combines bottom placement and full size with safe-area max-height seams', () => {
+    render(<OpenLayoutDrawer placement='bottom' size='full' />);
+
+    const dialog = screen.getByRole('dialog', { name: 'Layout drawer' });
+    expect(dialog).toHaveAttribute('data-size', 'full');
+    expect(dialog).toHaveAttribute('data-safe-area', 'block-end');
+    expect(dialog).toHaveAttribute('data-block-size-utility', 'max-h-drawer-full');
+  });
+
+  it('keeps transparent backdrop drawers accessible and explicitly closable', async () => {
+    render(<OpenLayoutDrawer backdrop='transparent' />);
+
+    expect(screen.getByRole('dialog', { name: 'Layout drawer' })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Close layout drawer' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Layout drawer' })).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe('Drawer — composition edge cases', () => {
+  it.each([
+    ['Enter', 'Enter'],
+    ['Space', ' ']
+  ] as const)('opens non-native asChild triggers with %s', async (_label, key) => {
+    render(
+      <Drawer>
+        <Drawer.Trigger asChild={true}>
+          <span>Keyboard trigger</span>
+        </Drawer.Trigger>
+        <Drawer.Content>
+          <Drawer.Title>Keyboard trigger drawer</Drawer.Title>
+          <Drawer.Body>Body</Drawer.Body>
+        </Drawer.Content>
+      </Drawer>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Keyboard trigger' });
+    expect(trigger).toHaveAttribute('tabIndex', '0');
+
+    fireEvent.keyDown(trigger, { key });
+
+    expect(screen.getByRole('dialog', { name: 'Keyboard trigger drawer' })).toBeInTheDocument();
+  });
+
+  it('blocks disabled asChild project Button triggers before child click side effects', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    const handleOpenChange = vi.fn();
+
+    render(
+      <Drawer onOpenChange={handleOpenChange}>
+        <Drawer.Trigger asChild={true} disabled={true}>
+          <Button text='Disabled Button trigger' onClick={handleClick} variant='secondary' />
+        </Drawer.Trigger>
+        <Drawer.Content>
+          <Drawer.Title>Disabled Button drawer</Drawer.Title>
+          <Drawer.Body>Body</Drawer.Body>
+        </Drawer.Content>
+      </Drawer>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Disabled Button trigger' });
+    await user.click(trigger);
+
+    expect(trigger).toBeDisabled();
+    expect(handleClick).not.toHaveBeenCalled();
+    expect(handleOpenChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole('dialog', { name: 'Disabled Button drawer' })).not.toBeInTheDocument();
+  });
+
+  it('blocks disabled asChild anchor triggers before child click side effects', () => {
+    const handleClick = vi.fn();
+    const handleOpenChange = vi.fn();
+
+    render(
+      <Drawer onOpenChange={handleOpenChange}>
+        <Drawer.Trigger asChild={true} disabled={true}>
+          <a href='#drawer-target' onClick={handleClick}>
+            Disabled anchor trigger
+          </a>
+        </Drawer.Trigger>
+        <Drawer.Content>
+          <Drawer.Title>Disabled anchor drawer</Drawer.Title>
+          <Drawer.Body>Body</Drawer.Body>
+        </Drawer.Content>
+      </Drawer>
+    );
+
+    const trigger = screen.getByRole('link', { name: 'Disabled anchor trigger' });
+    expect(trigger).toHaveAttribute('aria-disabled', 'true');
+    expect(trigger).toHaveAttribute('tabIndex', '-1');
+
+    fireEvent.click(trigger);
+
+    expect(handleClick).not.toHaveBeenCalled();
+    expect(handleOpenChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole('dialog', { name: 'Disabled anchor drawer' })).not.toBeInTheDocument();
+  });
+
+  it('preserves asChild trigger click handlers while opening and recording the trigger', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(
+      <Drawer>
+        <Drawer.Trigger asChild={true}>
+          <button type='button' onClick={handleClick}>
+            Custom trigger
+          </button>
+        </Drawer.Trigger>
+        <Drawer.Content>
+          <Drawer.Title>Custom trigger drawer</Drawer.Title>
+          <Drawer.Body>Body</Drawer.Body>
+          <Drawer.Close>Close custom trigger drawer</Drawer.Close>
+        </Drawer.Content>
+      </Drawer>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Custom trigger' });
+    await user.click(trigger);
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('dialog', { name: 'Custom trigger drawer' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Close custom trigger drawer' }));
+    await waitFor(() => {
+      expect(trigger).toHaveFocus();
+    });
+  });
+
+  it('lets custom close controls rely on their own visible text or explicit accessible name', async () => {
+    render(
+      <Drawer defaultOpen={true}>
+        <Drawer.Content>
+          <Drawer.Title>Custom close drawer</Drawer.Title>
+          <Drawer.Body>Body</Drawer.Body>
+          <Drawer.Close asChild={true}>
+            <button type='button' aria-label='Dismiss panel'>
+              ×
+            </button>
+          </Drawer.Close>
+          <Drawer.Close>Close by text</Drawer.Close>
+        </Drawer.Content>
+      </Drawer>
+    );
+
+    expect(screen.getByRole('button', { name: 'Dismiss panel' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close by text' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Close drawer' })).not.toBeInTheDocument();
+  });
+
+  it('keeps an explicit close path available for a non-dismissible drawer', async () => {
+    render(<BasicDrawer dismissible={false} closeOnEscape={false} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open drawer' }));
+    await userEvent.keyboard('{Escape}');
+    fireEvent.pointerDown(document.body);
+    expect(screen.getByRole('dialog', { name: 'Account settings' })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Done' }));
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Account settings' })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/organisms/drawer/Drawer.test.tsx
+++ b/src/components/organisms/drawer/Drawer.test.tsx
@@ -560,6 +560,44 @@ describe('Drawer — composition edge cases', () => {
     });
   });
 
+  it('forwards wrapper props and handlers to asChild triggers', async () => {
+    const user = userEvent.setup();
+    const handleChildClick = vi.fn();
+    const handleWrapperClick = vi.fn();
+
+    render(
+      <Drawer>
+        <Drawer.Trigger
+          asChild={true}
+          aria-label='Open tracked drawer'
+          data-analytics='drawer-open'
+          id='tracked-drawer-trigger'
+          onClick={handleWrapperClick}
+          title='Tracked drawer trigger'
+        >
+          <button type='button' onClick={handleChildClick}>
+            Open tracked drawer by text
+          </button>
+        </Drawer.Trigger>
+        <Drawer.Content>
+          <Drawer.Title>Tracked trigger drawer</Drawer.Title>
+          <Drawer.Body>Body</Drawer.Body>
+        </Drawer.Content>
+      </Drawer>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open tracked drawer' });
+    expect(trigger).toHaveAttribute('id', 'tracked-drawer-trigger');
+    expect(trigger).toHaveAttribute('data-analytics', 'drawer-open');
+    expect(trigger).toHaveAttribute('title', 'Tracked drawer trigger');
+
+    await user.click(trigger);
+
+    expect(handleChildClick).toHaveBeenCalledTimes(1);
+    expect(handleWrapperClick).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('dialog', { name: 'Tracked trigger drawer' })).toBeInTheDocument();
+  });
+
   it('lets custom close controls rely on their own visible text or explicit accessible name', async () => {
     render(
       <Drawer defaultOpen={true}>
@@ -579,6 +617,46 @@ describe('Drawer — composition edge cases', () => {
     expect(screen.getByRole('button', { name: 'Dismiss panel' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Close by text' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Close drawer' })).not.toBeInTheDocument();
+  });
+
+  it('forwards wrapper props and handlers to asChild close controls', async () => {
+    const user = userEvent.setup();
+    const handleChildClick = vi.fn();
+    const handleWrapperClick = vi.fn();
+
+    render(
+      <Drawer defaultOpen={true}>
+        <Drawer.Content>
+          <Drawer.Title>Tracked close drawer</Drawer.Title>
+          <Drawer.Body>Body</Drawer.Body>
+          <Drawer.Close
+            asChild={true}
+            aria-label='Dismiss tracked drawer'
+            data-analytics='drawer-close'
+            id='tracked-drawer-close'
+            onClick={handleWrapperClick}
+            title='Tracked drawer close'
+          >
+            <button type='button' onClick={handleChildClick}>
+              Close tracked drawer by text
+            </button>
+          </Drawer.Close>
+        </Drawer.Content>
+      </Drawer>
+    );
+
+    const close = screen.getByRole('button', { name: 'Dismiss tracked drawer' });
+    expect(close).toHaveAttribute('id', 'tracked-drawer-close');
+    expect(close).toHaveAttribute('data-analytics', 'drawer-close');
+    expect(close).toHaveAttribute('title', 'Tracked drawer close');
+
+    await user.click(close);
+
+    expect(handleChildClick).toHaveBeenCalledTimes(1);
+    expect(handleWrapperClick).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Tracked close drawer' })).not.toBeInTheDocument();
+    });
   });
 
   it('keeps an explicit close path available for a non-dismissible drawer', async () => {

--- a/src/components/organisms/drawer/Drawer.test.tsx
+++ b/src/components/organisms/drawer/Drawer.test.tsx
@@ -79,6 +79,41 @@ describe('Drawer — dialog behavior and accessibility', () => {
     expect(screen.getByRole('dialog', { name: 'Account settings' })).toBeInTheDocument();
   });
 
+  it('keeps icon-only native fallback triggers at the minimum touch target width', () => {
+    render(
+      <Drawer>
+        <Drawer.Trigger aria-label='Open icon-only drawer'>☰</Drawer.Trigger>
+        <Drawer.Content>
+          <Drawer.Title>Icon-only drawer</Drawer.Title>
+          <Drawer.Body>Body</Drawer.Body>
+        </Drawer.Content>
+      </Drawer>
+    );
+
+    expect(screen.getByRole('button', { name: 'Open icon-only drawer' })).toHaveClass('min-w-11');
+  });
+
+  it('lets consumer Escape handlers prevent dismissal before internal Drawer handling runs', async () => {
+    const user = userEvent.setup();
+    const handleEscapeKeyDown = vi.fn((event: Event) => {
+      event.preventDefault();
+    });
+
+    render(
+      <Drawer defaultOpen={true}>
+        <Drawer.Content onEscapeKeyDown={handleEscapeKeyDown}>
+          <Drawer.Title>Consumer Escape drawer</Drawer.Title>
+          <Drawer.Body>Body</Drawer.Body>
+        </Drawer.Content>
+      </Drawer>
+    );
+
+    await user.keyboard('{Escape}');
+
+    expect(handleEscapeKeyDown).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('dialog', { name: 'Consumer Escape drawer' })).toBeInTheDocument();
+  });
+
   it('only links aria-controls while the dialog content is mounted', async () => {
     render(<BasicDrawer />);
 

--- a/src/components/organisms/drawer/Drawer.tsx
+++ b/src/components/organisms/drawer/Drawer.tsx
@@ -1,0 +1,172 @@
+import * as DrawerPrimitive from '@radix-ui/react-dialog';
+import { cloneElement, type FC, isValidElement, type ReactElement } from 'react';
+import { cn } from '@/lib/utils';
+import type {
+  DrawerBodyProps,
+  DrawerCloseProps,
+  DrawerCompoundComponent,
+  DrawerContentProps,
+  DrawerDescriptionProps,
+  DrawerFooterProps,
+  DrawerHeaderProps,
+  DrawerProps,
+  DrawerTitleProps,
+  DrawerTriggerProps
+} from './types';
+import {
+  DrawerRootProvider,
+  useDrawerBody,
+  useDrawerClose,
+  useDrawerContent,
+  useDrawerDescription,
+  useDrawerFooter,
+  useDrawerHeader,
+  useDrawerRoot,
+  useDrawerTitle,
+  useDrawerTrigger
+} from './useDrawer';
+
+const DrawerRoot: FC<DrawerProps> = (props) => {
+  const { contextValue, rootProps } = useDrawerRoot(props);
+
+  return (
+    <DrawerRootProvider value={contextValue}>
+      <DrawerPrimitive.Root {...rootProps}>{props.children}</DrawerPrimitive.Root>
+    </DrawerRootProvider>
+  );
+};
+
+const DrawerTrigger: FC<DrawerTriggerProps> = (props) => {
+  const trigger = useDrawerTrigger(props);
+
+  if (trigger.asChild) {
+    return trigger.child;
+  }
+
+  return (
+    <button {...trigger.buttonProps} data-slot='drawer-trigger'>
+      {props.children}
+    </button>
+  );
+};
+
+const DrawerContent: FC<DrawerContentProps> = (props) => {
+  const { children, contentProps, overlayProps } = useDrawerContent(props);
+
+  return (
+    <DrawerPrimitive.Portal>
+      <DrawerPrimitive.Overlay {...overlayProps} data-slot='drawer-overlay' />
+      <DrawerPrimitive.Content {...contentProps} data-slot='drawer-content'>
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPrimitive.Portal>
+  );
+};
+
+const DrawerHeader: FC<DrawerHeaderProps> = ({ children, className, ...props }) => {
+  const { className: headerClassName } = useDrawerHeader({ children, className });
+
+  return (
+    <div {...props} className={headerClassName} data-scroll-lock='static' data-slot='drawer-header'>
+      {children}
+    </div>
+  );
+};
+
+const DrawerTitle: FC<DrawerTitleProps> = ({ children, className, ...props }) => {
+  const { className: titleClassName } = useDrawerTitle({ children, className });
+
+  return (
+    <DrawerPrimitive.Title {...props} className={titleClassName} data-slot='drawer-title'>
+      {children}
+    </DrawerPrimitive.Title>
+  );
+};
+
+const DrawerDescription: FC<DrawerDescriptionProps> = ({ children, className, ...props }) => {
+  const { className: descriptionClassName } = useDrawerDescription({ children, className });
+
+  return (
+    <DrawerPrimitive.Description {...props} className={descriptionClassName} data-slot='drawer-description'>
+      {children}
+    </DrawerPrimitive.Description>
+  );
+};
+
+const DrawerBody: FC<DrawerBodyProps> = ({ children, className, ...props }) => {
+  const { className: bodyClassName } = useDrawerBody({ children, className });
+
+  return (
+    <div {...props} className={bodyClassName} data-scroll-region='internal' data-slot='drawer-body'>
+      {children}
+    </div>
+  );
+};
+
+const DrawerFooter: FC<DrawerFooterProps> = ({ children, className, ...props }) => {
+  const { className: footerClassName } = useDrawerFooter({ children, className });
+
+  return (
+    <div {...props} className={footerClassName} data-scroll-lock='static' data-slot='drawer-footer'>
+      {children}
+    </div>
+  );
+};
+
+type DrawerCloseChild = ReactElement<{ className?: string }>;
+
+const DrawerClose: FC<DrawerCloseProps> = ({ asChild = false, children, className, type = 'button', ...props }) => {
+  const { className: closeClassName } = useDrawerClose({ asChild, children, className, type, ...props });
+
+  if (asChild && isValidElement(children)) {
+    const closeChild = children as DrawerCloseChild;
+
+    return (
+      <DrawerPrimitive.Close asChild={true}>
+        {cloneElement(closeChild, {
+          className: cn(closeChild.props.className, closeClassName)
+        })}
+      </DrawerPrimitive.Close>
+    );
+  }
+
+  if (children) {
+    return (
+      <DrawerPrimitive.Close asChild={true}>
+        <button {...props} className={closeClassName} type={type}>
+          {children}
+        </button>
+      </DrawerPrimitive.Close>
+    );
+  }
+
+  return (
+    <DrawerPrimitive.Close asChild={true}>
+      <button {...props} aria-label={props['aria-label'] ?? 'Close drawer'} className={closeClassName} type={type}>
+        <span aria-hidden={true}>×</span>
+      </button>
+    </DrawerPrimitive.Close>
+  );
+};
+
+DrawerTrigger.displayName = 'Drawer.Trigger';
+DrawerContent.displayName = 'Drawer.Content';
+DrawerHeader.displayName = 'Drawer.Header';
+DrawerTitle.displayName = 'Drawer.Title';
+DrawerDescription.displayName = 'Drawer.Description';
+DrawerBody.displayName = 'Drawer.Body';
+DrawerFooter.displayName = 'Drawer.Footer';
+DrawerClose.displayName = 'Drawer.Close';
+
+const compoundDrawer = DrawerRoot as DrawerCompoundComponent;
+
+compoundDrawer['Trigger'] = DrawerTrigger;
+compoundDrawer['Content'] = DrawerContent;
+compoundDrawer['Header'] = DrawerHeader;
+compoundDrawer['Title'] = DrawerTitle;
+compoundDrawer['Description'] = DrawerDescription;
+compoundDrawer['Body'] = DrawerBody;
+compoundDrawer['Footer'] = DrawerFooter;
+compoundDrawer['Close'] = DrawerClose;
+
+export const Drawer = compoundDrawer;

--- a/src/components/organisms/drawer/Drawer.tsx
+++ b/src/components/organisms/drawer/Drawer.tsx
@@ -1,5 +1,5 @@
 import * as DrawerPrimitive from '@radix-ui/react-dialog';
-import { cloneElement, type FC, isValidElement, type ReactElement } from 'react';
+import { cloneElement, type FC, isValidElement, type ReactElement, type ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 import type {
   DrawerBodyProps,
@@ -26,12 +26,22 @@ import {
   useDrawerTrigger
 } from './useDrawer';
 
+type JsxCompatiblePrimitive = (props: { [key: string]: unknown; children?: ReactNode }) => ReactElement | null;
+
+const DialogRootPrimitive = DrawerPrimitive.Root as unknown as JsxCompatiblePrimitive;
+const DialogPortalPrimitive = DrawerPrimitive.Portal as unknown as JsxCompatiblePrimitive;
+const DialogOverlayPrimitive = DrawerPrimitive.Overlay as unknown as JsxCompatiblePrimitive;
+const DialogContentPrimitive = DrawerPrimitive.Content as unknown as JsxCompatiblePrimitive;
+const DialogTitlePrimitive = DrawerPrimitive.Title as unknown as JsxCompatiblePrimitive;
+const DialogDescriptionPrimitive = DrawerPrimitive.Description as unknown as JsxCompatiblePrimitive;
+const DialogClosePrimitive = DrawerPrimitive.Close as unknown as JsxCompatiblePrimitive;
+
 const DrawerRoot: FC<DrawerProps> = (props) => {
   const { contextValue, rootProps } = useDrawerRoot(props);
 
   return (
     <DrawerRootProvider value={contextValue}>
-      <DrawerPrimitive.Root {...rootProps}>{props.children}</DrawerPrimitive.Root>
+      <DialogRootPrimitive {...rootProps}>{props.children}</DialogRootPrimitive>
     </DrawerRootProvider>
   );
 };
@@ -54,12 +64,12 @@ const DrawerContent: FC<DrawerContentProps> = (props) => {
   const { children, contentProps, overlayProps } = useDrawerContent(props);
 
   return (
-    <DrawerPrimitive.Portal>
-      <DrawerPrimitive.Overlay {...overlayProps} data-slot='drawer-overlay' />
-      <DrawerPrimitive.Content {...contentProps} data-slot='drawer-content'>
+    <DialogPortalPrimitive>
+      <DialogOverlayPrimitive {...overlayProps} data-slot='drawer-overlay' />
+      <DialogContentPrimitive {...contentProps} data-slot='drawer-content'>
         {children}
-      </DrawerPrimitive.Content>
-    </DrawerPrimitive.Portal>
+      </DialogContentPrimitive>
+    </DialogPortalPrimitive>
   );
 };
 
@@ -77,9 +87,9 @@ const DrawerTitle: FC<DrawerTitleProps> = ({ children, className, ...props }) =>
   const { className: titleClassName } = useDrawerTitle({ children, className });
 
   return (
-    <DrawerPrimitive.Title {...props} className={titleClassName} data-slot='drawer-title'>
+    <DialogTitlePrimitive {...props} className={titleClassName} data-slot='drawer-title'>
       {children}
-    </DrawerPrimitive.Title>
+    </DialogTitlePrimitive>
   );
 };
 
@@ -87,9 +97,9 @@ const DrawerDescription: FC<DrawerDescriptionProps> = ({ children, className, ..
   const { className: descriptionClassName } = useDrawerDescription({ children, className });
 
   return (
-    <DrawerPrimitive.Description {...props} className={descriptionClassName} data-slot='drawer-description'>
+    <DialogDescriptionPrimitive {...props} className={descriptionClassName} data-slot='drawer-description'>
       {children}
-    </DrawerPrimitive.Description>
+    </DialogDescriptionPrimitive>
   );
 };
 
@@ -113,39 +123,71 @@ const DrawerFooter: FC<DrawerFooterProps> = ({ children, className, ...props }) 
   );
 };
 
-type DrawerCloseChild = ReactElement<{ className?: string }>;
+type PreventableEvent = {
+  defaultPrevented: boolean;
+};
+
+type DrawerCloseChild = ReactElement<{
+  [key: string]: unknown;
+  className?: string;
+  onClick?: DrawerCloseProps['onClick'];
+}>;
+
+const composeEventHandlers = <TEvent extends PreventableEvent>(
+  ...handlers: Array<((event: TEvent) => void) | undefined>
+) => {
+  const composedHandlers = handlers.filter((handler): handler is (event: TEvent) => void => Boolean(handler));
+
+  if (composedHandlers.length === 0) {
+    return undefined;
+  }
+
+  return (event: TEvent) => {
+    for (const handler of composedHandlers) {
+      handler(event);
+
+      if (event.defaultPrevented) {
+        return;
+      }
+    }
+  };
+};
 
 const DrawerClose: FC<DrawerCloseProps> = ({ asChild = false, children, className, type = 'button', ...props }) => {
   const { className: closeClassName } = useDrawerClose({ asChild, children, className, type, ...props });
 
   if (asChild && isValidElement(children)) {
     const closeChild = children as DrawerCloseChild;
+    const { onClick, ...forwardedProps } = props;
 
     return (
-      <DrawerPrimitive.Close asChild={true}>
+      <DialogClosePrimitive asChild={true}>
         {cloneElement(closeChild, {
-          className: cn(closeChild.props.className, closeClassName)
+          ...forwardedProps,
+          ...closeChild.props,
+          className: cn(closeChild.props.className, closeClassName),
+          onClick: composeEventHandlers(closeChild.props.onClick, onClick)
         })}
-      </DrawerPrimitive.Close>
+      </DialogClosePrimitive>
     );
   }
 
   if (children) {
     return (
-      <DrawerPrimitive.Close asChild={true}>
+      <DialogClosePrimitive asChild={true}>
         <button {...props} className={closeClassName} type={type}>
           {children}
         </button>
-      </DrawerPrimitive.Close>
+      </DialogClosePrimitive>
     );
   }
 
   return (
-    <DrawerPrimitive.Close asChild={true}>
+    <DialogClosePrimitive asChild={true}>
       <button {...props} aria-label={props['aria-label'] ?? 'Close drawer'} className={closeClassName} type={type}>
         <span aria-hidden={true}>×</span>
       </button>
-    </DrawerPrimitive.Close>
+    </DialogClosePrimitive>
   );
 };
 

--- a/src/components/organisms/drawer/index.ts
+++ b/src/components/organisms/drawer/index.ts
@@ -1,0 +1,2 @@
+export { Drawer } from './Drawer';
+export type * from './types';

--- a/src/components/organisms/drawer/types.ts
+++ b/src/components/organisms/drawer/types.ts
@@ -1,3 +1,4 @@
+import type { DialogContentProps } from '@radix-ui/react-dialog';
 import { cva, type VariantProps } from 'class-variance-authority';
 import type { ComponentProps, FC, FocusEvent, KeyboardEvent, MouseEvent, ReactElement, ReactNode } from 'react';
 
@@ -137,7 +138,7 @@ export type DrawerTriggerProps = Omit<ComponentProps<'button'>, 'children'> & {
   disabled?: boolean;
 };
 
-export type DrawerContentProps = Omit<ComponentProps<'div'>, 'children' | 'dir'> & {
+export type DrawerContentProps = Omit<DialogContentProps, 'children' | 'dir'> & {
   /** @control object */
   children: ReactNode;
   /**

--- a/src/components/organisms/drawer/types.ts
+++ b/src/components/organisms/drawer/types.ts
@@ -217,6 +217,7 @@ export type DrawerCompoundComponent = FC<DrawerProps> & {
 };
 
 export type DrawerTriggerElement = ReactElement<{
+  [key: string]: unknown;
   'aria-controls'?: string;
   'aria-disabled'?: boolean;
   'aria-expanded'?: boolean;

--- a/src/components/organisms/drawer/types.ts
+++ b/src/components/organisms/drawer/types.ts
@@ -1,0 +1,232 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { ComponentProps, FC, FocusEvent, KeyboardEvent, MouseEvent, ReactElement, ReactNode } from 'react';
+
+export const drawerOverlayVariants = cva(
+  [
+    'fixed inset-0 z-modal',
+    'data-[state=closed]:animate-out data-[state=open]:animate-in',
+    'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0'
+  ],
+  {
+    variants: {
+      backdrop: {
+        opacity: 'bg-overlay-dark',
+        blur: 'bg-overlay-dark backdrop-blur-overlay',
+        transparent: 'bg-transparent'
+      }
+    },
+    defaultVariants: {
+      backdrop: 'opacity'
+    }
+  }
+);
+
+export const drawerPanelVariants = cva(
+  [
+    'fixed z-modal flex w-full flex-col border shadow-modal outline-none dark:shadow-modal-dark',
+    'bg-surface-light text-text-light dark:bg-surface-dark dark:text-text-dark',
+    'border-border-light dark:border-border-dark',
+    'data-[state=closed]:animate-out data-[state=open]:animate-in',
+    'transition-[opacity,transform] duration-250 ease-out motion-reduce:!animate-none motion-reduce:!transition-none'
+  ],
+  {
+    variants: {
+      placement: {
+        start: [
+          'inset-x-0 bottom-0 max-h-drawer-md rounded-t-lg border-t',
+          'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+          'md:inset-x-auto md:inset-y-0 md:bottom-auto md:h-dvh md:max-h-none md:rounded-none md:border-t-0',
+          'ltr:md:left-0 ltr:md:border-r rtl:md:right-0 rtl:md:border-l',
+          'md:data-[state=closed]:slide-out-to-start md:data-[state=open]:slide-in-from-start',
+          'md:data-[state=closed]:slide-out-to-bottom-0 md:data-[state=open]:slide-in-from-bottom-0'
+        ],
+        end: [
+          'inset-x-0 bottom-0 max-h-drawer-md rounded-t-lg border-t',
+          'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+          'md:inset-x-auto md:inset-y-0 md:bottom-auto md:h-dvh md:max-h-none md:rounded-none md:border-t-0',
+          'ltr:md:right-0 ltr:md:border-l rtl:md:left-0 rtl:md:border-r',
+          'md:data-[state=closed]:slide-out-to-end md:data-[state=open]:slide-in-from-end',
+          'md:data-[state=closed]:slide-out-to-bottom-0 md:data-[state=open]:slide-in-from-bottom-0'
+        ],
+        top: 'inset-x-0 top-0 rounded-b-lg border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
+        bottom:
+          'inset-x-0 bottom-0 rounded-t-lg border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom'
+      },
+      size: {
+        xs: '',
+        sm: '',
+        md: '',
+        lg: '',
+        xl: '',
+        full: ''
+      }
+    },
+    compoundVariants: [
+      { placement: ['start', 'end'], size: 'xs', class: 'max-h-drawer-xs md:max-h-none md:max-w-modal-xs' },
+      { placement: ['start', 'end'], size: 'sm', class: 'max-h-drawer-sm md:max-h-none md:max-w-modal-sm' },
+      { placement: ['start', 'end'], size: 'md', class: 'max-h-drawer-md md:max-h-none md:max-w-modal-md' },
+      { placement: ['start', 'end'], size: 'lg', class: 'max-h-drawer-lg md:max-h-none md:max-w-modal-lg' },
+      { placement: ['start', 'end'], size: 'xl', class: 'max-h-drawer-xl md:max-h-none md:max-w-modal-xl' },
+      { placement: ['start', 'end'], size: 'full', class: 'h-dvh max-h-drawer-full md:max-h-dvh md:max-w-full' },
+      { placement: ['top', 'bottom'], size: 'xs', class: 'max-h-drawer-xs' },
+      { placement: ['top', 'bottom'], size: 'sm', class: 'max-h-drawer-sm' },
+      { placement: ['top', 'bottom'], size: 'md', class: 'max-h-drawer-md' },
+      { placement: ['top', 'bottom'], size: 'lg', class: 'max-h-drawer-lg' },
+      { placement: ['top', 'bottom'], size: 'xl', class: 'max-h-drawer-xl' },
+      { placement: ['top', 'bottom'], size: 'full', class: 'max-h-drawer-full' }
+    ],
+    defaultVariants: {
+      placement: 'end',
+      size: 'md'
+    }
+  }
+);
+
+export const drawerHeaderVariants = cva('shrink-0 border-b border-border-light p-6 pb-4 dark:border-border-dark');
+export const drawerTitleVariants = cva('fs-h5 font-semibold text-text-light dark:text-text-dark');
+export const drawerDescriptionVariants = cva('mt-2 text-sm text-text-secondary-light dark:text-text-secondary-dark');
+export const drawerBodyVariants = cva(
+  'flex-1 overflow-y-auto p-6 py-4 text-text-secondary-light dark:text-text-secondary-dark'
+);
+export const drawerFooterVariants = cva(
+  'flex shrink-0 items-center justify-end gap-2 border-t border-border-light p-6 pt-4 pb-drawer-safe dark:border-border-dark'
+);
+export const drawerCloseVariants = cva(
+  [
+    'inline-flex min-h-11 min-w-11 cursor-pointer items-center justify-center rounded-md px-3 py-2 text-sm font-semibold',
+    'text-text-light dark:text-text-dark',
+    'hover:bg-black-tint-low dark:hover:bg-white-tint-faint',
+    'focus-visible:outline-none focus-visible:shadow-glow-focus-light dark:focus-visible:shadow-glow-focus-dark',
+    'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-40',
+    'transition-[background,box-shadow,color] duration-150 ease-out'
+  ].join(' ')
+);
+
+type DrawerPanelVariantProps = VariantProps<typeof drawerPanelVariants>;
+type DrawerOverlayVariantProps = VariantProps<typeof drawerOverlayVariants>;
+
+export type DrawerPlacement = NonNullable<DrawerPanelVariantProps['placement']>;
+export type DrawerSize = NonNullable<DrawerPanelVariantProps['size']>;
+export type DrawerBackdrop = NonNullable<DrawerOverlayVariantProps['backdrop']>;
+
+export type DrawerProps = {
+  /** @control object */
+  children: ReactNode;
+  /** @control boolean */
+  open?: boolean;
+  /**
+   * @control boolean
+   * @default false
+   */
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+};
+
+export type DrawerTriggerProps = Omit<ComponentProps<'button'>, 'children'> & {
+  /** @control object */
+  children: ReactNode;
+  /**
+   * @control boolean
+   * @default false
+   */
+  asChild?: boolean;
+  /**
+   * @control boolean
+   * @default false
+   */
+  disabled?: boolean;
+};
+
+export type DrawerContentProps = Omit<ComponentProps<'div'>, 'children' | 'dir'> & {
+  /** @control object */
+  children: ReactNode;
+  /**
+   * @control select
+   * @default end
+   */
+  placement?: DrawerPlacement;
+  /**
+   * @control select
+   * @default md
+   */
+  size?: DrawerSize;
+  /**
+   * @control select
+   * @default opacity
+   */
+  backdrop?: DrawerBackdrop;
+  /**
+   * @control boolean
+   * @default true
+   */
+  dismissible?: boolean;
+  /**
+   * @control boolean
+   * @default true
+   */
+  closeOnEscape?: boolean;
+};
+
+type DrawerSlotProps = ComponentProps<'div'> & {
+  /** @control object */
+  children: ReactNode;
+};
+
+export type DrawerHeaderProps = DrawerSlotProps;
+export type DrawerBodyProps = DrawerSlotProps;
+export type DrawerFooterProps = DrawerSlotProps;
+
+export type DrawerTitleProps = ComponentProps<'h2'> & {
+  /** @control object */
+  children: ReactNode;
+};
+
+export type DrawerDescriptionProps = ComponentProps<'p'> & {
+  /** @control object */
+  children: ReactNode;
+};
+
+export type DrawerCloseProps = Omit<ComponentProps<'button'>, 'children'> & {
+  /** @control object */
+  children?: ReactNode;
+  /**
+   * @control boolean
+   * @default false
+   */
+  asChild?: boolean;
+};
+
+export type DrawerCompoundComponent = FC<DrawerProps> & {
+  // biome-ignore lint/style/useNamingConvention: compound API requires PascalCase slot names
+  Trigger: FC<DrawerTriggerProps>;
+  // biome-ignore lint/style/useNamingConvention: compound API requires PascalCase slot names
+  Content: FC<DrawerContentProps>;
+  // biome-ignore lint/style/useNamingConvention: compound API requires PascalCase slot names
+  Header: FC<DrawerHeaderProps>;
+  // biome-ignore lint/style/useNamingConvention: compound API requires PascalCase slot names
+  Title: FC<DrawerTitleProps>;
+  // biome-ignore lint/style/useNamingConvention: compound API requires PascalCase slot names
+  Description: FC<DrawerDescriptionProps>;
+  // biome-ignore lint/style/useNamingConvention: compound API requires PascalCase slot names
+  Body: FC<DrawerBodyProps>;
+  // biome-ignore lint/style/useNamingConvention: compound API requires PascalCase slot names
+  Footer: FC<DrawerFooterProps>;
+  // biome-ignore lint/style/useNamingConvention: compound API requires PascalCase slot names
+  Close: FC<DrawerCloseProps>;
+};
+
+export type DrawerTriggerElement = ReactElement<{
+  'aria-controls'?: string;
+  'aria-disabled'?: boolean;
+  'aria-expanded'?: boolean;
+  'aria-haspopup'?: 'dialog';
+  'data-disabled'?: 'true';
+  className?: string;
+  disabled?: boolean;
+  onClick?: (event: MouseEvent<HTMLElement>) => void;
+  onFocus?: (event: FocusEvent<HTMLElement>) => void;
+  onKeyDown?: (event: KeyboardEvent<HTMLElement>) => void;
+  role?: string;
+  tabIndex?: number;
+  type?: 'button';
+}>;

--- a/src/components/organisms/drawer/useDrawer.ts
+++ b/src/components/organisms/drawer/useDrawer.ts
@@ -167,6 +167,26 @@ type PreventableEvent = {
   defaultPrevented: boolean;
 };
 
+const composeEventHandlers = <TEvent extends PreventableEvent>(
+  ...handlers: Array<((event: TEvent) => void) | undefined>
+) => {
+  const composedHandlers = handlers.filter((handler): handler is (event: TEvent) => void => Boolean(handler));
+
+  if (composedHandlers.length === 0) {
+    return undefined;
+  }
+
+  return (event: TEvent) => {
+    for (const handler of composedHandlers) {
+      handler(event);
+
+      if (event.defaultPrevented) {
+        return;
+      }
+    }
+  };
+};
+
 const withComposedHandler = <TEvent extends ComposableEvent>(
   originalHandler: ((event: TEvent) => void) | undefined,
   nextHandler: (event: TEvent) => void,
@@ -323,22 +343,36 @@ export const useDrawerTrigger = ({
 
   if (asChild && isValidElement(children)) {
     const triggerChild = children as DrawerTriggerElement;
+    const forwardedProps = nativeButtonProps as DrawerTriggerElement['props'];
+    const forwardedOnClick = onClick as ((event: MouseEvent<HTMLElement>) => void) | undefined;
+    const forwardedOnFocus = onFocus as ((event: FocusEvent<HTMLElement>) => void) | undefined;
     const isIntrinsicInteractive = isIntrinsicInteractiveTrigger(triggerChild);
+    const composedOnKeyDown = composeEventHandlers(triggerChild.props.onKeyDown, forwardedProps.onKeyDown);
     const childProps: DrawerTriggerElement['props'] = {
+      ...forwardedProps,
       ...triggerChild.props,
       className: cn(triggerChild.props.className, className),
       'aria-controls': open ? contentId : undefined,
       'aria-disabled': disabled || undefined,
       'aria-expanded': open,
       'aria-haspopup': 'dialog',
-      onClick: withComposedHandler(triggerChild.props.onClick, handleClick, disabled),
-      onFocus: withComposedHandler(triggerChild.props.onFocus, handleFocus, disabled)
+      onClick: withComposedHandler(
+        composeEventHandlers(triggerChild.props.onClick, forwardedOnClick),
+        handleClick,
+        disabled
+      ),
+      onFocus: withComposedHandler(
+        composeEventHandlers(triggerChild.props.onFocus, forwardedOnFocus),
+        handleFocus,
+        disabled
+      ),
+      onKeyDown: composedOnKeyDown
     };
 
     if (!isIntrinsicInteractive) {
       childProps.role = triggerChild.props.role ?? 'button';
       childProps.tabIndex = disabled ? -1 : (triggerChild.props.tabIndex ?? 0);
-      childProps.onKeyDown = withComposedHandler(triggerChild.props.onKeyDown, handleKeyboardActivation, disabled);
+      childProps.onKeyDown = withComposedHandler(composedOnKeyDown, handleKeyboardActivation, disabled);
     }
 
     if (disabled) {

--- a/src/components/organisms/drawer/useDrawer.ts
+++ b/src/components/organisms/drawer/useDrawer.ts
@@ -163,6 +163,10 @@ type ComposableEvent = {
   stopPropagation: () => void;
 };
 
+type PreventableEvent = {
+  defaultPrevented: boolean;
+};
+
 const withComposedHandler = <TEvent extends ComposableEvent>(
   originalHandler: ((event: TEvent) => void) | undefined,
   nextHandler: (event: TEvent) => void,
@@ -175,6 +179,21 @@ const withComposedHandler = <TEvent extends ComposableEvent>(
       return;
     }
 
+    originalHandler?.(event);
+
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    nextHandler(event);
+  };
+};
+
+const withPreventableComposedHandler = <TEvent extends PreventableEvent>(
+  originalHandler: ((event: TEvent) => void) | undefined,
+  nextHandler: (event: TEvent) => void
+) => {
+  return (event: TEvent) => {
     originalHandler?.(event);
 
     if (event.defaultPrevented) {
@@ -356,7 +375,7 @@ export const useDrawerTrigger = ({
       'aria-haspopup': 'dialog',
       'data-disabled': disabled ? 'true' : undefined,
       className: cn(
-        'inline-flex min-h-11 cursor-pointer items-center justify-center rounded-md px-3 py-2 text-sm font-semibold',
+        'inline-flex min-h-11 min-w-11 cursor-pointer items-center justify-center rounded-md px-3 py-2 text-sm font-semibold',
         'focus-visible:outline-none focus-visible:shadow-glow-focus-light dark:focus-visible:shadow-glow-focus-dark',
         'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-40',
         className
@@ -425,6 +444,10 @@ export const useDrawerContent = ({
   className,
   closeOnEscape = true,
   dismissible = true,
+  onCloseAutoFocus,
+  onEscapeKeyDown,
+  onInteractOutside,
+  onPointerDownOutside,
   placement = 'end',
   size = 'md',
   ...restProps
@@ -470,10 +493,10 @@ export const useDrawerContent = ({
       ...restProps,
       id: contentId,
       className: cn(drawerPanelVariants({ placement, size }), className),
-      onCloseAutoFocus: handleCloseAutoFocus,
-      onPointerDownOutside: handlePointerDownOutside,
-      onInteractOutside: handleInteractOutside,
-      onEscapeKeyDown: handleEscapeKeyDown,
+      onCloseAutoFocus: withPreventableComposedHandler(onCloseAutoFocus, handleCloseAutoFocus),
+      onPointerDownOutside: withPreventableComposedHandler(onPointerDownOutside, handlePointerDownOutside),
+      onInteractOutside: withPreventableComposedHandler(onInteractOutside, handleInteractOutside),
+      onEscapeKeyDown: withPreventableComposedHandler(onEscapeKeyDown, handleEscapeKeyDown),
       'data-backdrop': backdrop,
       'data-block-size-utility': getBlockSizeUtility(size),
       'data-effective-placement': placement,

--- a/src/components/organisms/drawer/useDrawer.ts
+++ b/src/components/organisms/drawer/useDrawer.ts
@@ -1,0 +1,518 @@
+import type { DialogContentProps } from '@radix-ui/react-dialog';
+import {
+  Children,
+  cloneElement,
+  createContext,
+  createElement,
+  type FocusEvent,
+  isValidElement,
+  type KeyboardEvent,
+  type MouseEvent,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useId,
+  useMemo,
+  useState
+} from 'react';
+import { cn } from '@/lib/utils';
+import {
+  type DrawerBackdrop,
+  type DrawerBodyProps,
+  type DrawerCloseProps,
+  type DrawerContentProps,
+  type DrawerDescriptionProps,
+  type DrawerFooterProps,
+  type DrawerHeaderProps,
+  type DrawerPlacement,
+  type DrawerProps,
+  type DrawerSize,
+  type DrawerTitleProps,
+  type DrawerTriggerElement,
+  type DrawerTriggerProps,
+  drawerBodyVariants,
+  drawerCloseVariants,
+  drawerDescriptionVariants,
+  drawerFooterVariants,
+  drawerHeaderVariants,
+  drawerOverlayVariants,
+  drawerPanelVariants,
+  drawerTitleVariants
+} from './types';
+
+type CloseAutoFocusEvent = Parameters<NonNullable<DialogContentProps['onCloseAutoFocus']>>[0];
+type PointerDownOutsideEvent = Parameters<NonNullable<DialogContentProps['onPointerDownOutside']>>[0];
+type InteractOutsideEvent = Parameters<NonNullable<DialogContentProps['onInteractOutside']>>[0];
+type EscapeKeyDownEvent = Parameters<NonNullable<DialogContentProps['onEscapeKeyDown']>>[0];
+
+type DrawerRootContextValue = {
+  contentId: string;
+  open: boolean;
+  recordTriggerElement: (element: HTMLElement | null) => void;
+  setOpen: (open: boolean) => void;
+  triggerElement: HTMLElement | null;
+};
+
+type DrawerRootProviderProps = {
+  children: ReactNode;
+  value: DrawerRootContextValue;
+};
+
+type UseDrawerRootReturn = {
+  contextValue: DrawerRootContextValue;
+  rootProps: {
+    onOpenChange: (open: boolean) => void;
+    open: boolean;
+  };
+};
+
+type UseDrawerTriggerReturn =
+  | {
+      asChild: false;
+      buttonProps: {
+        'aria-controls': string | undefined;
+        'aria-disabled': true | undefined;
+        'aria-expanded': boolean;
+        'aria-haspopup': 'dialog';
+        'data-disabled': 'true' | undefined;
+        className: string;
+        disabled: boolean;
+        onClick: (event: MouseEvent<HTMLButtonElement>) => void;
+        onFocus: (event: FocusEvent<HTMLButtonElement>) => void;
+        type: 'button';
+      };
+      child: null;
+    }
+  | {
+      asChild: true;
+      buttonProps: null;
+      child: ReactElement;
+    };
+
+type UseDrawerContentReturn = {
+  children: ReactNode;
+  contentProps: DialogContentProps & {
+    'data-backdrop': DrawerBackdrop;
+    'data-block-size-utility': `max-h-drawer-${DrawerSize}`;
+    'data-effective-placement': DrawerPlacement;
+    'data-inline-size-utility'?: `max-w-modal-${Exclude<DrawerSize, 'full'>}` | 'max-w-full';
+    'data-logical-placement':
+      | `inline-${Extract<DrawerPlacement, 'start' | 'end'>}`
+      | `block-${Extract<DrawerPlacement, 'top' | 'bottom'>}`;
+    'data-ltr-placement': 'left' | 'right' | 'top' | 'bottom';
+    'data-mobile-placement'?: 'bottom';
+    'data-motion': 'placement-slide';
+    'data-placement': DrawerPlacement;
+    'data-placement-axis': 'inline' | 'block';
+    'data-reduced-motion': 'supported';
+    'data-rtl-placement': 'left' | 'right' | 'top' | 'bottom';
+    'data-safe-area': 'block-end' | 'none';
+    'data-size': DrawerSize;
+    'data-size-mode': 'responsive-inline' | 'block';
+    className: string;
+    id: string;
+  };
+  overlayProps: {
+    'data-backdrop': DrawerBackdrop;
+    className: string;
+  };
+};
+
+type UseDrawerSlotReturn = {
+  className: string;
+};
+
+const DrawerRootContext = createContext<DrawerRootContextValue | null>(null);
+
+const isDevelopmentRuntime = (): boolean => process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test';
+
+const getDrawerSlotDisplayName = (child: ReactNode): string | undefined => {
+  if (!isValidElement(child) || typeof child.type === 'string') {
+    return undefined;
+  }
+
+  return (child.type as { displayName?: string }).displayName;
+};
+
+const hasDrawerSlot = ({ children, displayName }: { children: ReactNode; displayName: string }): boolean => {
+  return Children.toArray(children).some((child) => {
+    if (getDrawerSlotDisplayName(child) === displayName) {
+      return true;
+    }
+
+    if (!isValidElement<{ children?: ReactNode }>(child)) {
+      return false;
+    }
+
+    return hasDrawerSlot({ children: child.props.children, displayName });
+  });
+};
+
+const isHtmlTag = (element: DrawerTriggerElement, tagName: string): boolean => {
+  return typeof element.type === 'string' && element.type.toLowerCase() === tagName;
+};
+
+const isIntrinsicInteractiveTrigger = (element: DrawerTriggerElement): boolean => {
+  return isHtmlTag(element, 'button') || isHtmlTag(element, 'a') || isHtmlTag(element, 'input');
+};
+
+type ComposableEvent = {
+  defaultPrevented: boolean;
+  preventDefault: () => void;
+  stopPropagation: () => void;
+};
+
+const withComposedHandler = <TEvent extends ComposableEvent>(
+  originalHandler: ((event: TEvent) => void) | undefined,
+  nextHandler: (event: TEvent) => void,
+  disabled = false
+) => {
+  return (event: TEvent) => {
+    if (disabled) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    originalHandler?.(event);
+
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    nextHandler(event);
+  };
+};
+
+export const DrawerRootProvider = ({ children, value }: DrawerRootProviderProps) => {
+  return createElement(DrawerRootContext.Provider, { value }, children);
+};
+
+export const useDrawerRoot = ({
+  defaultOpen = false,
+  onOpenChange,
+  open: openProp
+}: DrawerProps): UseDrawerRootReturn => {
+  const isControlled = typeof openProp === 'boolean';
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+  const [triggerElement, setTriggerElement] = useState<HTMLElement | null>(null);
+  const idBase = useId().replaceAll(':', '');
+  const open = isControlled ? openProp : uncontrolledOpen;
+
+  const setOpen = useCallback(
+    (nextOpen: boolean) => {
+      if (!isControlled) {
+        setUncontrolledOpen(nextOpen);
+      }
+
+      onOpenChange?.(nextOpen);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  const recordTriggerElement = useCallback((element: HTMLElement | null) => {
+    setTriggerElement((currentElement) => (currentElement === element ? currentElement : element));
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({
+      contentId: `drawer-${idBase}-content`,
+      open,
+      recordTriggerElement,
+      setOpen,
+      triggerElement
+    }),
+    [idBase, open, recordTriggerElement, setOpen, triggerElement]
+  );
+
+  return {
+    contextValue,
+    rootProps: {
+      open,
+      onOpenChange: setOpen
+    }
+  };
+};
+
+const useDrawerRootContext = (): DrawerRootContextValue => {
+  const context = useContext(DrawerRootContext);
+
+  if (!context) {
+    throw new Error('Drawer compound components must be rendered inside <Drawer>.');
+  }
+
+  return context;
+};
+
+export const useDrawerTrigger = ({
+  asChild = false,
+  children,
+  className,
+  disabled = false,
+  onClick,
+  onFocus,
+  ...nativeButtonProps
+}: DrawerTriggerProps): UseDrawerTriggerReturn => {
+  const { contentId, open, recordTriggerElement, setOpen } = useDrawerRootContext();
+
+  const openDrawer = useCallback(
+    (element: HTMLElement) => {
+      if (disabled) {
+        return;
+      }
+
+      recordTriggerElement(element);
+      setOpen(true);
+    },
+    [disabled, recordTriggerElement, setOpen]
+  );
+
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLElement>) => {
+      if (event.defaultPrevented || disabled) {
+        return;
+      }
+
+      openDrawer(event.currentTarget);
+    },
+    [disabled, openDrawer]
+  );
+
+  const handleFocus = useCallback(
+    (event: FocusEvent<HTMLElement>) => {
+      if (disabled) {
+        return;
+      }
+
+      recordTriggerElement(event.currentTarget);
+    },
+    [disabled, recordTriggerElement]
+  );
+
+  const handleKeyboardActivation = useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      if (event.key !== 'Enter' && event.key !== ' ') {
+        return;
+      }
+
+      event.preventDefault();
+      openDrawer(event.currentTarget);
+    },
+    [openDrawer]
+  );
+
+  if (asChild && isValidElement(children)) {
+    const triggerChild = children as DrawerTriggerElement;
+    const isIntrinsicInteractive = isIntrinsicInteractiveTrigger(triggerChild);
+    const childProps: DrawerTriggerElement['props'] = {
+      ...triggerChild.props,
+      className: cn(triggerChild.props.className, className),
+      'aria-controls': open ? contentId : undefined,
+      'aria-disabled': disabled || undefined,
+      'aria-expanded': open,
+      'aria-haspopup': 'dialog',
+      onClick: withComposedHandler(triggerChild.props.onClick, handleClick, disabled),
+      onFocus: withComposedHandler(triggerChild.props.onFocus, handleFocus, disabled)
+    };
+
+    if (!isIntrinsicInteractive) {
+      childProps.role = triggerChild.props.role ?? 'button';
+      childProps.tabIndex = disabled ? -1 : (triggerChild.props.tabIndex ?? 0);
+      childProps.onKeyDown = withComposedHandler(triggerChild.props.onKeyDown, handleKeyboardActivation, disabled);
+    }
+
+    if (disabled) {
+      childProps['data-disabled'] = 'true';
+
+      if (!isHtmlTag(triggerChild, 'button')) {
+        childProps.tabIndex = -1;
+      }
+    }
+
+    if (isHtmlTag(triggerChild, 'button') || typeof triggerChild.type !== 'string') {
+      childProps.disabled = disabled;
+    }
+
+    if (isHtmlTag(triggerChild, 'button')) {
+      childProps.type = 'button';
+    }
+
+    return {
+      asChild: true,
+      buttonProps: null,
+      child: cloneElement(triggerChild, childProps)
+    };
+  }
+
+  return {
+    asChild: false,
+    child: null,
+    buttonProps: {
+      ...nativeButtonProps,
+      'aria-controls': open ? contentId : undefined,
+      'aria-disabled': disabled || undefined,
+      'aria-expanded': open,
+      'aria-haspopup': 'dialog',
+      'data-disabled': disabled ? 'true' : undefined,
+      className: cn(
+        'inline-flex min-h-11 cursor-pointer items-center justify-center rounded-md px-3 py-2 text-sm font-semibold',
+        'focus-visible:outline-none focus-visible:shadow-glow-focus-light dark:focus-visible:shadow-glow-focus-dark',
+        'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-40',
+        className
+      ),
+      disabled,
+      onClick: withComposedHandler(onClick, handleClick, disabled),
+      onFocus: withComposedHandler(onFocus, handleFocus, disabled),
+      type: 'button'
+    }
+  };
+};
+
+const isInlinePlacement = (placement: DrawerPlacement): placement is Extract<DrawerPlacement, 'start' | 'end'> => {
+  return placement === 'start' || placement === 'end';
+};
+
+const getPlacementAxis = (placement: DrawerPlacement): 'inline' | 'block' => {
+  return isInlinePlacement(placement) ? 'inline' : 'block';
+};
+
+const getLogicalPlacement = (
+  placement: DrawerPlacement
+): `inline-${Extract<DrawerPlacement, 'start' | 'end'>}` | `block-${Extract<DrawerPlacement, 'top' | 'bottom'>}` => {
+  return isInlinePlacement(placement) ? `inline-${placement}` : `block-${placement}`;
+};
+
+const getLtrPlacement = (placement: DrawerPlacement): 'left' | 'right' | 'top' | 'bottom' => {
+  if (placement === 'start') {
+    return 'left';
+  }
+
+  if (placement === 'end') {
+    return 'right';
+  }
+
+  return placement;
+};
+
+const getRtlPlacement = (placement: DrawerPlacement): 'left' | 'right' | 'top' | 'bottom' => {
+  if (placement === 'start') {
+    return 'right';
+  }
+
+  if (placement === 'end') {
+    return 'left';
+  }
+
+  return placement;
+};
+
+const getInlineSizeUtility = (size: DrawerSize): `max-w-modal-${Exclude<DrawerSize, 'full'>}` | 'max-w-full' => {
+  return size === 'full' ? 'max-w-full' : `max-w-modal-${size}`;
+};
+
+const getBlockSizeUtility = (size: DrawerSize): `max-h-drawer-${DrawerSize}` => {
+  return `max-h-drawer-${size}`;
+};
+
+const getSafeArea = (placement: DrawerPlacement): 'block-end' | 'none' => {
+  return placement === 'bottom' || isInlinePlacement(placement) ? 'block-end' : 'none';
+};
+
+export const useDrawerContent = ({
+  backdrop = 'opacity',
+  children,
+  className,
+  closeOnEscape = true,
+  dismissible = true,
+  placement = 'end',
+  size = 'md',
+  ...restProps
+}: DrawerContentProps): UseDrawerContentReturn => {
+  const { contentId, triggerElement } = useDrawerRootContext();
+
+  if (isDevelopmentRuntime() && !hasDrawerSlot({ children, displayName: 'Drawer.Title' })) {
+    throw new Error('Drawer.Content requires a Drawer.Title descendant for accessible dialog naming.');
+  }
+
+  const handleCloseAutoFocus = (event: CloseAutoFocusEvent) => {
+    if (triggerElement?.isConnected) {
+      event.preventDefault();
+      triggerElement.focus();
+    }
+  };
+
+  const handlePointerDownOutside = (event: PointerDownOutsideEvent) => {
+    if (!dismissible) {
+      event.preventDefault();
+    }
+  };
+
+  const handleInteractOutside = (event: InteractOutsideEvent) => {
+    if (!dismissible) {
+      event.preventDefault();
+    }
+  };
+
+  const handleEscapeKeyDown = (event: EscapeKeyDownEvent) => {
+    if (!closeOnEscape) {
+      event.preventDefault();
+    }
+  };
+
+  return {
+    children,
+    overlayProps: {
+      className: drawerOverlayVariants({ backdrop }),
+      'data-backdrop': backdrop
+    },
+    contentProps: {
+      ...restProps,
+      id: contentId,
+      className: cn(drawerPanelVariants({ placement, size }), className),
+      onCloseAutoFocus: handleCloseAutoFocus,
+      onPointerDownOutside: handlePointerDownOutside,
+      onInteractOutside: handleInteractOutside,
+      onEscapeKeyDown: handleEscapeKeyDown,
+      'data-backdrop': backdrop,
+      'data-block-size-utility': getBlockSizeUtility(size),
+      'data-effective-placement': placement,
+      'data-inline-size-utility': isInlinePlacement(placement) ? getInlineSizeUtility(size) : undefined,
+      'data-logical-placement': getLogicalPlacement(placement),
+      'data-ltr-placement': getLtrPlacement(placement),
+      'data-mobile-placement': isInlinePlacement(placement) ? 'bottom' : undefined,
+      'data-motion': 'placement-slide',
+      'data-placement': placement,
+      'data-placement-axis': getPlacementAxis(placement),
+      'data-reduced-motion': 'supported',
+      'data-rtl-placement': getRtlPlacement(placement),
+      'data-safe-area': getSafeArea(placement),
+      'data-size': size,
+      'data-size-mode': isInlinePlacement(placement) ? 'responsive-inline' : 'block'
+    }
+  };
+};
+
+export const useDrawerHeader = ({ className }: DrawerHeaderProps): UseDrawerSlotReturn => ({
+  className: cn(drawerHeaderVariants(), className)
+});
+
+export const useDrawerTitle = ({ className }: DrawerTitleProps): UseDrawerSlotReturn => ({
+  className: cn(drawerTitleVariants(), className)
+});
+
+export const useDrawerDescription = ({ className }: DrawerDescriptionProps): UseDrawerSlotReturn => ({
+  className: cn(drawerDescriptionVariants(), className)
+});
+
+export const useDrawerBody = ({ className }: DrawerBodyProps): UseDrawerSlotReturn => ({
+  className: cn(drawerBodyVariants(), className)
+});
+
+export const useDrawerFooter = ({ className }: DrawerFooterProps): UseDrawerSlotReturn => ({
+  className: cn(drawerFooterVariants(), className)
+});
+
+export const useDrawerClose = ({ className }: DrawerCloseProps): UseDrawerSlotReturn => ({
+  className: cn(drawerCloseVariants(), className)
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export {
 export { Snippet } from './components/molecules/snippet';
 
 // ─── Organisms ───────────────────────────────────────────────────────────────
+export { Drawer } from './components/organisms/drawer';
 export { Footer } from './components/organisms/footer';
 export { NavigationHeader } from './components/organisms/header';
 export { Modal } from './components/organisms/modal';

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -422,6 +422,9 @@
   --size-modal-4xl: 56rem;
   --size-modal-5xl: 64rem;
 
+  /* ── Drawer sizing ───────────────────────────────────────────── */
+  --size-drawer-block-viewport: calc(100dvh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+
   /* ── Transiciones ────────────────────────────────────────────── */
   --transition-fast: 150ms ease-in-out;
   --transition-base: 250ms ease;
@@ -531,6 +534,34 @@
 
 @utility max-w-modal-5xl {
   max-width: min(var(--size-modal-viewport), var(--size-modal-5xl));
+}
+
+@utility max-h-drawer-xs {
+  max-height: min(var(--size-drawer-block-viewport), var(--size-modal-xs));
+}
+
+@utility max-h-drawer-sm {
+  max-height: min(var(--size-drawer-block-viewport), var(--size-modal-sm));
+}
+
+@utility max-h-drawer-md {
+  max-height: min(var(--size-drawer-block-viewport), var(--size-modal-md));
+}
+
+@utility max-h-drawer-lg {
+  max-height: min(var(--size-drawer-block-viewport), var(--size-modal-lg));
+}
+
+@utility max-h-drawer-xl {
+  max-height: min(var(--size-drawer-block-viewport), var(--size-modal-xl));
+}
+
+@utility max-h-drawer-full {
+  max-height: var(--size-drawer-block-viewport);
+}
+
+@utility pb-drawer-safe {
+  padding-bottom: max(var(--spacing-6), env(safe-area-inset-bottom));
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary

Closes #23

- Adds the Drawer organism with Radix Dialog-backed focus, dismissal, and compound slots.
- Covers logical placements, responsive mobile bottom-sheet behavior, sizing, safe-area footer padding, and reduced-motion seams.
- Adds Storybook examples, docs, tests, export wiring, and accessibility hardening from Judgment Day review.

## Review scope

- Primary files/areas:
  - `src/components/organisms/drawer/**`
  - `src/index.ts`
  - `src/styles/theme.css`
  - `docs/COMPONENTS.md`
  - `docs/DESIGN.md`
- Out of scope:
  - Global Button gradient contrast behavior beyond Drawer story trigger mitigation.
  - Local SDD/Judgment artifacts and harness files (`.atl/`, `judgment/`, `reports/`).
- Review workload: large. Maintainer explicitly approved a single-PR exception for this Drawer component work.

## Type of change

- [x] New component
- [ ] Existing component update/refactor
- [ ] Bug fix
- [x] Accessibility
- [x] Design tokens
- [x] Storybook/docs
- [ ] Infrastructure/tooling
- [ ] NPM/dependencies

## Workflow gates

- [x] Linked issue is present with `Closes #NNN` or maintainer approved an exception.
- [x] Linked issue has label `status:approved` before implementation starts.
- [x] Work was started through the Project flow: assignee set, Project status `In progress`, branch/worktree recorded.
- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`.
- [x] Commits follow the same commitlint-enforced format.
- [x] Diff is focused; unrelated work is called out in Review scope.
- [x] MCP/runtime artifacts are absent: `.playwright-mcp`, `page-*.png`, `page-*.jpeg`, `*.md.playwright-output`.

## Component evidence (required for component changes)

- [x] Validated component spec is linked or quoted in the issue.
- [x] Accessibility contract from the spec was implemented or deviations are explained below.
- [x] Follows the 6-file pattern: `types.ts`, `use*.ts`, `Component.tsx`, `Component.test.tsx`, `Component.stories.tsx`, `index.ts`.
- [x] CVA variants live in `types.ts`; JSX component has no state, CVA calls, or business logic.
- [x] Public props with runtime defaults have matching `@default` JSDoc in `types.ts` (`node scripts/verify-prop-default-docs.mjs`).
- [x] Uses design tokens from `theme.css`; no hardcoded colors or arbitrary color utilities.
- [x] Storybook covers default, variants, documented states, edge cases, and dark mode when visually different.
- [x] Component audit result is PASS or accepted PASS WITH WARNINGS.
- [x] Visual review result is included when visuals changed.

## Accessibility evidence

- [x] Role/name semantics verified with Testing Library queries or equivalent.
- [x] Keyboard-only behavior verified: Tab / Shift+Tab, Enter / Space, Arrow keys, Escape, Home / End / typeahead where applicable.
- [x] Focus lifecycle verified: initial focus, roving/active descendant, focus restore, trap/portal behavior where applicable.
- [x] Disabled, required, invalid/error, loading, and empty states expose the expected semantics where applicable.
- [x] Reduced motion behavior is respected where motion changed.
- [x] Screen reader or axe/manual evidence is included below when applicable.

## Validation evidence

- TypeScript: `pnpm exec tsc --noEmit` ✅
- Unit tests: `pnpm test -- src/components/organisms/drawer/Drawer.test.tsx` ✅
- Build/package: `pnpm run build` ✅, `pnpm run verify:package` ✅
- Storybook or visual check: `pnpm run storybook-build` ✅
- Accessibility check:
  - Drawer trigger `aria-controls` is only present while content is mounted/open.
  - Non-native `asChild` triggers support Enter/Space keyboard activation.
  - Disabled `asChild` triggers block child side effects and do not open.
  - Drawer Placement story triggers use opaque backgrounds for deterministic contrast checks in light/dark mode.
  - Judgment Day Round 2: APPROVED ✅
- Security/dependency check: N/A — no dependency changes.

## Screenshots or recordings

N/A — component behavior is covered by Storybook stories and local visual/a11y checks.

## Notes for reviewer

- Drawer side placements (`start`/`end`) adapt to bottom-sheet layout below `md`; on `md+`, logical LTR/RTL placement seams are exposed via `data-*` attributes and responsive classes.
- `Drawer.Title` is required in development/test so the dialog has an accessible name.
- `dismissible` and `closeOnEscape` are intentionally independent; explicit close controls remain available for non-dismissible drawers.
- The large diff is mostly the new component, tests, and stories; this PR intentionally keeps the approved single-PR scope.
- The Project item is now `In progress`; assignee and approved label are present.

