### PR TITLE
feat(text-area): add TextArea atom

### DIFF
--- a/src/components/atoms/input/types.ts
+++ b/src/components/atoms/input/types.ts
@@ -171,9 +171,9 @@ export const hintMessageVariants = cva('fs-small', {
   variants: {
     tone: {
       info: 'text-text-secondary-light dark:text-text-secondary-dark',
-      warning: 'text-[#92400e] dark:text-warning',
+      warning: 'text-warning-text-light dark:text-warning',
       error: 'text-error-light dark:text-error',
-      success: 'text-[#15803d] dark:text-success'
+      success: 'text-success-text-light dark:text-success'
     }
   },
   defaultVariants: {

--- a/src/components/atoms/text-area/TextArea.stories.tsx
+++ b/src/components/atoms/text-area/TextArea.stories.tsx
@@ -1,0 +1,232 @@
+import { action } from '@storybook/addon-actions';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { TextArea } from './TextArea';
+
+/**
+ * ## Description
+ * TextArea renders an accessible native multiline text field for longer form content.
+ * It follows the local Input label, hint, status, variant, and sizing conventions while adding multiline rows, resize, and autosize behavior.
+ *
+ * ## Dependencies
+ * Uses `Icon` indirectly for semantic hint icons so hints match other form controls in the design system.
+ *
+ * ## Usage Guide
+ * Prefer a visible `label` whenever possible. Use `hint` for help, validation, and status messages; use `autosize` only when the field should grow with content.
+ */
+const meta: Meta<typeof TextArea> = {
+  title: 'Atoms/TextArea',
+  component: TextArea,
+  parameters: {
+    docs: {
+      autodocs: true
+    }
+  },
+  tags: ['autodocs']
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TextArea>;
+
+/**
+ * Demonstrates the default uncontrolled multiline field with a visible label and placeholder for baseline form usage.
+ */
+export const Default: Story = {
+  args: {
+    id: 'textarea-default',
+    label: 'Message',
+    placeholder: 'Write your message',
+    onChange: action('textarea-change'),
+    onValueChange: action('textarea-value-change')
+  }
+};
+
+/**
+ * Demonstrates controlled value ownership through `onValueChange`, matching common form-state integrations.
+ */
+export const Controlled: Story = {
+  render: () => {
+    const [value, setValue] = useState('Stack-and-Flow components are built with native semantics first.');
+
+    return (
+      <TextArea
+        id='textarea-controlled'
+        label='Controlled message'
+        value={value}
+        onValueChange={(nextValue) => {
+          action('textarea-controlled-value-change')(nextValue);
+          setValue(nextValue);
+        }}
+      />
+    );
+  }
+};
+
+/**
+ * Compares the supported local visual variants so reviewers can verify parity with Input without HeroUI-only variants.
+ */
+export const Variants: Story = {
+  render: () => (
+    <div className='flex flex-wrap items-start gap-6 rounded-xl bg-background-light p-4 dark:bg-background-dark'>
+      <TextArea id='textarea-regular' label='Regular' variant='regular' placeholder='Regular surface' />
+      <TextArea id='textarea-bordered' label='Bordered' variant='bordered' placeholder='Stronger border' />
+      <TextArea id='textarea-underlined' label='Underlined' variant='underlined' placeholder='Underlined surface' />
+      <TextArea id='textarea-line' label='Line' variant='line' placeholder='Bottom border only' />
+    </div>
+  )
+};
+
+/**
+ * Compares small, medium, and large sizes with textarea-appropriate minimum heights and typography.
+ */
+export const Sizes: Story = {
+  render: () => (
+    <div className='flex flex-wrap items-start gap-6'>
+      <TextArea id='textarea-small' label='Small' size='sm' placeholder='Small textarea' />
+      <TextArea id='textarea-medium' label='Medium' size='md' placeholder='Medium textarea' />
+      <TextArea id='textarea-large' label='Large' size='lg' placeholder='Large textarea' />
+    </div>
+  )
+};
+
+/**
+ * Shows disabled, read-only, and required states together because they have different native semantics and interaction behavior.
+ */
+export const States: Story = {
+  render: () => (
+    <div className='flex flex-wrap items-start gap-6'>
+      <TextArea id='textarea-disabled' label='Disabled' disabled={true} defaultValue='Disabled content' />
+      <TextArea id='textarea-readonly' label='Read only' readOnly={true} defaultValue='Read-only content' />
+      <TextArea id='textarea-required' label='Required' isRequired={true} placeholder='Required message' />
+    </div>
+  )
+};
+
+/**
+ * Provides deterministic visual fixtures for default, hover-like, and focus-like surfaces without requiring pointer or keyboard interaction.
+ */
+export const InteractionStates: Story = {
+  render: () => (
+    <div className='flex flex-wrap items-start gap-6 rounded-xl bg-background-light p-4 dark:bg-background-dark'>
+      <TextArea id='textarea-static-default' label='Default' placeholder='Default surface' />
+      <TextArea
+        id='textarea-static-hover'
+        label='Hover'
+        placeholder='Hover-like surface'
+        className='border-border-strong-light bg-surface-raised-light dark:border-border-strong-dark dark:bg-surface-raised-dark'
+      />
+      <TextArea
+        id='textarea-static-focus'
+        label='Focus'
+        placeholder='Focus-like surface'
+        className='!border-brand-light/50 shadow-glow-input-focus-light dark:!border-brand-dark/50 dark:shadow-glow-input-focus'
+      />
+    </div>
+  )
+};
+
+/**
+ * Demonstrates each semantic hint tone and how the hint message drives default visual status when `status` is not explicit.
+ * TextArea reuses Input hint colors, so this story also guards shared hint contrast.
+ */
+export const ValidationStates: Story = {
+  render: () => (
+    <div className='flex flex-wrap items-start gap-6 rounded-xl bg-background-light p-4 dark:bg-background-dark'>
+      <TextArea id='textarea-error' label='Error' hint={{ message: 'Message is required', type: 'error' }} />
+      <TextArea id='textarea-warning' label='Warning' hint={{ message: 'Message is getting long', type: 'warning' }} />
+      <TextArea id='textarea-success' label='Success' hint={{ message: 'Message looks good', type: 'success' }} />
+      <TextArea
+        id='textarea-info'
+        label='Info'
+        hint={{ message: 'You can include multiple paragraphs', type: 'info' }}
+      />
+    </div>
+  )
+};
+
+/**
+ * Shows local autosize behavior with minimum and maximum rows; manual resize is disabled by default in autosize mode.
+ */
+export const Autosize: Story = {
+  args: {
+    id: 'textarea-autosize',
+    label: 'Autosize message',
+    autosize: true,
+    minRows: 2,
+    maxRows: 5,
+    defaultValue: 'Start typing to grow the textarea between the configured row limits.',
+    onChange: action('textarea-autosize-change')
+  }
+};
+
+/**
+ * Compares native CSS resize modes, including explicit resize override when autosize would otherwise default to `none`.
+ */
+export const Resize: Story = {
+  render: () => (
+    <div className='flex flex-wrap items-start gap-6'>
+      <TextArea id='textarea-resize-none' label='None' resize='none' defaultValue='No manual resize.' />
+      <TextArea id='textarea-resize-vertical' label='Vertical' resize='vertical' defaultValue='Vertical resize.' />
+      <TextArea
+        id='textarea-resize-horizontal'
+        label='Horizontal'
+        resize='horizontal'
+        defaultValue='Horizontal resize.'
+      />
+      <TextArea id='textarea-resize-both' label='Both' resize='both' defaultValue='Both directions.' />
+    </div>
+  )
+};
+
+/**
+ * Demonstrates `isFullWidth` for layouts where the textarea should fill its parent container.
+ */
+export const FullWidth: Story = {
+  args: {
+    id: 'textarea-full-width',
+    label: 'Full width',
+    isFullWidth: true,
+    placeholder: 'This textarea fills the wrapper.'
+  },
+  decorators: [
+    (StoryComponent) => (
+      <div className='w-full max-w-modal-md'>
+        <StoryComponent />
+      </div>
+    )
+  ]
+};
+
+/**
+ * Demonstrates external accessible naming for layouts where a visible label is owned outside the component.
+ */
+export const ExternalLabel: Story = {
+  render: () => (
+    <div className='flex flex-col gap-2 rounded-xl bg-background-light p-4 dark:bg-background-dark'>
+      <span id='textarea-external-label' className='fs-small font-semibold text-text-light dark:text-text-dark'>
+        External project summary label
+      </span>
+      <TextArea
+        id='textarea-external'
+        ariaLabelledBy='textarea-external-label'
+        placeholder='Externally labelled textarea'
+      />
+    </div>
+  )
+};
+
+/**
+ * Shows safe native textarea attributes passing through for form integration and browser-managed constraints.
+ */
+export const NativeProps: Story = {
+  args: {
+    id: 'textarea-native-props',
+    label: 'Native props',
+    name: 'message',
+    maxLength: 140,
+    rows: 5,
+    autoComplete: 'off',
+    placeholder: 'Native rows, name, and maxLength are passed through.'
+  }
+};

--- a/src/components/atoms/text-area/TextArea.stories.tsx
+++ b/src/components/atoms/text-area/TextArea.stories.tsx
@@ -78,6 +78,18 @@ export const Variants: Story = {
 };
 
 /**
+ * Demonstrates rounded TextArea geometry, which softens the multiline surface without becoming pill-shaped like single-line Input.
+ */
+export const Rounded: Story = {
+  args: {
+    id: 'textarea-rounded',
+    label: 'Rounded message',
+    rounded: true,
+    placeholder: 'Rounded multiline surface'
+  }
+};
+
+/**
  * Compares small, medium, and large sizes with textarea-appropriate minimum heights and typography.
  */
 export const Sizes: Story = {

--- a/src/components/atoms/text-area/TextArea.test.tsx
+++ b/src/components/atoms/text-area/TextArea.test.tsx
@@ -1,4 +1,4 @@
-import { render, renderHook, screen } from '@testing-library/react';
+import { act, render, renderHook, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createElement, createRef, type ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -62,7 +62,73 @@ const mockComputedTextAreaMetrics = () => {
   });
 };
 
+let restoreResizeObserver: (() => void) | undefined;
+
+const installResizeObserverMock = () => {
+  const originalResizeObserver = globalThis.ResizeObserver;
+  const observedElements = new Set<Element>();
+  let activeCallback: ResizeObserverCallback | undefined;
+  let activeObserver: ResizeObserver | undefined;
+  let constructorCalls = 0;
+
+  class MockResizeObserver {
+    constructor(callback: ResizeObserverCallback) {
+      activeCallback = callback;
+      activeObserver = this as unknown as ResizeObserver;
+      constructorCalls += 1;
+    }
+
+    observe(element: Element) {
+      observedElements.add(element);
+    }
+
+    unobserve(element: Element) {
+      observedElements.delete(element);
+    }
+
+    disconnect() {
+      observedElements.clear();
+    }
+  }
+
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    configurable: true,
+    writable: true,
+    value: MockResizeObserver
+  });
+
+  restoreResizeObserver = () => {
+    if (originalResizeObserver) {
+      Object.defineProperty(globalThis, 'ResizeObserver', {
+        configurable: true,
+        writable: true,
+        value: originalResizeObserver
+      });
+      return;
+    }
+
+    Reflect.deleteProperty(globalThis, 'ResizeObserver');
+  };
+
+  return {
+    get constructorCalls() {
+      return constructorCalls;
+    },
+    observedElements,
+    trigger: (observations: { target: Element; width: number }[]) => {
+      const entries = observations.map(({ target, width }) => ({
+        target,
+        contentRect: { width } as DOMRectReadOnly
+      })) as ResizeObserverEntry[];
+
+      activeCallback?.(entries, activeObserver as ResizeObserver);
+    }
+  };
+};
+
 afterEach(() => {
+  restoreResizeObserver?.();
+  restoreResizeObserver = undefined;
   vi.restoreAllMocks();
 });
 
@@ -501,6 +567,71 @@ describe('TextArea — component behavior', () => {
     rerender(renderControlledTextArea({ value: 'Short\nLonger', onValueChange: handleValueChange }));
 
     expect(screen.getByRole('textbox', { name: 'Controlled' }).style.height).toBe('120px');
+  });
+
+  it('recalculates autosize when ResizeObserver reports a width change', () => {
+    const resizeObserver = installResizeObserverMock();
+    mockComputedTextAreaMetrics();
+    setTextAreaScrollHeight(70);
+
+    render(<TextArea id='message' label='Message' autosize={true} minRows={1} />);
+    const textarea = screen.getByRole('textbox', { name: 'Message' });
+    const surface = screen.getByTestId('message-surface');
+
+    expect(resizeObserver.constructorCalls).toBe(1);
+    expect(resizeObserver.observedElements.has(textarea)).toBe(true);
+    expect(resizeObserver.observedElements.has(surface)).toBe(true);
+    expect(textarea.style.height).toBe('70px');
+
+    act(() => {
+      resizeObserver.trigger([
+        { target: textarea, width: 320 },
+        { target: surface, width: 320 }
+      ]);
+    });
+
+    setTextAreaScrollHeight(120);
+
+    act(() => {
+      resizeObserver.trigger([{ target: textarea, width: 260 }]);
+    });
+
+    expect(textarea.style.height).toBe('120px');
+  });
+
+  it('does not install a ResizeObserver when autosize is disabled', () => {
+    const resizeObserver = installResizeObserverMock();
+
+    render(<TextArea id='message' label='Message' autosize={false} />);
+
+    expect(resizeObserver.constructorCalls).toBe(0);
+  });
+
+  it('keeps autosize safe when ResizeObserver is unavailable', () => {
+    const originalResizeObserver = globalThis.ResizeObserver;
+
+    Object.defineProperty(globalThis, 'ResizeObserver', {
+      configurable: true,
+      writable: true,
+      value: undefined
+    });
+    restoreResizeObserver = () => {
+      if (originalResizeObserver) {
+        Object.defineProperty(globalThis, 'ResizeObserver', {
+          configurable: true,
+          writable: true,
+          value: originalResizeObserver
+        });
+        return;
+      }
+
+      Reflect.deleteProperty(globalThis, 'ResizeObserver');
+    };
+    mockComputedTextAreaMetrics();
+    setTextAreaScrollHeight(80);
+
+    expect(() => render(<TextArea id='message' label='Message' autosize={true} minRows={1} />)).not.toThrow();
+    expect(screen.getByRole('textbox', { name: 'Message' }).style.height).toBe('80px');
   });
 
   it('uses resize defaults and explicit resize overrides', () => {

--- a/src/components/atoms/text-area/TextArea.test.tsx
+++ b/src/components/atoms/text-area/TextArea.test.tsx
@@ -1,0 +1,563 @@
+import { render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createElement, createRef, type ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks (declared before component import) ---
+
+vi.mock('lucide-react/dynamic.js', () => ({
+  // biome-ignore lint/style/useNamingConvention: must match library export name
+  DynamicIcon: () => null
+}));
+
+// --- Imports after mocks ---
+
+import * as RootExports from '../../../index';
+import { TextArea } from './TextArea';
+import { useTextArea } from './useTextArea';
+
+type RenderControlledTextAreaProps = {
+  value: string;
+  onValueChange: (value: string) => void;
+};
+
+const renderControlledTextArea = ({ value, onValueChange }: RenderControlledTextAreaProps) => (
+  <TextArea id='controlled' label='Controlled' autosize={true} value={value} onValueChange={onValueChange} />
+);
+
+const withExternalLabels = (children: ReactNode) => (
+  <div>
+    <span id='external-label'>External label</span>
+    <span id='external-description'>External description</span>
+    {children}
+  </div>
+);
+
+const setTextAreaScrollHeight = (height: number) => {
+  Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get: () => height
+  });
+};
+
+const mockComputedTextAreaMetrics = () => {
+  const originalGetComputedStyle = window.getComputedStyle.bind(window);
+
+  return vi.spyOn(window, 'getComputedStyle').mockImplementation((element, pseudoElement) => {
+    const originalStyle = originalGetComputedStyle(element, pseudoElement);
+
+    if (!(element instanceof HTMLTextAreaElement)) {
+      return originalStyle;
+    }
+
+    return {
+      ...originalStyle,
+      lineHeight: '20px',
+      paddingTop: '8px',
+      paddingBottom: '8px',
+      borderTopWidth: '1px',
+      borderBottomWidth: '1px',
+      getPropertyValue: originalStyle.getPropertyValue.bind(originalStyle)
+    } as CSSStyleDeclaration;
+  });
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useTextArea — logic', () => {
+  it('derives default rows, status, and resize for the non-autosize mode', () => {
+    const { result } = renderHook(() => useTextArea({ id: 'message', label: 'Message' }, null));
+
+    expect(result.current.textareaProps.rows).toBe(3);
+    expect(result.current.textareaProps['data-status']).toBe('default');
+    expect(result.current.textareaProps['data-resize']).toBe('vertical');
+  });
+
+  it('respects consumer rows when autosize is disabled', () => {
+    const { result } = renderHook(() => useTextArea({ id: 'message', label: 'Message', rows: 7 }, null));
+
+    expect(result.current.textareaProps.rows).toBe(7);
+    expect(result.current.textareaProps['data-autosize']).toBeUndefined();
+  });
+
+  it('keeps size styling from overriding the row-based height source', () => {
+    const sizes = ['sm', 'md', 'lg'] as const;
+
+    for (const size of sizes) {
+      const { result } = renderHook(() =>
+        useTextArea({ id: `message-${size}`, label: 'Message', size, rows: 1, minRows: 1 }, null)
+      );
+
+      expect(result.current.textareaProps.rows).toBe(1);
+      expect(result.current.surfaceProps.className).not.toMatch(/\bmin-h-(24|28|32)\b/);
+    }
+  });
+
+  it('lets explicit status override hint tone for the visual status', () => {
+    const { result } = renderHook(() =>
+      useTextArea(
+        {
+          id: 'message',
+          label: 'Message',
+          status: 'success',
+          hint: { message: 'Needs attention', type: 'error' }
+        },
+        null
+      )
+    );
+
+    expect(result.current.textareaProps['data-status']).toBe('success');
+    expect(result.current.textareaProps['aria-invalid']).toBe('true');
+  });
+
+  it('dedupes aria-describedby sources while preserving order', () => {
+    const { result } = renderHook(() =>
+      useTextArea(
+        {
+          id: 'message',
+          label: 'Message',
+          ariaDescribedBy: ['external-description', 'message-hint'],
+          'aria-describedby': 'external-description',
+          hint: { message: 'Helpful text', type: 'info' }
+        },
+        null
+      )
+    );
+
+    expect(result.current.textareaProps['aria-describedby']).toBe('external-description message-hint');
+  });
+
+  it('uses autosize mode defaults without passing native rows or fixed surface min-height as the height source', () => {
+    const { result } = renderHook(() =>
+      useTextArea({ id: 'message', label: 'Message', autosize: true, rows: 9, minRows: 2 }, null)
+    );
+
+    expect(result.current.textareaProps.rows).toBeUndefined();
+    expect(result.current.textareaProps['data-autosize']).toBe('true');
+    expect(result.current.textareaProps['data-resize']).toBe('none');
+    expect(result.current.surfaceProps.className).not.toMatch(/\bmin-h-(24|28|32)\b/);
+  });
+});
+
+describe('TextArea — component behavior', () => {
+  it('renders a native textarea with a visible label connected to the id', () => {
+    render(<TextArea id='message' label='Message' placeholder='Write a message' />);
+    const textarea = screen.getByRole('textbox', { name: 'Message' });
+
+    expect(textarea.tagName).toBe('TEXTAREA');
+    expect(screen.getByText('Message')).toHaveAttribute('for', 'message');
+    expect(textarea).toHaveAttribute('id', 'message');
+  });
+
+  it('supports external accessible names through ariaLabelledBy and native aria-labelledby', () => {
+    render(
+      withExternalLabels(
+        <>
+          <TextArea id='camel-label' ariaLabelledBy='external-label' />
+          <TextArea id='native-label' aria-labelledby='external-label' />
+          <TextArea id='external-overrides-label' label='Visible label' ariaLabelledBy='external-label' />
+        </>
+      )
+    );
+
+    const externallyLabelledTextareas = screen.getAllByRole('textbox', { name: 'External label' });
+
+    expect(externallyLabelledTextareas).toHaveLength(3);
+    expect(externallyLabelledTextareas[0]).toHaveAttribute('id', 'camel-label');
+    expect(externallyLabelledTextareas[1]).toHaveAttribute('id', 'native-label');
+    expect(externallyLabelledTextareas[2]).toHaveAttribute('id', 'external-overrides-label');
+    expect(externallyLabelledTextareas[2]).toHaveAttribute('aria-labelledby', 'external-label');
+  });
+
+  it('uses placeholder as a fallback accessible name when no label source exists without reserving label space', () => {
+    render(<TextArea id='fallback' placeholder='Describe your project' />);
+    const textarea = screen.getByRole('textbox', { name: 'Describe your project' });
+
+    expect(textarea).toBeInTheDocument();
+    expect(textarea).not.toHaveClass('pt-5');
+  });
+
+  it('merges external descriptions with the generated hint', () => {
+    render(
+      withExternalLabels(
+        <TextArea
+          id='message'
+          label='Message'
+          ariaDescribedBy='external-description'
+          hint={{ message: 'Keep it short', type: 'info' }}
+        />
+      )
+    );
+
+    expect(screen.getByRole('textbox', { name: 'Message' })).toHaveAccessibleDescription(
+      'External description Keep it short'
+    );
+  });
+
+  it('renders semantic hints and exposes required semantics', () => {
+    render(<TextArea id='message' label='Message' isRequired={true} hint={{ message: 'Required', type: 'error' }} />);
+    const textarea = screen.getByRole('textbox', { name: /Message/i });
+
+    expect(textarea).toBeRequired();
+    expect(textarea).toHaveAttribute('aria-required', 'true');
+    expect(textarea).toHaveAttribute('aria-invalid', 'true');
+    expect(textarea).toHaveAccessibleDescription('Required');
+    expect(screen.getByText('*')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('preserves native aria-invalid values when no error status is present', () => {
+    render(<TextArea id='message' label='Message' aria-invalid='grammar' />);
+
+    expect(screen.getByRole('textbox', { name: 'Message' })).toHaveAttribute('aria-invalid', 'grammar');
+  });
+
+  it('preserves native aria-required unless required semantics force true', () => {
+    render(
+      <>
+        <TextArea id='optional' label='Optional' aria-required='false' />
+        <TextArea id='forced' label='Forced' aria-required='false' isRequired={true} />
+      </>
+    );
+
+    expect(screen.getByRole('textbox', { name: 'Optional' })).toHaveAttribute('aria-required', 'false');
+    expect(screen.getByRole('textbox', { name: /Forced/i })).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('supports controlled value, onChange(event, value), and onValueChange(value)', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    const handleValueChange = vi.fn();
+    render(
+      <TextArea id='message' label='Message' value='Hi' onChange={handleChange} onValueChange={handleValueChange} />
+    );
+
+    await user.type(screen.getByRole('textbox', { name: 'Message' }), '!');
+
+    expect(screen.getByRole('textbox', { name: 'Message' })).toHaveValue('Hi');
+    expect(handleChange.mock.lastCall?.[1]).toBe('Hi!');
+    expect(handleValueChange).toHaveBeenLastCalledWith('Hi!');
+  });
+
+  it('supports uncontrolled defaultValue and forwarded refs', () => {
+    const ref = createRef<HTMLTextAreaElement>();
+    render(<TextArea ref={ref} id='message' label='Message' defaultValue='Draft text' />);
+
+    expect(screen.getByRole('textbox', { name: 'Message' })).toHaveValue('Draft text');
+    expect(ref.current).toBe(screen.getByRole('textbox', { name: 'Message' }));
+  });
+
+  it('keeps disabled and read-only semantics distinct', () => {
+    render(
+      <>
+        <TextArea id='disabled' label='Disabled' disabled={true} />
+        <TextArea id='readonly' label='Read only' readOnly={true} />
+      </>
+    );
+
+    expect(screen.getByRole('textbox', { name: 'Disabled' })).toBeDisabled();
+    expect(screen.getByRole('textbox', { name: 'Disabled' })).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByRole('textbox', { name: 'Read only' })).toHaveAttribute('readonly');
+    expect(screen.getByRole('textbox', { name: 'Read only' })).not.toBeDisabled();
+  });
+
+  it('exposes stable data affordances for layout, variants, sizes, and rounded geometry', () => {
+    render(
+      <TextArea
+        id='message'
+        label='Message'
+        isFullWidth={true}
+        variant='bordered'
+        size='lg'
+        rounded={true}
+        status='warning'
+      />
+    );
+    const textarea = screen.getByRole('textbox', { name: 'Message' });
+
+    expect(textarea).toHaveAttribute('data-full-width', 'true');
+    expect(textarea).toHaveAttribute('data-variant', 'bordered');
+    expect(textarea).toHaveAttribute('data-size', 'lg');
+    expect(textarea).toHaveAttribute('data-rounded', 'true');
+    expect(textarea).toHaveAttribute('data-status', 'warning');
+  });
+
+  it('passes safe native textarea props through', () => {
+    render(
+      <TextArea
+        id='message'
+        label='Message'
+        name='project-message'
+        maxLength={140}
+        minLength={10}
+        spellCheck={false}
+        autoComplete='off'
+        form='contact-form'
+        wrap='hard'
+        data-testid='native-message'
+      />
+    );
+    const textarea = screen.getByTestId('native-message');
+
+    expect(textarea).toHaveAttribute('name', 'project-message');
+    expect(textarea).toHaveAttribute('maxlength', '140');
+    expect(textarea).toHaveAttribute('minlength', '10');
+    expect(textarea).toHaveAttribute('spellcheck', 'false');
+    expect(textarea).toHaveAttribute('autocomplete', 'off');
+    expect(textarea).toHaveAttribute('form', 'contact-form');
+    expect(textarea).toHaveAttribute('wrap', 'hard');
+  });
+
+  it('respects non-autosize rows precedence and minRows defaults', () => {
+    render(
+      <>
+        <TextArea id='default-rows' label='Default rows' />
+        <TextArea id='consumer-rows' label='Consumer rows' rows={8} minRows={2} />
+      </>
+    );
+
+    expect(screen.getByRole('textbox', { name: 'Default rows' })).toHaveAttribute('rows', '3');
+    expect(screen.getByRole('textbox', { name: 'Consumer rows' })).toHaveAttribute('rows', '8');
+  });
+
+  it('calculates autosize height on mount and clamps by maxRows', () => {
+    const computedStyle = mockComputedTextAreaMetrics();
+    setTextAreaScrollHeight(200);
+
+    render(<TextArea id='message' label='Message' autosize={true} minRows={2} maxRows={4} defaultValue='Long text' />);
+    const textarea = screen.getByRole('textbox', { name: 'Message' });
+
+    expect(computedStyle).toHaveBeenCalledWith(textarea);
+    expect(textarea).not.toHaveAttribute('rows');
+    expect(textarea.style.height).toBe('98px');
+    expect(textarea.style.overflowY).toBe('auto');
+  });
+
+  it('top-composes an empty labeled textarea and reserves label space before focus', () => {
+    const originalGetComputedStyle = window.getComputedStyle.bind(window);
+    vi.spyOn(window, 'getComputedStyle').mockImplementation((element, pseudoElement) => {
+      const originalStyle = originalGetComputedStyle(element, pseudoElement);
+
+      if (!(element instanceof HTMLTextAreaElement)) {
+        return originalStyle;
+      }
+
+      return {
+        ...originalStyle,
+        lineHeight: '20px',
+        paddingTop: element.getAttribute('aria-labelledby') ? '20px' : '0px',
+        paddingBottom: '0px',
+        borderTopWidth: '0px',
+        borderBottomWidth: '0px',
+        getPropertyValue: originalStyle.getPropertyValue.bind(originalStyle)
+      } as CSSStyleDeclaration;
+    });
+    setTextAreaScrollHeight(40);
+
+    render(<TextArea id='message' label='Message' autosize={true} minRows={2} />);
+    const textarea = screen.getByRole('textbox', { name: 'Message' });
+    const label = screen.getByText('Message');
+
+    expect(textarea).toHaveAttribute('aria-labelledby', 'message-label');
+    expect(label).toHaveClass('top-1.5');
+    expect(label).not.toHaveClass('top-1/2');
+    expect(label).not.toHaveClass('-translate-y-1/2');
+    expect(textarea.style.height).toBe('60px');
+  });
+
+  it('renders on the server without a React useLayoutEffect warning', async () => {
+    const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    vi.resetModules();
+    Object.defineProperty(globalThis, 'window', { configurable: true, value: undefined });
+
+    try {
+      const [{ renderToString }, { TextArea: ServerTextArea }] = await Promise.all([
+        import('react-dom/server'),
+        import('./TextArea')
+      ]);
+
+      renderToString(createElement(ServerTextArea, { id: 'server-message', label: 'Server message' }));
+    } finally {
+      if (originalWindowDescriptor) {
+        Object.defineProperty(globalThis, 'window', originalWindowDescriptor);
+      }
+    }
+
+    const warningOutput = consoleError.mock.calls.flat().join('\n');
+
+    expect(warningOutput).not.toContain('useLayoutEffect');
+  });
+
+  it('recalculates autosize when size changes textarea metrics without changing value or focus', () => {
+    const originalGetComputedStyle = window.getComputedStyle.bind(window);
+    vi.spyOn(window, 'getComputedStyle').mockImplementation((element, pseudoElement) => {
+      const originalStyle = originalGetComputedStyle(element, pseudoElement);
+
+      if (!(element instanceof HTMLTextAreaElement)) {
+        return originalStyle;
+      }
+
+      return {
+        ...originalStyle,
+        lineHeight: element.dataset.size === 'lg' ? '24px' : '16px',
+        paddingTop: '0px',
+        paddingBottom: '0px',
+        borderTopWidth: '0px',
+        borderBottomWidth: '0px',
+        getPropertyValue: originalStyle.getPropertyValue.bind(originalStyle)
+      } as CSSStyleDeclaration;
+    });
+    setTextAreaScrollHeight(0);
+
+    const { rerender } = render(<TextArea id='message' label='Message' autosize={true} minRows={2} size='sm' />);
+    const textarea = screen.getByRole('textbox', { name: 'Message' });
+
+    expect(textarea.style.height).toBe('32px');
+
+    rerender(<TextArea id='message' label='Message' autosize={true} minRows={2} size='lg' />);
+
+    expect(textarea.style.height).toBe('48px');
+  });
+
+  it('recalculates autosize when adding or removing a label changes floating-label offset without changing value or focus', () => {
+    const originalGetComputedStyle = window.getComputedStyle.bind(window);
+    vi.spyOn(window, 'getComputedStyle').mockImplementation((element, pseudoElement) => {
+      const originalStyle = originalGetComputedStyle(element, pseudoElement);
+
+      if (!(element instanceof HTMLTextAreaElement)) {
+        return originalStyle;
+      }
+
+      return {
+        ...originalStyle,
+        lineHeight: '20px',
+        paddingTop: element.getAttribute('aria-labelledby') ? '20px' : '0px',
+        paddingBottom: '0px',
+        borderTopWidth: '0px',
+        borderBottomWidth: '0px',
+        getPropertyValue: originalStyle.getPropertyValue.bind(originalStyle)
+      } as CSSStyleDeclaration;
+    });
+    setTextAreaScrollHeight(0);
+
+    const { rerender } = render(
+      <TextArea id='message' autosize={true} minRows={2} placeholder='Describe your project' />
+    );
+    const textarea = screen.getByRole('textbox', { name: 'Describe your project' });
+
+    expect(textarea.style.height).toBe('40px');
+
+    rerender(<TextArea id='message' label='Message' autosize={true} minRows={2} placeholder='Describe your project' />);
+
+    expect(textarea.style.height).toBe('60px');
+
+    rerender(<TextArea id='message' autosize={true} minRows={2} placeholder='Describe your project' />);
+
+    expect(textarea.style.height).toBe('40px');
+  });
+
+  it('clears autosize-managed inline styles when autosize is disabled', () => {
+    mockComputedTextAreaMetrics();
+    setTextAreaScrollHeight(200);
+    const { rerender } = render(
+      <TextArea id='message' label='Message' autosize={true} minRows={1} maxRows={2} defaultValue='Long text' />
+    );
+    const textarea = screen.getByRole('textbox', { name: 'Message' });
+
+    expect(textarea.style.height).toBe('58px');
+    expect(textarea.style.overflowY).toBe('auto');
+
+    rerender(<TextArea id='message' label='Message' autosize={false} rows={4} defaultValue='Long text' />);
+
+    expect(textarea).toHaveAttribute('rows', '4');
+    expect(textarea.style.height).toBe('');
+    expect(textarea.style.overflowY).toBe('');
+  });
+
+  it('recalculates autosize after uncontrolled typing without stealing focus', async () => {
+    const user = userEvent.setup();
+    mockComputedTextAreaMetrics();
+    setTextAreaScrollHeight(96);
+    render(<TextArea id='message' label='Message' autosize={true} minRows={1} />);
+    const textarea = screen.getByRole('textbox', { name: 'Message' });
+
+    await user.type(textarea, 'Hello');
+
+    expect(textarea).toHaveFocus();
+    expect(textarea.style.height).toBe('96px');
+    expect(textarea.style.overflowY).toBe('hidden');
+  });
+
+  it('recalculates autosize when a controlled value changes', () => {
+    const handleValueChange = vi.fn();
+    mockComputedTextAreaMetrics();
+    setTextAreaScrollHeight(70);
+    const { rerender } = render(renderControlledTextArea({ value: 'Short', onValueChange: handleValueChange }));
+
+    setTextAreaScrollHeight(120);
+    rerender(renderControlledTextArea({ value: 'Short\nLonger', onValueChange: handleValueChange }));
+
+    expect(screen.getByRole('textbox', { name: 'Controlled' }).style.height).toBe('120px');
+  });
+
+  it('uses resize defaults and explicit resize overrides', () => {
+    render(
+      <>
+        <TextArea id='default-resize' label='Default resize' />
+        <TextArea id='autosize-resize' label='Autosize resize' autosize={true} />
+        <TextArea id='explicit-resize' label='Explicit resize' autosize={true} resize='horizontal' />
+        <TextArea id='both-resize' label='Both resize' resize='both' />
+      </>
+    );
+
+    expect(screen.getByRole('textbox', { name: 'Default resize' })).toHaveAttribute('data-resize', 'vertical');
+    expect(screen.getByRole('textbox', { name: 'Autosize resize' })).toHaveAttribute('data-resize', 'none');
+    expect(screen.getByRole('textbox', { name: 'Explicit resize' })).toHaveAttribute('data-resize', 'horizontal');
+    expect(screen.getByRole('textbox', { name: 'Both resize' })).toHaveAttribute('data-resize', 'both');
+  });
+
+  it('falls back to a safe row height when computed line height is unavailable', () => {
+    const originalGetComputedStyle = window.getComputedStyle.bind(window);
+    vi.spyOn(window, 'getComputedStyle').mockImplementation((element, pseudoElement) => {
+      const originalStyle = originalGetComputedStyle(element, pseudoElement);
+
+      if (!(element instanceof HTMLTextAreaElement)) {
+        return originalStyle;
+      }
+
+      return {
+        ...originalStyle,
+        lineHeight: 'normal',
+        paddingTop: '0px',
+        paddingBottom: '0px',
+        borderTopWidth: '0px',
+        borderBottomWidth: '0px',
+        getPropertyValue: originalStyle.getPropertyValue.bind(originalStyle)
+      } as CSSStyleDeclaration;
+    });
+    setTextAreaScrollHeight(0);
+
+    render(<TextArea id='fallback-height' label='Fallback height' autosize={true} minRows={2} />);
+
+    expect(screen.getByRole('textbox', { name: 'Fallback height' }).style.height).toBe('40px');
+  });
+
+  it('focuses the textarea when the visible surface is clicked', async () => {
+    const user = userEvent.setup();
+    render(<TextArea id='message' label='Message' />);
+    const textarea = screen.getByRole('textbox', { name: 'Message' });
+
+    await user.click(screen.getByTestId('message-surface'));
+
+    expect(textarea).toHaveFocus();
+  });
+
+  it('exports TextArea from the component folder and package root only with TextArea casing', () => {
+    expect(TextArea.displayName).toBe('TextArea');
+    expect(RootExports.TextArea).toBe(TextArea);
+    expect(RootExports).not.toHaveProperty('Textarea');
+  });
+});

--- a/src/components/atoms/text-area/TextArea.tsx
+++ b/src/components/atoms/text-area/TextArea.tsx
@@ -1,0 +1,47 @@
+import { forwardRef } from 'react';
+import { Icon } from '../icon';
+import type { TextAreaProps } from './types';
+import { useTextArea } from './useTextArea';
+
+export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, ref) => {
+  const {
+    hasHint,
+    hasLabel,
+    hintIconProps,
+    hintMessage,
+    hintMessageClassName,
+    isRequired,
+    label,
+    labelProps,
+    surfaceProps,
+    textareaProps,
+    textareaRef,
+    wrapperClassName
+  } = useTextArea(props, ref);
+
+  return (
+    <div className={wrapperClassName}>
+      <div {...surfaceProps}>
+        {hasLabel && (
+          <label {...labelProps}>
+            {label}{' '}
+            {isRequired && (
+              <span className='text-brand-light dark:text-brand-dark' aria-hidden={true}>
+                *
+              </span>
+            )}
+          </label>
+        )}
+        <textarea {...textareaProps} ref={textareaRef} />
+      </div>
+      {hasHint && (
+        <div id={`${props.id}-hint`} className='flex items-center gap-2 py-0.5'>
+          {hintIconProps && <Icon {...hintIconProps} decorative={true} />}
+          <span className={hintMessageClassName}>{hintMessage}</span>
+        </div>
+      )}
+    </div>
+  );
+});
+
+TextArea.displayName = 'TextArea';

--- a/src/components/atoms/text-area/index.ts
+++ b/src/components/atoms/text-area/index.ts
@@ -1,0 +1,2 @@
+export { TextArea } from './TextArea';
+export type * from './types';

--- a/src/components/atoms/text-area/types.ts
+++ b/src/components/atoms/text-area/types.ts
@@ -1,10 +1,26 @@
 import { cva, type VariantProps } from 'class-variance-authority';
-import type { ChangeEvent, ComponentProps, ReactNode } from 'react';
+import type { ChangeEvent, ComponentProps } from 'react';
+import { hintMessageVariants as inputHintMessageVariants } from '@/components/atoms/input/types';
 
-export const inputVariants = cva(
+/** Re-exported from Input for consistency — avoids API drift. */
+export const hintMessageVariants = inputHintMessageVariants;
+
+export const textAreaWrapperVariants = cva('flex max-w-full flex-col gap-2', {
+  variants: {
+    fullWidth: {
+      true: 'w-full',
+      false: 'w-auto'
+    }
+  },
+  defaultVariants: {
+    fullWidth: false
+  }
+});
+
+export const textAreaSurfaceVariants = cva(
   [
-    'relative flex max-w-full justify-between overflow-hidden border py-2',
-    'cursor-text transition-[background,border-color,box-shadow] duration-200 ease-[ease]',
+    'relative flex max-w-full overflow-hidden border cursor-text',
+    'transition-[background,border-color,box-shadow] duration-200 ease-[ease]',
     'focus-within:outline-none'
   ],
   {
@@ -14,6 +30,10 @@ export const inputVariants = cva(
           'bg-surface-light border-border-light hover:bg-surface-raised-light hover:border-border-strong-light',
           'dark:bg-surface-dark dark:border-border-dark dark:hover:bg-surface-raised-dark dark:hover:border-border-strong-dark'
         ],
+        bordered: [
+          'bg-surface-light border-border-strong-light hover:bg-surface-raised-light',
+          'dark:bg-surface-dark dark:border-border-strong-dark dark:hover:bg-surface-raised-dark'
+        ],
         underlined: [
           'bg-transparent border-border-light hover:border-border-strong-light',
           'dark:border-border-dark dark:hover:border-border-strong-dark'
@@ -22,20 +42,16 @@ export const inputVariants = cva(
           'bg-transparent border-t-transparent border-l-transparent border-r-transparent rounded-none!',
           'border-b-border-light hover:border-b-border-strong-light',
           'dark:border-b-border-dark dark:hover:border-b-border-strong-dark'
-        ],
-        bordered: [
-          'bg-surface-light border-border-strong-light hover:bg-surface-raised-light',
-          'dark:bg-surface-dark dark:border-border-strong-dark dark:hover:bg-surface-raised-dark'
         ]
       },
       rounded: {
-        true: 'rounded-full',
+        true: 'rounded-lg',
         false: 'rounded-md'
       },
       size: {
-        sm: 'h-12 px-3 fs-small',
-        md: 'h-14 px-4 fs-base',
-        lg: 'h-16 px-4 fs-h6'
+        sm: 'px-3 py-2',
+        md: 'px-4 py-3',
+        lg: 'px-4 py-3'
       },
       status: {
         default: '',
@@ -84,9 +100,9 @@ export const inputVariants = cva(
   }
 );
 
-export const labelVariants = cva(
+export const textAreaLabelVariants = cva(
   [
-    'absolute w-auto line-clamp-1 pt-0.5 text-text-light dark:text-text-dark',
+    'absolute z-10 w-auto line-clamp-1 pt-0.5 text-text-light dark:text-text-dark',
     'transition-[top,font-size,color] duration-200 ease-[ease]'
   ],
   {
@@ -97,128 +113,105 @@ export const labelVariants = cva(
         lg: 'left-4 font-medium'
       },
       state: {
-        resting: 'top-1/2 -translate-y-1/2',
-        floatingSm: 'top-0.5 fs-xs font-semibold',
+        floatingSm: 'top-1 fs-xs font-semibold',
         floatingMd: 'top-1.5 fs-small font-semibold',
         floatingLg: 'top-2 fs-small font-semibold'
       }
     },
-    compoundVariants: [
-      {
-        size: 'sm',
-        state: 'resting',
-        class: 'fs-small'
-      },
-      {
-        size: 'md',
-        state: 'resting',
-        class: 'fs-base'
-      },
-      {
-        size: 'lg',
-        state: 'resting',
-        class: 'fs-h6'
-      }
-    ],
     defaultVariants: {
       size: 'md',
-      state: 'resting'
+      state: 'floatingMd'
     }
   }
 );
 
-export const nativeInputVariants = cva(
+export const nativeTextAreaVariants = cva(
   [
-    'flex-1 border-none bg-transparent font-medium outline-none',
+    'min-h-full w-full flex-1 border-none bg-transparent p-0 font-medium outline-none',
     'text-text-light dark:text-text-dark placeholder:text-text-muted-light dark:placeholder:text-text-muted-dark',
     'disabled:cursor-not-allowed'
   ],
   {
     variants: {
-      hasInlineAction: {
-        true: 'pr-6',
+      size: {
+        sm: 'fs-small leading-relaxed',
+        md: 'fs-base leading-relaxed',
+        lg: 'fs-h6 leading-relaxed'
+      },
+      hasFloatingLabel: {
+        true: 'pt-5',
         false: ''
+      },
+      resize: {
+        none: 'resize-none',
+        vertical: 'resize-y',
+        horizontal: 'resize-x',
+        both: 'resize'
       }
     },
     defaultVariants: {
-      hasInlineAction: false
+      size: 'md',
+      hasFloatingLabel: false,
+      resize: 'vertical'
     }
   }
 );
 
-export const inputInlineButtonVariants = cva(
-  [
-    'cursor-pointer rounded-sm bg-surface-light px-1 text-text-light hover:bg-surface-raised-light',
-    'dark:bg-surface-dark dark:text-text-dark dark:hover:bg-surface-raised-dark',
-    'focus-visible:outline-none focus-visible:shadow-glow-focus-light dark:focus-visible:shadow-glow-focus-dark',
-    'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-40'
-  ],
-  {
-    variants: {
-      shape: {
-        top: 'rounded-b-none',
-        bottom: 'rounded-t-none',
-        icon: 'rounded-full p-0.5'
-      }
-    },
-    defaultVariants: {
-      shape: 'icon'
-    }
-  }
-);
-
-export const hintMessageVariants = cva('fs-small', {
-  variants: {
-    tone: {
-      info: 'text-text-secondary-light dark:text-text-secondary-dark',
-      warning: 'text-[#92400e] dark:text-warning',
-      error: 'text-error-light dark:text-error',
-      success: 'text-[#15803d] dark:text-success'
-    }
-  },
-  defaultVariants: {
-    tone: 'info'
-  }
-});
-
-type InputVariantProps = VariantProps<typeof inputVariants>;
-type NativeInputProps = Omit<
-  ComponentProps<'input'>,
-  'children' | 'className' | 'disabled' | 'id' | 'onChange' | 'size' | 'type'
+type TextAreaVariantProps = VariantProps<typeof textAreaSurfaceVariants>;
+type NativeTextAreaProps = Omit<
+  ComponentProps<'textarea'>,
+  'children' | 'className' | 'disabled' | 'id' | 'onChange' | 'readOnly' | 'size'
 >;
 
-export type InputHintType = 'error' | 'warning' | 'success' | 'info';
-export type InputTypeVariant = 'text' | 'email' | 'password' | 'number' | 'tel' | 'url' | 'search' | 'hidden';
-export type InputVariant = NonNullable<InputVariantProps['variant']>;
-export type InputSize = NonNullable<InputVariantProps['size']>;
-export type InputHint = {
+export type TextAreaVariant = NonNullable<TextAreaVariantProps['variant']>;
+export type TextAreaSize = NonNullable<TextAreaVariantProps['size']>;
+export type TextAreaStatus = NonNullable<TextAreaVariantProps['status']>;
+export type TextAreaResize = 'none' | 'vertical' | 'horizontal' | 'both';
+
+export type TextAreaHint = {
   message: string;
-  type: InputHintType;
+  type: 'error' | 'warning' | 'success' | 'info';
 };
 
-export type InputProps = NativeInputProps & {
+export type TextAreaProps = NativeTextAreaProps & {
   /** @control text */
   id: string;
+  /** @control text */
+  value?: string;
+  /** @control text */
+  defaultValue?: string;
+  onChange?: (event: ChangeEvent<HTMLTextAreaElement>, value: string) => void;
+  onValueChange?: (value: string) => void;
+  /**
+   * @control text
+   * @default ''
+   */
+  label?: string;
+  /** @control text */
+  placeholder?: string;
   /**
    * @control select
    * @default regular
    */
-  variant?: InputVariant;
+  variant?: TextAreaVariant;
   /**
    * @control select
-   * @default text
+   * @default md
    */
-  type?: InputTypeVariant;
+  size?: TextAreaSize;
   /**
    * @control boolean
    * @default false
    */
   rounded?: boolean;
   /**
-   * @control text
-   * @default ''
+   * Defaults to the resolved hint type when a hint is present.
+   * @control select
+   * @default default
    */
-  label?: string;
+  status?: TextAreaStatus;
+  /** @control object */
+  hint?: TextAreaHint;
   /**
    * @control boolean
    * @default false
@@ -230,28 +223,37 @@ export type InputProps = NativeInputProps & {
    */
   disabled?: boolean;
   /**
-   * @control select
-   * @default md
+   * @control boolean
+   * @default false
    */
-  size?: InputSize;
+  readOnly?: boolean;
   /**
    * @control boolean
    * @default false
    */
   isFullWidth?: boolean;
-  /** @control text */
-  placeholder?: string;
-  /** @control text */
-  className?: string;
-  /** @control object */
-  hint?: InputHint;
-  /** @control object */
-  startContent?: ReactNode;
-  /** @control object */
-  endContent?: ReactNode;
+  /**
+   * @control boolean
+   * @default false
+   */
+  autosize?: boolean;
+  /**
+   * @control number
+   * @default 3
+   */
+  minRows?: number;
+  /** @control number */
+  maxRows?: number;
+  /**
+   * Defaults to `none` when autosize is enabled.
+   * @control select
+   * @default vertical
+   */
+  resize?: TextAreaResize;
   /** @control text */
   ariaDescribedBy?: string | string[];
   /** @control text */
   ariaLabelledBy?: string | string[];
-  onChange?: (event: ChangeEvent<HTMLInputElement>, value: string) => void;
+  /** @control text */
+  className?: string;
 };

--- a/src/components/atoms/text-area/useTextArea.ts
+++ b/src/components/atoms/text-area/useTextArea.ts
@@ -1,0 +1,346 @@
+import type { ChangeEvent, ComponentProps, FocusEvent, ForwardedRef } from 'react';
+import * as React from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
+import type { DynamicIconName } from '@/types';
+import type { IconTone } from '../icon';
+import {
+  hintMessageVariants,
+  nativeTextAreaVariants,
+  type TextAreaHint,
+  type TextAreaProps,
+  textAreaLabelVariants,
+  textAreaSurfaceVariants,
+  textAreaWrapperVariants
+} from './types';
+
+type HintIconProps = {
+  name: DynamicIconName;
+  tone: IconTone;
+  size: 16;
+};
+
+type TextAreaLabelState = 'floatingSm' | 'floatingMd' | 'floatingLg';
+
+type TextAreaSurfaceProps = ComponentProps<'div'> & {
+  'data-testid': string;
+};
+
+type TextAreaNativeProps = ComponentProps<'textarea'> & {
+  'data-autosize'?: 'true';
+  'data-full-width'?: 'true';
+  'data-resize': NonNullable<TextAreaProps['resize']>;
+  'data-rounded': 'true' | 'false';
+  'data-size': NonNullable<TextAreaProps['size']>;
+  'data-status': NonNullable<TextAreaProps['status']>;
+  'data-variant': NonNullable<TextAreaProps['variant']>;
+};
+
+type UseTextAreaReturn = {
+  hasHint: boolean;
+  hasLabel: boolean;
+  hintIconProps?: HintIconProps;
+  hintMessage?: string;
+  hintMessageClassName: string;
+  isRequired: boolean;
+  label: string;
+  labelProps: ComponentProps<'label'>;
+  surfaceProps: TextAreaSurfaceProps;
+  textareaProps: TextAreaNativeProps;
+  textareaRef: (node: HTMLTextAreaElement | null) => void;
+  wrapperClassName: string;
+};
+
+const DEFAULT_MIN_ROWS = 3;
+const DEFAULT_ROW_HEIGHT = 20;
+const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useEffect : React.useLayoutEffect;
+
+const normalizeRows = (rows: number | undefined, fallback: number) => {
+  if (rows === undefined || !Number.isFinite(rows)) {
+    return fallback;
+  }
+
+  return Math.max(1, Math.floor(rows));
+};
+
+const parseMetric = (value: string, fallback = 0) => {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const formatAriaIds = (...ids: (string | string[] | undefined)[]) => {
+  const uniqueIds = new Set<string>();
+
+  for (const id of ids) {
+    const parts = Array.isArray(id) ? id : id?.split(/\s+/);
+
+    for (const part of parts ?? []) {
+      if (part) {
+        uniqueIds.add(part);
+      }
+    }
+  }
+
+  return Array.from(uniqueIds).join(' ') || undefined;
+};
+
+const getFloatingLabelState = (size: NonNullable<TextAreaProps['size']>): TextAreaLabelState => {
+  if (size === 'sm') {
+    return 'floatingSm';
+  }
+
+  if (size === 'lg') {
+    return 'floatingLg';
+  }
+
+  return 'floatingMd';
+};
+
+const getHintIconProps = (type?: TextAreaHint['type']): HintIconProps | undefined => {
+  switch (type) {
+    case 'error':
+      return { name: 'circle-alert', tone: 'danger', size: 16 };
+    case 'warning':
+      return { name: 'triangle-alert', tone: 'warning', size: 16 };
+    case 'success':
+      return { name: 'circle-check', tone: 'success', size: 16 };
+    case 'info':
+      return { name: 'info', tone: 'muted', size: 16 };
+    default:
+      return undefined;
+  }
+};
+
+const assignForwardedRef = (ref: ForwardedRef<HTMLTextAreaElement> | undefined, node: HTMLTextAreaElement | null) => {
+  if (!ref) {
+    return;
+  }
+
+  if (typeof ref === 'function') {
+    ref(node);
+    return;
+  }
+
+  ref.current = node;
+};
+
+const autosizeTextArea = (textarea: HTMLTextAreaElement, minRows: number, maxRows?: number) => {
+  const styles = window.getComputedStyle(textarea);
+  const rowHeight = parseMetric(styles.lineHeight, DEFAULT_ROW_HEIGHT);
+  const boxOffset =
+    parseMetric(styles.paddingTop) +
+    parseMetric(styles.paddingBottom) +
+    parseMetric(styles.borderTopWidth) +
+    parseMetric(styles.borderBottomWidth);
+  const minHeight = rowHeight * minRows + boxOffset;
+  const resolvedMaxRows = maxRows === undefined ? undefined : Math.max(minRows, normalizeRows(maxRows, minRows));
+  const maxHeight = resolvedMaxRows === undefined ? undefined : rowHeight * resolvedMaxRows + boxOffset;
+
+  textarea.style.height = 'auto';
+
+  const unclampedHeight = Math.max(textarea.scrollHeight, minHeight);
+  const clampedHeight = maxHeight === undefined ? unclampedHeight : Math.min(unclampedHeight, maxHeight);
+
+  textarea.style.height = `${clampedHeight}px`;
+  textarea.style.overflowY = maxHeight !== undefined && unclampedHeight > maxHeight ? 'auto' : 'hidden';
+};
+
+export const useTextArea = (
+  {
+    rounded = false,
+    size = 'md',
+    label = '',
+    placeholder,
+    id,
+    variant = 'regular',
+    className,
+    isFullWidth = false,
+    isRequired = false,
+    required = false,
+    hint,
+    status,
+    onFocus,
+    onBlur,
+    onChange,
+    onValueChange,
+    value,
+    defaultValue,
+    disabled = false,
+    readOnly = false,
+    autosize = false,
+    minRows = DEFAULT_MIN_ROWS,
+    maxRows,
+    resize,
+    rows,
+    ariaDescribedBy,
+    ariaLabelledBy,
+    'aria-describedby': nativeAriaDescribedBy,
+    'aria-labelledby': nativeAriaLabelledBy,
+    'aria-label': nativeAriaLabel,
+    'aria-invalid': nativeAriaInvalid,
+    'aria-required': nativeAriaRequired,
+    ...props
+  }: TextAreaProps,
+  forwardedRef?: ForwardedRef<HTMLTextAreaElement>
+): UseTextAreaReturn => {
+  const [isFocused, setIsFocused] = useState(false);
+  const textareaElementRef = useRef<HTMLTextAreaElement | null>(null);
+  const autosizeStyleRef = useRef<{ height: string; overflowY: string } | null>(null);
+
+  const normalizedMinRows = normalizeRows(minRows, DEFAULT_MIN_ROWS);
+  const normalizedMaxRows = maxRows === undefined ? undefined : normalizeRows(maxRows, normalizedMinRows);
+  const requiredState = isRequired || required;
+  const effectiveStatus = status ?? hint?.type ?? 'default';
+  const hasLabel = Boolean(label);
+  const hasFloatingLabelOffset = hasLabel;
+  const effectiveResize = resize ?? (autosize ? 'none' : 'vertical');
+  const resolvedRows = autosize ? undefined : (rows ?? normalizedMinRows);
+  const hintDescribedBy = hint?.message ? `${id}-hint` : undefined;
+  const labelledBy = formatAriaIds(ariaLabelledBy ?? nativeAriaLabelledBy ?? (label ? `${id}-label` : undefined));
+  const describedBy = formatAriaIds(nativeAriaDescribedBy, ariaDescribedBy, hintDescribedBy);
+  const isInvalid = effectiveStatus === 'error' || hint?.type === 'error';
+
+  const runAutosize = useCallback(() => {
+    const textarea = textareaElementRef.current;
+
+    if (!textarea) {
+      return;
+    }
+
+    if (!autosize) {
+      const autosizeStyle = autosizeStyleRef.current;
+
+      if (autosizeStyle) {
+        if (textarea.style.height === autosizeStyle.height) {
+          textarea.style.height = '';
+        }
+
+        if (textarea.style.overflowY === autosizeStyle.overflowY) {
+          textarea.style.overflowY = '';
+        }
+
+        autosizeStyleRef.current = null;
+      }
+
+      return;
+    }
+
+    autosizeTextArea(textarea, normalizedMinRows, normalizedMaxRows);
+    autosizeStyleRef.current = { height: textarea.style.height, overflowY: textarea.style.overflowY };
+  }, [autosize, normalizedMaxRows, normalizedMinRows]);
+
+  useIsomorphicLayoutEffect(() => {
+    runAutosize();
+  }, [hasFloatingLabelOffset, runAutosize, size, value]);
+
+  const textareaRef = useCallback(
+    (node: HTMLTextAreaElement | null) => {
+      textareaElementRef.current = node;
+      assignForwardedRef(forwardedRef, node);
+    },
+    [forwardedRef]
+  );
+
+  const handleSurfaceClick = () => {
+    if (disabled) {
+      return;
+    }
+
+    textareaElementRef.current?.focus();
+  };
+
+  const handleFocus = (event: FocusEvent<HTMLTextAreaElement>) => {
+    setIsFocused(true);
+    onFocus?.(event);
+  };
+
+  const handleBlur = (event: FocusEvent<HTMLTextAreaElement>) => {
+    setIsFocused(false);
+    onBlur?.(event);
+  };
+
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    const nextValue = event.target.value;
+
+    onChange?.(event, nextValue);
+    onValueChange?.(nextValue);
+
+    if (autosize) {
+      autosizeTextArea(event.currentTarget, normalizedMinRows, normalizedMaxRows);
+      autosizeStyleRef.current = {
+        height: event.currentTarget.style.height,
+        overflowY: event.currentTarget.style.overflowY
+      };
+    }
+  };
+
+  const surfaceClassName = cn(
+    textAreaSurfaceVariants({
+      size,
+      rounded,
+      variant,
+      status: effectiveStatus,
+      focused: isFocused,
+      fullWidth: isFullWidth
+    }),
+    disabled && 'pointer-events-none cursor-not-allowed opacity-40',
+    className
+  );
+
+  const labelClassName = textAreaLabelVariants({
+    size,
+    state: getFloatingLabelState(size)
+  });
+
+  const hintIconProps = useMemo(() => getHintIconProps(hint?.type), [hint?.type]);
+
+  return {
+    hasHint: Boolean(hint?.message),
+    hasLabel,
+    hintIconProps,
+    hintMessage: hint?.message,
+    hintMessageClassName: hintMessageVariants({ tone: hint?.type ?? 'info' }),
+    isRequired: requiredState,
+    label,
+    labelProps: {
+      id: `${id}-label`,
+      htmlFor: id,
+      className: labelClassName
+    },
+    surfaceProps: {
+      className: surfaceClassName,
+      onClick: handleSurfaceClick,
+      'data-testid': `${id}-surface`
+    },
+    textareaProps: {
+      ...props,
+      id,
+      placeholder,
+      disabled,
+      readOnly,
+      rows: resolvedRows,
+      'aria-disabled': disabled ? true : undefined,
+      'aria-invalid': isInvalid ? 'true' : nativeAriaInvalid,
+      'aria-describedby': describedBy,
+      'aria-labelledby': labelledBy,
+      'aria-label': nativeAriaLabel ?? (!labelledBy ? placeholder : undefined),
+      required: requiredState,
+      'aria-required': requiredState ? true : nativeAriaRequired,
+      className: nativeTextAreaVariants({ size, hasFloatingLabel: hasFloatingLabelOffset, resize: effectiveResize }),
+      onFocus: handleFocus,
+      onBlur: handleBlur,
+      onChange: handleChange,
+      value,
+      defaultValue,
+      'data-autosize': autosize ? 'true' : undefined,
+      'data-full-width': isFullWidth ? 'true' : undefined,
+      'data-resize': effectiveResize,
+      'data-rounded': rounded ? 'true' : 'false',
+      'data-size': size,
+      'data-status': effectiveStatus,
+      'data-variant': variant
+    },
+    textareaRef,
+    wrapperClassName: textAreaWrapperVariants({ fullWidth: isFullWidth })
+  };
+};

--- a/src/components/atoms/text-area/useTextArea.ts
+++ b/src/components/atoms/text-area/useTextArea.ts
@@ -233,6 +233,48 @@ export const useTextArea = (
     runAutosize();
   }, [hasFloatingLabelOffset, runAutosize, size, value]);
 
+  useIsomorphicLayoutEffect(() => {
+    if (!autosize || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const textarea = textareaElementRef.current;
+
+    if (!textarea) {
+      return;
+    }
+
+    const observedWidths = new WeakMap<Element, number>();
+    const observer = new ResizeObserver((entries) => {
+      let shouldAutosize = false;
+
+      for (const entry of entries) {
+        const previousWidth = observedWidths.get(entry.target);
+        const nextWidth = entry.contentRect.width;
+
+        observedWidths.set(entry.target, nextWidth);
+
+        if (previousWidth !== undefined && previousWidth !== nextWidth) {
+          shouldAutosize = true;
+        }
+      }
+
+      if (shouldAutosize) {
+        runAutosize();
+      }
+    });
+
+    observer.observe(textarea);
+
+    if (textarea.parentElement) {
+      observer.observe(textarea.parentElement);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [autosize, runAutosize]);
+
   const textareaRef = useCallback(
     (node: HTMLTextAreaElement | null) => {
       textareaElementRef.current = node;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export { Spacer } from './components/atoms/spacer';
 export { Switch } from './components/atoms/switch';
 export { Table } from './components/atoms/table';
 export { Text } from './components/atoms/text';
+export { TextArea } from './components/atoms/text-area';
 export { Tooltip } from './components/atoms/tooltip';
 
 // ─── Molecules ───────────────────────────────────────────────────────────────

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -111,11 +111,13 @@
   --color-success: #22c55e; /* Dark */
   --color-success-light: #16a34a; /* Light */
   --color-success-dark: #138a3d;
+  --color-success-text-light: #15803d; /* Light hint text — AA on white */
   --color-success-tint: rgba(34, 197, 94, 0.12);
 
   --color-warning: #fbbf24; /* Dark */
   --color-warning-light: #d97706; /* Light */
   --color-warning-dark: #b58903;
+  --color-warning-text-light: #92400e; /* Light hint text — AA on white */
   --color-warning-tint: rgba(251, 191, 36, 0.12);
 
   --color-error: #ff0036; /* Dark — igual que brand en dark */


### PR DESCRIPTION
## Summary

- Add the `TextArea` atom with native textarea semantics, labels, hints, validation states, resize, and autosize behavior.
- Add Storybook coverage and tests for accessibility, autosize, controlled/uncontrolled behavior, and exports.
- Update shared hint text colors used by Input/TextArea to meet WCAG AA contrast in `TextArea / ValidationStates`.

Closes #36

## Review scope

- Primary files/areas:
  - `src/components/atoms/text-area/*`
  - `src/components/atoms/input/types.ts` shared hint contrast colors
  - `src/index.ts` root export
- Out of scope:
  - Promoting the new warning/success hint colors into semantic theme tokens; this is noted as follow-up.
  - Broader Input visual redesign beyond shared hint contrast.
- Review workload: large by lines, but focused: one new 6-file component pattern plus tests/stories and a small shared hint contrast fix.

## Type of change

- [x] New component
- [ ] Existing component update/refactor
- [ ] Bug fix
- [x] Accessibility
- [ ] Design tokens
- [x] Storybook/docs
- [ ] Infrastructure/tooling
- [ ] NPM/dependencies

## Workflow gates

- [x] Linked issue is present with `Closes #NNN` or maintainer approved an exception.
- [x] Linked issue has label `status:approved` before implementation starts.
- [x] Linked issue assignee was checked before work started; if it was assigned to someone else, explicit reassignment permission is documented.
- [x] Work was started through the Project flow: assignee set, Project status `In progress`, branch/worktree recorded.
- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`.
- [x] Commits follow the same commitlint-enforced format.
- [x] Diff is focused; unrelated work is called out in Review scope.
- [x] MCP/runtime artifacts are absent: `.playwright-mcp`, `page-*.png`, `page-*.jpeg`, `*.md.playwright-output`.

## Component evidence (required for component changes)

- [x] Validated component spec is linked or quoted in the issue.
- [x] Accessibility contract from the spec was implemented or deviations are explained below.
- [x] Follows the 6-file pattern: `types.ts`, `use*.ts`, `Component.tsx`, `Component.test.tsx`, `Component.stories.tsx`, `index.ts`.
- [x] CVA variants live in `types.ts`; JSX component has no state, CVA calls, or business logic.
- [x] Public props with runtime defaults have matching `@default` JSDoc in `types.ts` (`node scripts/verify-prop-default-docs.mjs`).
- [ ] Uses design tokens from `theme.css`; no hardcoded colors or arbitrary color utilities.
- [x] Storybook covers default, variants, documented states, edge cases, and dark mode when visually different.
- [x] Component audit result is PASS or accepted PASS WITH WARNINGS.
- [ ] Visual review result is included when visuals changed.

## Accessibility evidence

- [x] Role/name semantics verified with Testing Library queries or equivalent.
- [x] Keyboard-only behavior verified: native textarea focus/editing behavior; surface click focuses textarea.
- [x] Focus lifecycle verified: focus/blur state, visible focus treatment, and surface click focusing are covered.
- [x] Disabled, required, invalid/error, loading, and empty states expose the expected semantics where applicable.
- [x] Reduced motion behavior is respected where motion changed.
- [x] Screen reader or axe/manual evidence is included below when applicable.

## Validation evidence

- TypeScript: `pnpm exec tsc --noEmit` — passed.
- Unit tests: `pnpm exec vitest run` — 34 files passed, 660 tests passed.
- Focused unit tests: `pnpm vitest run src/components/atoms/text-area/TextArea.test.tsx` — 31 tests passed.
- Build/package: pre-commit `node scripts/verify-prop-default-docs.mjs` — passed; declaration-only build in reviewer pass — passed.
- Storybook or visual check: `pnpm run storybook-build` — built successfully.
- Accessibility check: manual contrast calculation for shared hint colors:
  - warning `#92400e` on `#ffffff`: 7.09:1
  - success `#15803d` on `#ffffff`: 5.02:1
  - fixes prior axe failures in `TextArea / ValidationStates` for warning/success hint text.
- Security/dependency check: N/A, no dependency changes.

## Screenshots or recordings

<img width="1103" height="232" alt="image" src="https://github.com/user-attachments/assets/5100df74-ee04-47fe-beb6-de1f22764610" />

<img width="1092" height="188" alt="image" src="https://github.com/user-attachments/assets/0a5ae48c-5b23-453f-8e76-e11af83a499e" />

<img width="801" height="179" alt="image" src="https://github.com/user-attachments/assets/8213b80f-0730-40cd-a2ab-9c66f9ad66eb" />

## Notes for reviewer

- `TextArea` intentionally reuses Input `hintMessageVariants`; the small `Input` change is required to fix TextArea `ValidationStates` contrast.
- Known token follow-up: `#92400e` and `#15803d` should ideally become semantic theme tokens for AA-compliant hint text instead of remaining arbitrary Tailwind values.
- Fresh read-only reviewer found no blockers before PR preparation.

@egdev6 ready to review