### PR TITLE
fix(tokens): use opaque status surfaces

### DIFF
--- a/docs/DESIGN.en.md
+++ b/docs/DESIGN.en.md
@@ -104,7 +104,9 @@ The brand color. Two values depending on the mode:
 
 ### Functional transparencies (tints)
 
-Used in overlays, glows, and interactive states:
+Used in overlays, glows, and interactive states.
+Use transparent semantic tints for inline emphasis, hover/active/focus feedback, and progress/slider tracks.
+Use opaque semantic surface tokens (`*-surface-light` / `*-surface-dark`) for status containers or floating/elevated surfaces where underlying content must not bleed through.
 
 | Role | Value |
 |-----|-------|

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -104,7 +104,9 @@ El color de marca. Dos valores según el modo:
 
 ### Transparencias funcionales (tints)
 
-Usadas en overlays, glows y estados interactivos:
+Usadas en overlays, glows y estados interactivos.
+Usá los tints semánticos transparentes para énfasis inline, feedback de hover/active/focus y tracks de progress/slider.
+Usá los tokens de superficie semántica opaca (`*-surface-light` / `*-surface-dark`) para contenedores de estado o superficies flotantes/elevadas donde el contenido de abajo no debe transparentarse.
 
 | Rol | Valor |
 |-----|-------|

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -105,8 +105,8 @@ El color de marca. Dos valores según el modo:
 ### Transparencias funcionales (tints)
 
 Usadas en overlays, glows y estados interactivos.
-Usá los tints semánticos transparentes para énfasis inline, feedback de hover/active/focus y tracks de progress/slider.
-Usá los tokens de superficie semántica opaca (`*-surface-light` / `*-surface-dark`) para contenedores de estado o superficies flotantes/elevadas donde el contenido de abajo no debe transparentarse.
+Usa los tints semánticos transparentes para énfasis inline, feedback de hover/active/focus y tracks de progress/slider.
+Usa los tokens de superficie semántica opaca (`*-surface-light` / `*-surface-dark`) para contenedores de estado o superficies flotantes/elevadas donde el contenido de abajo no debe transparentarse.
 
 | Rol | Valor |
 |-----|-------|

--- a/src/components/atoms/alert/Alert.stories.tsx
+++ b/src/components/atoms/alert/Alert.stories.tsx
@@ -130,13 +130,13 @@ export const VariantFlat: Story = {
 };
 
 /**
- * Shows a custom token-backed color treatment through className and startContent.
+ * Shows a custom token-backed status surface using the opaque semantic background tokens.
  */
 export const CustomColor: Story = {
   args: {
     title: 'Informational note',
     subtitle: 'Use className and custom startContent when the alert needs a non-standard semantic color.',
-    className: 'border-info-light bg-info-tint dark:border-info dark:bg-info-tint',
+    className: 'border-info-light bg-info-surface-light dark:border-info dark:bg-info-surface-dark',
     startContent: (
       <Icon color='text-info-light' colorDark='dark:text-info' decorative={true} name='badge-info' size={20} />
     )

--- a/src/components/atoms/alert/Alert.stories.tsx
+++ b/src/components/atoms/alert/Alert.stories.tsx
@@ -203,7 +203,7 @@ export const RichDescriptionContent: Story = {
       <span>
         The description accepts <strong>rich inline HTML</strong>, including{' '}
         <a
-          className='font-semibold underline underline-offset-2'
+          className='font-semibold text-current underline underline-offset-2'
           href='https://github.com/Stack-and-Flow/design-system/issues/13'
         >
           contextual links

--- a/src/components/atoms/alert/Alert.test.tsx
+++ b/src/components/atoms/alert/Alert.test.tsx
@@ -11,6 +11,7 @@ vi.mock('lucide-react/dynamic.js', () => ({
 }));
 
 import { Alert } from './Alert';
+import { alertVariants } from './types';
 import { useAlert } from './useAlert';
 
 const setReducedMotion = (matches: boolean) => {
@@ -48,6 +49,20 @@ describe('useAlert — logic', () => {
     expect(result.current.resolvedIconName).toBe('info');
     expect(result.current.rootProps['data-state']).toBe('open');
     expect(result.current.shouldRender).toBe(true);
+  });
+
+  it.each([
+    ['success', 'solid', 'bg-success-surface-light', 'dark:bg-success-surface-dark'],
+    ['success', 'flat', 'bg-success-surface-light', 'dark:bg-success-surface-dark'],
+    ['warning', 'solid', 'bg-warning-surface-light', 'dark:bg-warning-surface-dark'],
+    ['warning', 'flat', 'bg-warning-surface-light', 'dark:bg-warning-surface-dark'],
+    ['danger', 'solid', 'bg-error-surface-light', 'dark:bg-error-surface-dark'],
+    ['danger', 'flat', 'bg-error-surface-light', 'dark:bg-error-surface-dark']
+  ] as const)('uses opaque status surfaces for %s %s alerts', (color, variant, lightClass, darkClass) => {
+    const className = alertVariants({ color, variant });
+
+    expect(className).toContain(lightClass);
+    expect(className).toContain(darkClass);
   });
 
   it('uses the provided iconName instead of the color default', () => {

--- a/src/components/atoms/alert/types.ts
+++ b/src/components/atoms/alert/types.ts
@@ -45,12 +45,13 @@ export const alertVariants = cva(
       {
         color: 'success',
         variant: 'solid',
-        class: 'border-success-light bg-success-tint text-text-light dark:border-success dark:text-text-dark'
+        class:
+          'border-success-light bg-success-surface-light text-text-light dark:border-success dark:bg-success-surface-dark dark:text-text-dark'
       },
       {
         color: 'success',
         variant: 'flat',
-        class: 'bg-success-tint text-text-light dark:text-text-dark'
+        class: 'bg-success-surface-light text-text-light dark:bg-success-surface-dark dark:text-text-dark'
       },
       {
         color: 'success',
@@ -60,12 +61,13 @@ export const alertVariants = cva(
       {
         color: 'warning',
         variant: 'solid',
-        class: 'border-warning-light bg-warning-tint text-text-light dark:border-warning dark:text-text-dark'
+        class:
+          'border-warning-light bg-warning-surface-light text-text-light dark:border-warning dark:bg-warning-surface-dark dark:text-text-dark'
       },
       {
         color: 'warning',
         variant: 'flat',
-        class: 'bg-warning-tint text-text-light dark:text-text-dark'
+        class: 'bg-warning-surface-light text-text-light dark:bg-warning-surface-dark dark:text-text-dark'
       },
       {
         color: 'warning',
@@ -75,12 +77,13 @@ export const alertVariants = cva(
       {
         color: 'danger',
         variant: 'solid',
-        class: 'border-error-light bg-error-tint text-text-light dark:border-error dark:text-text-dark'
+        class:
+          'border-error-light bg-error-surface-light text-text-light dark:border-error dark:bg-error-surface-dark dark:text-text-dark'
       },
       {
         color: 'danger',
         variant: 'flat',
-        class: 'bg-error-tint text-text-light dark:text-text-dark'
+        class: 'bg-error-surface-light text-text-light dark:bg-error-surface-dark dark:text-text-dark'
       },
       {
         color: 'danger',

--- a/src/components/atoms/badge/Badge.test.tsx
+++ b/src/components/atoms/badge/Badge.test.tsx
@@ -1,6 +1,7 @@
 import { render, renderHook, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { Badge } from './Badge';
+import { badgeVariants } from './types';
 import { useBadge } from './useBadge';
 
 describe('useBadge — logic', () => {
@@ -66,6 +67,18 @@ describe('useBadge — logic', () => {
 
     expect(defaultResult.current.shouldAnimateIn).toBe(true);
     expect(pulseResult.current.shouldAnimateIn).toBe(false);
+  });
+
+  it.each([
+    ['primary', 'bg-red-surface-light', 'dark:bg-red-surface-dark'],
+    ['success', 'bg-success-surface-light', 'dark:bg-success-surface-dark'],
+    ['warning', 'bg-warning-surface-light', 'dark:bg-warning-surface-dark'],
+    ['danger', 'bg-error-surface-light', 'dark:bg-error-surface-dark']
+  ] as const)('uses opaque status surfaces for %s flat badges', (color, lightClass, darkClass) => {
+    const className = badgeVariants({ color, variant: 'flat' });
+
+    expect(className).toContain(lightClass);
+    expect(className).toContain(darkClass);
   });
 });
 

--- a/src/components/atoms/badge/types.ts
+++ b/src/components/atoms/badge/types.ts
@@ -48,8 +48,8 @@ export const badgeVariants = cva(
         variant: 'flat',
         color: 'primary',
         class: [
-          'bg-red-tint-subtle border-brand-light text-brand-light',
-          'dark:bg-red-tint-subtle dark:border-brand-dark dark:text-brand-dark-light'
+          'bg-red-surface-light border-brand-light text-brand-light',
+          'dark:bg-red-surface-dark dark:border-brand-dark dark:text-brand-dark-light'
         ]
       },
       {
@@ -64,24 +64,24 @@ export const badgeVariants = cva(
         variant: 'flat',
         color: 'success',
         class: [
-          'bg-success-tint border-success-light text-success-light',
-          'dark:bg-success-tint dark:border-success dark:text-success'
+          'bg-success-surface-light border-success-light text-success-light',
+          'dark:bg-success-surface-dark dark:border-success dark:text-success'
         ]
       },
       {
         variant: 'flat',
         color: 'warning',
         class: [
-          'bg-warning-tint border-warning-light text-warning-light',
-          'dark:bg-warning-tint dark:border-warning dark:text-warning'
+          'bg-warning-surface-light border-warning-light text-warning-light',
+          'dark:bg-warning-surface-dark dark:border-warning dark:text-warning'
         ]
       },
       {
         variant: 'flat',
         color: 'danger',
         class: [
-          'bg-error-tint border-error-light text-error-light',
-          'dark:bg-error-tint dark:border-error dark:text-error'
+          'bg-error-surface-light border-error-light text-error-light',
+          'dark:bg-error-surface-dark dark:border-error dark:text-error'
         ]
       },
       {

--- a/src/components/atoms/badge/types.ts
+++ b/src/components/atoms/badge/types.ts
@@ -48,8 +48,8 @@ export const badgeVariants = cva(
         variant: 'flat',
         color: 'primary',
         class: [
-          'bg-red-surface-light border-brand-light text-brand-light',
-          'dark:bg-red-surface-dark dark:border-brand-dark dark:text-brand-dark-light'
+          'bg-red-surface-light border-brand-light text-text-light',
+          'dark:bg-red-surface-dark dark:border-brand-dark dark:text-text-dark'
         ]
       },
       {
@@ -64,24 +64,24 @@ export const badgeVariants = cva(
         variant: 'flat',
         color: 'success',
         class: [
-          'bg-success-surface-light border-success-light text-success-light',
-          'dark:bg-success-surface-dark dark:border-success dark:text-success'
+          'bg-success-surface-light border-success-light text-text-light',
+          'dark:bg-success-surface-dark dark:border-success dark:text-text-dark'
         ]
       },
       {
         variant: 'flat',
         color: 'warning',
         class: [
-          'bg-warning-surface-light border-warning-light text-warning-light',
-          'dark:bg-warning-surface-dark dark:border-warning dark:text-warning'
+          'bg-warning-surface-light border-warning-light text-text-light',
+          'dark:bg-warning-surface-dark dark:border-warning dark:text-text-dark'
         ]
       },
       {
         variant: 'flat',
         color: 'danger',
         class: [
-          'bg-error-surface-light border-error-light text-error-light',
-          'dark:bg-error-surface-dark dark:border-error dark:text-error'
+          'bg-error-surface-light border-error-light text-text-light',
+          'dark:bg-error-surface-dark dark:border-error dark:text-text-dark'
         ]
       },
       {

--- a/src/components/atoms/chip/Chip.test.tsx
+++ b/src/components/atoms/chip/Chip.test.tsx
@@ -43,6 +43,19 @@ describe('Chip — interactive and accessibility behavior', () => {
     expect(result.current.propsBase['data-interactive']).toBe('false');
   });
 
+  it.each([
+    ['primary', 'bg-red-surface-light', 'dark:bg-red-surface-dark', 'hover:bg-red-tint-low'],
+    ['success', 'bg-success-surface-light', 'dark:bg-success-surface-dark', 'hover:bg-success-tint'],
+    ['warning', 'bg-warning-surface-light', 'dark:bg-warning-surface-dark', 'hover:bg-warning-tint'],
+    ['danger', 'bg-error-surface-light', 'dark:bg-error-surface-dark', 'hover:bg-error-tint']
+  ] as const)('uses opaque status surfaces for %s flat chips while leaving hover tints intact', (color, lightClass, darkClass, hoverClass) => {
+    const { result } = renderHook(() => useChip({ color, variant: 'flat' }));
+
+    expect(result.current.slots.base).toContain(lightClass);
+    expect(result.current.slots.base).toContain(darkClass);
+    expect(result.current.slots.base).toContain(hoverClass);
+  });
+
   it('handles disabled and isDisabled alias in useChip', () => {
     const { result: disabledResult } = renderHook(() => useChip({ disabled: true }));
     expect(disabledResult.current.isDisabled).toBe(true);

--- a/src/components/atoms/chip/types.ts
+++ b/src/components/atoms/chip/types.ts
@@ -61,7 +61,7 @@ export const chipVariants = cva(
         color: 'primary',
         variant: 'flat',
         class:
-          'bg-red-tint-subtle text-brand-light dark:text-brand-dark-light data-[interactive=true]:hover:bg-red-tint-low'
+          'bg-red-surface-light text-brand-light dark:bg-red-surface-dark dark:text-brand-dark-light data-[interactive=true]:hover:bg-red-tint-low'
       },
       {
         color: 'primary',
@@ -120,7 +120,8 @@ export const chipVariants = cva(
       {
         color: 'success',
         variant: 'flat',
-        class: 'bg-success-tint text-text-light dark:text-success data-[interactive=true]:hover:bg-success-tint'
+        class:
+          'bg-success-surface-light text-text-light dark:bg-success-surface-dark dark:text-success data-[interactive=true]:hover:bg-success-tint'
       },
       {
         color: 'success',
@@ -148,7 +149,8 @@ export const chipVariants = cva(
       {
         color: 'warning',
         variant: 'flat',
-        class: 'bg-warning-tint text-text-light dark:text-warning data-[interactive=true]:hover:bg-warning-tint'
+        class:
+          'bg-warning-surface-light text-text-light dark:bg-warning-surface-dark dark:text-warning data-[interactive=true]:hover:bg-warning-tint'
       },
       {
         color: 'warning',
@@ -176,7 +178,8 @@ export const chipVariants = cva(
       {
         color: 'danger',
         variant: 'flat',
-        class: 'bg-error-tint text-red-800 dark:text-error data-[interactive=true]:hover:bg-error-tint'
+        class:
+          'bg-error-surface-light text-red-800 dark:bg-error-surface-dark dark:text-error data-[interactive=true]:hover:bg-error-tint'
       },
       {
         color: 'danger',

--- a/src/components/atoms/chip/types.ts
+++ b/src/components/atoms/chip/types.ts
@@ -61,7 +61,7 @@ export const chipVariants = cva(
         color: 'primary',
         variant: 'flat',
         class:
-          'bg-red-surface-light text-brand-light dark:bg-red-surface-dark dark:text-brand-dark-light data-[interactive=true]:hover:bg-red-tint-low'
+          'bg-red-surface-light text-text-light dark:bg-red-surface-dark dark:text-text-dark data-[interactive=true]:hover:bg-red-tint-low'
       },
       {
         color: 'primary',
@@ -121,7 +121,7 @@ export const chipVariants = cva(
         color: 'success',
         variant: 'flat',
         class:
-          'bg-success-surface-light text-text-light dark:bg-success-surface-dark dark:text-success data-[interactive=true]:hover:bg-success-tint'
+          'bg-success-surface-light text-text-light dark:bg-success-surface-dark dark:text-text-dark data-[interactive=true]:hover:bg-success-tint'
       },
       {
         color: 'success',
@@ -150,7 +150,7 @@ export const chipVariants = cva(
         color: 'warning',
         variant: 'flat',
         class:
-          'bg-warning-surface-light text-text-light dark:bg-warning-surface-dark dark:text-warning data-[interactive=true]:hover:bg-warning-tint'
+          'bg-warning-surface-light text-text-light dark:bg-warning-surface-dark dark:text-text-dark data-[interactive=true]:hover:bg-warning-tint'
       },
       {
         color: 'warning',
@@ -179,7 +179,7 @@ export const chipVariants = cva(
         color: 'danger',
         variant: 'flat',
         class:
-          'bg-error-surface-light text-red-800 dark:bg-error-surface-dark dark:text-error data-[interactive=true]:hover:bg-error-tint'
+          'bg-error-surface-light text-text-light dark:bg-error-surface-dark dark:text-text-dark data-[interactive=true]:hover:bg-error-tint'
       },
       {
         color: 'danger',

--- a/src/components/atoms/table/Table.stories.tsx
+++ b/src/components/atoms/table/Table.stories.tsx
@@ -19,15 +19,15 @@ type UserData = {
 
 /**
  * StatusBadge component optimized for WCAG 2.1 AA accessibility compliance.
- * Uses design-system semantic colors that remain readable even with reduced opacity in disabled rows.
+ * Uses opaque semantic status surfaces so the badges stay legible over complex row backgrounds.
  */
 const statusBadgeClasses: Record<string, string> = {
   active:
-    'border border-success-light bg-success-tint text-text-light dark:border-success dark:bg-success-tint dark:text-text-dark',
+    'border border-success-light bg-success-surface-light text-text-light dark:border-success dark:bg-success-surface-dark dark:text-text-dark',
   inactive:
-    'border border-error-light bg-error-tint text-text-light dark:border-error dark:bg-error-tint dark:text-text-dark',
+    'border border-error-light bg-error-surface-light text-text-light dark:border-error dark:bg-error-surface-dark dark:text-text-dark',
   pending:
-    'border border-warning-light bg-warning-tint text-text-light dark:border-warning dark:bg-warning-tint dark:text-text-dark'
+    'border border-warning-light bg-warning-surface-light text-text-light dark:border-warning dark:bg-warning-surface-dark dark:text-text-dark'
 };
 
 const departmentBadgeClasses: Record<string, string> = {

--- a/src/components/molecules/snippet/Snippet.stories.tsx
+++ b/src/components/molecules/snippet/Snippet.stories.tsx
@@ -166,7 +166,7 @@ export const CustomClassName: Story = {
   args: {
     children: 'Themed custom class',
     className:
-      'border-brand-light bg-red-surface-light text-brand-light dark:border-brand-dark dark:bg-red-surface-dark dark:text-brand-dark',
+      'border-brand-light bg-red-surface-light text-text-light dark:border-brand-dark dark:bg-red-surface-dark dark:text-text-dark',
     onCopy: action('custom-class-copy')
   }
 };

--- a/src/components/molecules/snippet/Snippet.stories.tsx
+++ b/src/components/molecules/snippet/Snippet.stories.tsx
@@ -160,11 +160,13 @@ export const Disabled: Story = {
 
 /**
  * Shows how token-backed utility classes can extend the component without bypassing the theme.
+ * Use opaque surface tokens for branded containers and keep tint tokens for interactive overlays.
  */
 export const CustomClassName: Story = {
   args: {
     children: 'Themed custom class',
-    className: 'border-brand-light bg-red-tint-subtle text-brand-light dark:border-brand-dark dark:text-brand-dark',
+    className:
+      'border-brand-light bg-red-surface-light text-brand-light dark:border-brand-dark dark:bg-red-surface-dark dark:text-brand-dark',
     onCopy: action('custom-class-copy')
   }
 };

--- a/src/components/molecules/snippet/Snippet.test.tsx
+++ b/src/components/molecules/snippet/Snippet.test.tsx
@@ -66,6 +66,19 @@ describe('useSnippet — logic', () => {
     expect(snippetBase({ variant: 'shadow' })).toContain('border-border-strong-light');
   });
 
+  it.each([
+    ['primary', 'bg-red-surface-light', 'dark:bg-red-surface-dark'],
+    ['success', 'bg-success-surface-light', 'dark:bg-success-surface-dark'],
+    ['warning', 'bg-warning-surface-light', 'dark:bg-warning-surface-dark'],
+    ['danger', 'bg-error-surface-light', 'dark:bg-error-surface-dark'],
+    ['info', 'bg-info-surface-light', 'dark:bg-info-surface-dark']
+  ] as const)('uses opaque status surfaces for %s solid snippets', (color, lightClass, darkClass) => {
+    const className = snippetBase({ color, variant: 'solid' });
+
+    expect(className).toContain(lightClass);
+    expect(className).toContain(darkClass);
+  });
+
   it('maps provided aria props to the copy button and preserves the root id', () => {
     const { result } = renderHook(() =>
       useSnippet({

--- a/src/components/molecules/snippet/types.ts
+++ b/src/components/molecules/snippet/types.ts
@@ -49,7 +49,7 @@ export const snippetBase = cva(
       {
         variant: ['solid', 'shadow'],
         color: 'primary',
-        class: 'bg-red-tint-subtle border-brand-light/20 dark:bg-red-tint-low dark:border-brand-dark/30'
+        class: 'bg-red-surface-light border-brand-light/20 dark:bg-red-surface-dark dark:border-brand-dark/30'
       },
       {
         variant: ['solid', 'shadow'],
@@ -60,22 +60,22 @@ export const snippetBase = cva(
       {
         variant: ['solid', 'shadow'],
         color: 'success',
-        class: 'bg-success-tint border-success-light/30 dark:bg-success-tint dark:border-success/30'
+        class: 'bg-success-surface-light border-success-light/30 dark:bg-success-surface-dark dark:border-success/30'
       },
       {
         variant: ['solid', 'shadow'],
         color: 'warning',
-        class: 'bg-warning-tint border-warning-light/30 dark:bg-warning-tint dark:border-warning/30'
+        class: 'bg-warning-surface-light border-warning-light/30 dark:bg-warning-surface-dark dark:border-warning/30'
       },
       {
         variant: ['solid', 'shadow'],
         color: 'danger',
-        class: 'bg-error-tint border-error-light/30 dark:bg-error-tint dark:border-error/30'
+        class: 'bg-error-surface-light border-error-light/30 dark:bg-error-surface-dark dark:border-error/30'
       },
       {
         variant: ['solid', 'shadow'],
         color: 'info',
-        class: 'bg-info-tint border-info-light/30 dark:bg-info-tint dark:border-info/30'
+        class: 'bg-info-surface-light border-info-light/30 dark:bg-info-surface-dark dark:border-info/30'
       },
       {
         variant: 'outline',


### PR DESCRIPTION
## Summary

- Migrates status container surfaces from transparent tint backgrounds to opaque semantic surface tokens.
- Keeps transparent tints for intentional inline, hover/focus, track, glow, and subtle uses.
- Documents the tint-vs-surface rule and adds regression coverage for affected variants.

Closes #267

## Review scope

- Primary files/areas: Alert, Badge, Chip, Snippet variant classes; Table/Alert/Snippet stories; token guidance docs.
- Out of scope: Progress and Slider tracks, because docs now classify tracks as intentional transparent tint usage.
- Review workload: small/medium; 13 focused files, ~130 changed lines.

## Type of change

- [ ] New component
- [x] Existing component update/refactor
- [x] Bug fix
- [ ] Accessibility
- [x] Design tokens
- [x] Storybook/docs
- [ ] Infrastructure/tooling
- [ ] NPM/dependencies

## Workflow gates

- [x] Linked issue is present with `Closes #NNN` or maintainer approved an exception.
- [x] Linked issue has label `status:approved` before implementation starts.
- [x] Linked issue assignee was checked before work started; if it was assigned to someone else, explicit reassignment permission is documented.
- [x] Work was started through the Project flow: assignee set, Project status `In progress`, branch/worktree recorded.
- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`.
- [x] Commits follow the same commitlint-enforced format.
- [x] Diff is focused; unrelated work is called out in Review scope.
- [x] MCP/runtime artifacts are absent: `.playwright-mcp`, `page-*.png`, `page-*.jpeg`, `*.md.playwright-output`.

## Component evidence (required for component changes)

- [x] Validated component spec is linked or quoted in the issue.
- [x] Accessibility contract from the spec was implemented or deviations are explained below.
- [x] Follows the 6-file pattern: `types.ts`, `use*.ts`, `Component.tsx`, `Component.test.tsx`, `Component.stories.tsx`, `index.ts`.
- [x] CVA variants live in `types.ts`; JSX component has no state, CVA calls, or business logic.
- [x] Public props with runtime defaults have matching `@default` JSDoc in `types.ts` (`node scripts/verify-prop-default-docs.mjs`).
- [x] Uses design tokens from `theme.css`; no hardcoded colors or arbitrary color utilities.
- [x] Storybook covers default, variants, documented states, edge cases, and dark mode when visually different.
- [x] Component audit result is PASS or accepted PASS WITH WARNINGS.
- [x] Visual review result is included when visuals changed.

## Accessibility evidence

- [x] Role/name semantics verified with Testing Library queries or equivalent.
- [x] Keyboard-only behavior verified: Tab / Shift+Tab, Enter / Space, Arrow keys, Escape, Home / End / typeahead where applicable.
- [x] Focus lifecycle verified: initial focus, roving/active descendant, focus restore, trap/portal behavior where applicable.
- [x] Disabled, required, invalid/error, loading, and empty states expose the expected semantics where applicable.
- [x] Reduced motion behavior is respected where motion changed.
- [x] Screen reader or axe/manual evidence is included below when applicable.

No interactive behavior changed; existing component behavior tests remain green. This PR changes token-backed surface classes only.

## Validation evidence

- TypeScript: passed via lefthook pre-commit `typecheck`.
- Unit tests: `pnpm vitest run src/components/atoms/alert/Alert.test.tsx src/components/atoms/badge/Badge.test.tsx src/components/atoms/chip/Chip.test.tsx src/components/molecules/snippet/Snippet.test.tsx` — passed, 85 tests.
- Unit tests full suite: `pnpm test -- --run` — passed, 729 tests before final commit.
- Build/package: `pnpm build` — passed.
- Storybook or visual check: stories updated to demonstrate opaque status surfaces; no screenshot artifact included.
- Accessibility check: no semantic behavior changed; class-token regression tests added for status surface variants.
- Security/dependency check: N/A, no dependency changes.

## Screenshots or recordings

N/A — token/class migration with tests and story/docs updates; no runtime capture was required.

## Notes for reviewer

Progress and Slider tracks intentionally remain transparent tint usage. The docs now reserve tints for inline emphasis, hover/active/focus feedback, and progress/slider tracks, while using opaque `*-surface-light/dark` tokens for status containers or floating/elevated surfaces.
