### PR TITLE
feat(tokens): add info semantic state colors

### DIFF
--- a/.atl/skills/component-contributor/SKILL.md
+++ b/.atl/skills/component-contributor/SKILL.md
@@ -86,7 +86,7 @@ Map the component to the design system before coding:
 
 - surface pattern: opaque, raised, tinted, or floating/frosted;
 - relevant tokens from `theme.css`;
-- base/hover/focus/active/disabled/loading/error states;
+- base/hover/focus/active/disabled/loading/error/info states;
 - focus ring, disabled treatment, touch target, contrast, reduced motion;
 - allowed Radix primitive, if any.
 

--- a/.atl/skills/visual-review/SKILL.md
+++ b/.atl/skills/visual-review/SKILL.md
@@ -127,6 +127,8 @@ For every interactive component, check ALL of the following sections.
 - [ ] Minimum height `44px`
 - [ ] Focus ring softer than button: `box-shadow: 0 0 0 3px rgba(255, 0, 54, 0.12)` — 12%, not 40%
 - [ ] Error state changes border + shadow only — NOT input text color
+- [ ] Info state changes border + shadow only, using semantic blue tokens instead of neutral helper styling
+- [ ] Info helper text/icon use semantic info color (`text-info-light` / `dark:text-info`) instead of muted secondary text
 - [ ] Error message: `#ff0036` dark / `#db143c` light — check contrast on surface background
 - [ ] Labels always visible — never placeholder-only inputs
 - [ ] Placeholder `#6a6b6c` — WCAG exempts placeholder (informational, not functional)

--- a/docs/COMPONENTS.en.md
+++ b/docs/COMPONENTS.en.md
@@ -398,7 +398,7 @@ box-shadow: 0 0 0 3px rgba(219, 20, 60, 0.15);
 
 ---
 
-### 3.5 Input — Error / Warning / Success States
+### 3.5 Input — Error / Warning / Success / Info States
 
 States change only the `border-color` and `box-shadow`. Background, padding, and font remain identical to default.
 
@@ -421,6 +421,14 @@ box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.12);
 ```css
 border-color: rgba(34, 197, 94, 0.7); /* --color-success: #22c55e */
 box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.12);
+```
+
+**Info:**
+
+```css
+border-color: rgba(29, 78, 216, 0.7); /* --color-info-light: #1d4ed8 */
+box-shadow: 0 0 0 3px rgba(29, 78, 216, 0.15);
+/* dark: border-color: rgba(59, 130, 246, 1); box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.12); */
 ```
 
 **Error message text:**
@@ -1148,6 +1156,7 @@ background: linear-gradient(
 - [ ] Minimum height `44px`
 - [ ] Placeholder text `#6a6b6c` — WCAG exempts placeholder from contrast (informational, not functional)
 - [ ] Error state: border + shadow change, NOT color of input text
+- [ ] Info state: border + shadow change with `--color-info-light` in light mode and `--color-info` in dark mode; never treat it as neutral helper styling
 - [ ] Error message: `color: #ff0036` dark / `#db143c` light — check contrast on surface background
 - [ ] Labels always visible — never placeholder-only inputs
 - [ ] Focus ring: `box-shadow: 0 0 0 3px rgba(255, 0, 54, 0.12)` (softer than button — 12% not 40%)

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -398,7 +398,7 @@ box-shadow: 0 0 0 3px rgba(219, 20, 60, 0.15);
 
 ---
 
-### 3.5 Input — Error / Warning / Success States
+### 3.5 Input — Error / Warning / Success / Info States
 
 Estos estados cambian solo `border-color` y `box-shadow`. El fondo, el padding y la tipografía permanecen idénticos al estado por defecto.
 
@@ -421,6 +421,14 @@ box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.12);
 ```css
 border-color: rgba(34, 197, 94, 0.7); /* --color-success: #22c55e */
 box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.12);
+```
+
+**Info:**
+
+```css
+border-color: rgba(29, 78, 216, 0.7); /* --color-info-light: #1d4ed8 */
+box-shadow: 0 0 0 3px rgba(29, 78, 216, 0.15);
+/* dark: border-color: rgba(59, 130, 246, 1); box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.12); */
 ```
 
 **Texto del mensaje de error:**
@@ -1148,6 +1156,7 @@ background: linear-gradient(
 - [ ] Altura mínima `44px`
 - [ ] Texto del marcador de posición `#6a6b6c` — WCAG exime el marcador de posición del contraste (informativo, no funcional)
 - [ ] Estado Error: cambio de borde + sombra, color NOT del texto de entrada
+- [ ] Estado Info: cambio de borde + sombra con `--color-info-light` en claro y `--color-info` en oscuro; no tratarlo como helper neutral
 - [ ] Mensaje de error: `color: #ff0036` en oscuro / `#db143c` en claro; verifica el contraste sobre la superficie
 - [ ] Etiquetas siempre visibles; nunca inputs que dependan solo del placeholder
 - [ ] Anillo de enfoque: `box-shadow: 0 0 0 3px rgba(255, 0, 54, 0.12)` (más suave que el botón: 12%, no 40%)

--- a/docs/DESIGN.en.md
+++ b/docs/DESIGN.en.md
@@ -100,7 +100,7 @@ The brand color. Two values depending on the mode:
 | Error / Danger | `--color-error` | `#ff0036` | `#db143c` |
 | Success | `--color-success` | `#22c55e` | `#16a34a` |
 | Warning | `--color-warning` | `#fbbf24` | `#d97706` |
-| Info | `--color-info` | `#55b3ff` | `#0077cc` |
+| Info | `--color-info` | `#3b82f6` | `#1d4ed8` |
 
 ### Functional transparencies (tints)
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -100,7 +100,7 @@ El color de marca. Dos valores según el modo:
 | Error / Danger | `--color-error` | `#ff0036` | `#db143c` |
 | Success | `--color-success` | `#22c55e` | `#16a34a` |
 | Warning | `--color-warning` | `#fbbf24` | `#d97706` |
-| Info | `--color-info` | `#55b3ff` | `#0077cc` |
+| Info | `--color-info` | `#3b82f6` | `#1d4ed8` |
 
 ### Transparencias funcionales (tints)
 

--- a/src/components/atoms/alert/Alert.stories.tsx
+++ b/src/components/atoms/alert/Alert.stories.tsx
@@ -97,6 +97,7 @@ export const VariantSolid: Story = {
       <Alert color='success' subtitle='Success solid treatment.' title='Success' variant='solid' />
       <Alert color='warning' subtitle='Warning solid treatment.' title='Warning' variant='solid' />
       <Alert color='danger' subtitle='Danger solid treatment.' title='Danger' variant='solid' />
+      <Alert color='info' subtitle='Info solid treatment.' title='Info' variant='solid' />
     </div>
   )
 };
@@ -111,6 +112,7 @@ export const VariantBordered: Story = {
       <Alert color='success' subtitle='Success bordered treatment.' title='Success' variant='bordered' />
       <Alert color='warning' subtitle='Warning bordered treatment.' title='Warning' variant='bordered' />
       <Alert color='danger' subtitle='Danger bordered treatment.' title='Danger' variant='bordered' />
+      <Alert color='info' subtitle='Info bordered treatment.' title='Info' variant='bordered' />
     </div>
   )
 };
@@ -125,6 +127,7 @@ export const VariantFlat: Story = {
       <Alert color='success' subtitle='Success flat treatment.' title='Success' variant='flat' />
       <Alert color='warning' subtitle='Warning flat treatment.' title='Warning' variant='flat' />
       <Alert color='danger' subtitle='Danger flat treatment.' title='Danger' variant='flat' />
+      <Alert color='info' subtitle='Info flat treatment.' title='Info' variant='flat' />
     </div>
   )
 };
@@ -135,7 +138,7 @@ export const VariantFlat: Story = {
 export const CustomColor: Story = {
   args: {
     title: 'Informational note',
-    subtitle: 'Use className and custom startContent when the alert needs a non-standard semantic color.',
+    subtitle: 'Use className and custom startContent when the alert needs a custom token-backed surface.',
     className: 'border-info-light bg-info-surface-light dark:border-info dark:bg-info-surface-dark',
     startContent: (
       <Icon color='text-info-light' colorDark='dark:text-info' decorative={true} name='badge-info' size={20} />

--- a/src/components/atoms/alert/Alert.test.tsx
+++ b/src/components/atoms/alert/Alert.test.tsx
@@ -52,6 +52,8 @@ describe('useAlert — logic', () => {
   });
 
   it.each([
+    ['info', 'solid', 'bg-info-surface-light', 'dark:bg-info-surface-dark'],
+    ['info', 'flat', 'bg-info-surface-light', 'dark:bg-info-surface-dark'],
     ['success', 'solid', 'bg-success-surface-light', 'dark:bg-success-surface-dark'],
     ['success', 'flat', 'bg-success-surface-light', 'dark:bg-success-surface-dark'],
     ['warning', 'solid', 'bg-warning-surface-light', 'dark:bg-warning-surface-dark'],

--- a/src/components/atoms/alert/types.ts
+++ b/src/components/atoms/alert/types.ts
@@ -18,7 +18,8 @@ export const alertVariants = cva(
         primary: '',
         success: '',
         warning: '',
-        danger: ''
+        danger: '',
+        info: ''
       },
       rounded: {
         true: 'rounded-lg',
@@ -89,6 +90,22 @@ export const alertVariants = cva(
         color: 'danger',
         variant: 'bordered',
         class: 'border-error-light text-text-light dark:border-error dark:text-text-dark'
+      },
+      {
+        color: 'info',
+        variant: 'solid',
+        class:
+          'border-info-light bg-info-surface-light text-text-light dark:border-info dark:bg-info-surface-dark dark:text-text-dark'
+      },
+      {
+        color: 'info',
+        variant: 'flat',
+        class: 'bg-info-surface-light text-text-light dark:bg-info-surface-dark dark:text-text-dark'
+      },
+      {
+        color: 'info',
+        variant: 'bordered',
+        class: 'border-info-light text-text-light dark:border-info dark:text-text-dark'
       }
     ],
     defaultVariants: {
@@ -111,7 +128,8 @@ export const defaultAlertIcons: Record<AlertColor, DynamicIconName> = {
   primary: 'info',
   success: 'circle-check',
   warning: 'triangle-alert',
-  danger: 'circle-x'
+  danger: 'circle-x',
+  info: 'badge-info'
 };
 
 export type AlertProps = NativeAlertProps & {

--- a/src/components/atoms/badge/Badge.stories.tsx
+++ b/src/components/atoms/badge/Badge.stories.tsx
@@ -87,6 +87,9 @@ export const Color: Story = {
       <Badge content={5} color='danger' ariaLabel='Danger badge'>
         <Avatar src='https://i.pravatar.cc/300?u=badge-color-danger' alt='Danger avatar' rounded='full' size='lg' />
       </Badge>
+      <Badge content={6} color='info' ariaLabel='Info badge'>
+        <Avatar src='https://i.pravatar.cc/300?u=badge-color-info' alt='Info avatar' rounded='full' size='lg' />
+      </Badge>
     </div>
   )
 };
@@ -103,6 +106,7 @@ export const Variant: Story = {
         <Badge content='success' color='success' variant='solid' rounded={false} />
         <Badge content='warning' color='warning' variant='solid' rounded={false} />
         <Badge content='danger' color='danger' variant='solid' rounded={false} />
+        <Badge content='info' color='info' variant='solid' rounded={false} />
       </div>
       <div className='flex flex-wrap items-center gap-2'>
         <Badge content='primary' color='primary' variant='flat' rounded={false} />
@@ -110,6 +114,7 @@ export const Variant: Story = {
         <Badge content='success' color='success' variant='flat' rounded={false} />
         <Badge content='warning' color='warning' variant='flat' rounded={false} />
         <Badge content='danger' color='danger' variant='flat' rounded={false} />
+        <Badge content='info' color='info' variant='flat' rounded={false} />
       </div>
       <div className='flex flex-wrap items-center gap-2'>
         <Badge content='primary' color='primary' variant='subtle' rounded={false} />
@@ -117,6 +122,7 @@ export const Variant: Story = {
         <Badge content='success' color='success' variant='subtle' rounded={false} />
         <Badge content='warning' color='warning' variant='subtle' rounded={false} />
         <Badge content='danger' color='danger' variant='subtle' rounded={false} />
+        <Badge content='info' color='info' variant='subtle' rounded={false} />
       </div>
     </div>
   )

--- a/src/components/atoms/badge/Badge.test.tsx
+++ b/src/components/atoms/badge/Badge.test.tsx
@@ -71,6 +71,7 @@ describe('useBadge — logic', () => {
 
   it.each([
     ['primary', 'bg-red-surface-light', 'dark:bg-red-surface-dark'],
+    ['info', 'bg-info-surface-light', 'dark:bg-info-surface-dark'],
     ['success', 'bg-success-surface-light', 'dark:bg-success-surface-dark'],
     ['warning', 'bg-warning-surface-light', 'dark:bg-warning-surface-dark'],
     ['danger', 'bg-error-surface-light', 'dark:bg-error-surface-dark']

--- a/src/components/atoms/badge/types.ts
+++ b/src/components/atoms/badge/types.ts
@@ -14,7 +14,8 @@ export const badgeVariants = cva(
         secondary: ['bg-surface-light text-text-light', 'dark:bg-surface-dark dark:text-text-dark'],
         success: 'bg-success-light text-white dark:bg-success dark:text-white',
         warning: 'bg-warning-light text-text-light dark:bg-warning dark:text-text-light',
-        danger: 'bg-error-light text-white dark:bg-error dark:text-white'
+        danger: 'bg-error-light text-white dark:bg-error dark:text-white',
+        info: 'bg-info-light text-white dark:bg-info dark:text-text-light'
       },
       size: {
         sm: 'text-badge-sm min-w-4-5 h-4-5 px-1.5 py-0.5 mr-1-25 mt-0.5',
@@ -85,6 +86,14 @@ export const badgeVariants = cva(
         ]
       },
       {
+        variant: 'flat',
+        color: 'info',
+        class: [
+          'bg-info-surface-light border-info-light text-text-light',
+          'dark:bg-info-surface-dark dark:border-info dark:text-text-dark'
+        ]
+      },
+      {
         variant: 'subtle',
         color: 'primary',
         class: ['bg-red-tint-subtle text-brand-light', 'dark:bg-red-tint-subtle dark:text-brand-dark-light']
@@ -108,6 +117,11 @@ export const badgeVariants = cva(
         variant: 'subtle',
         color: 'danger',
         class: ['bg-error-tint text-error-light', 'dark:bg-error-tint dark:text-error']
+      },
+      {
+        variant: 'subtle',
+        color: 'info',
+        class: ['bg-info-tint text-info-light', 'dark:bg-info-tint dark:text-info']
       }
     ],
     defaultVariants: {

--- a/src/components/atoms/chip/Chip.stories.tsx
+++ b/src/components/atoms/chip/Chip.stories.tsx
@@ -67,6 +67,7 @@ export const Color: Story = {
       <Chip color='success'>Success</Chip>
       <Chip color='warning'>Warning</Chip>
       <Chip color='danger'>Danger</Chip>
+      <Chip color='info'>Info</Chip>
     </div>
   )
 };
@@ -115,6 +116,9 @@ export const VisualReviewMatrix: Story = {
           <Chip variant='solid' color='danger'>
             danger
           </Chip>
+          <Chip variant='solid' color='info'>
+            info
+          </Chip>
         </div>
       </section>
       <section className='grid gap-3'>
@@ -136,6 +140,9 @@ export const VisualReviewMatrix: Story = {
           </Chip>
           <Chip variant='flat' color='danger'>
             danger
+          </Chip>
+          <Chip variant='flat' color='info'>
+            info
           </Chip>
         </div>
       </section>
@@ -159,6 +166,9 @@ export const VisualReviewMatrix: Story = {
           <Chip variant='bordered' color='danger'>
             danger
           </Chip>
+          <Chip variant='bordered' color='info'>
+            info
+          </Chip>
         </div>
       </section>
       <section className='grid gap-3'>
@@ -180,6 +190,9 @@ export const VisualReviewMatrix: Story = {
           </Chip>
           <Chip variant='light' color='danger'>
             danger
+          </Chip>
+          <Chip variant='light' color='info'>
+            info
           </Chip>
         </div>
       </section>
@@ -203,6 +216,9 @@ export const VisualReviewMatrix: Story = {
           <Chip variant='faded' color='danger'>
             danger
           </Chip>
+          <Chip variant='faded' color='info'>
+            info
+          </Chip>
         </div>
       </section>
       <section className='grid gap-3'>
@@ -224,6 +240,9 @@ export const VisualReviewMatrix: Story = {
           </Chip>
           <Chip variant='dot' color='danger'>
             danger
+          </Chip>
+          <Chip variant='dot' color='info'>
+            info
           </Chip>
         </div>
       </section>
@@ -248,6 +267,9 @@ export const UsageReview: Story = {
           </Chip>
           <Chip color='danger' variant='faded'>
             Failing checks
+          </Chip>
+          <Chip color='info' variant='light'>
+            Needs context
           </Chip>
           <Chip color='secondary' variant='bordered'>
             Draft

--- a/src/components/atoms/chip/Chip.test.tsx
+++ b/src/components/atoms/chip/Chip.test.tsx
@@ -45,6 +45,7 @@ describe('Chip — interactive and accessibility behavior', () => {
 
   it.each([
     ['primary', 'bg-red-surface-light', 'dark:bg-red-surface-dark', 'hover:bg-red-tint-low'],
+    ['info', 'bg-info-surface-light', 'dark:bg-info-surface-dark', 'hover:bg-info-tint'],
     ['success', 'bg-success-surface-light', 'dark:bg-success-surface-dark', 'hover:bg-success-tint'],
     ['warning', 'bg-warning-surface-light', 'dark:bg-warning-surface-dark', 'hover:bg-warning-tint'],
     ['danger', 'bg-error-surface-light', 'dark:bg-error-surface-dark', 'hover:bg-error-tint']

--- a/src/components/atoms/chip/types.ts
+++ b/src/components/atoms/chip/types.ts
@@ -203,7 +203,7 @@ export const chipVariants = cva(
         color: 'info',
         variant: 'solid',
         class:
-          'bg-info-light text-white dark:bg-info dark:text-text-light data-[interactive=true]:hover:bg-blue dark:data-[interactive=true]:hover:bg-blue-light'
+          'bg-info-light text-white dark:bg-info dark:text-text-light data-[interactive=true]:hover:bg-info dark:data-[interactive=true]:hover:bg-blue-light'
       },
       {
         color: 'info',
@@ -215,7 +215,7 @@ export const chipVariants = cva(
         color: 'info',
         variant: ['bordered', 'faded', 'dot'],
         class:
-          'border-info-light text-info-light dark:border-info dark:text-info data-[interactive=true]:hover:border-blue dark:data-[interactive=true]:hover:border-blue-light'
+          'border-info-light text-info-light dark:border-info dark:text-info data-[interactive=true]:hover:border-info dark:data-[interactive=true]:hover:border-blue-light'
       },
       {
         color: 'info',

--- a/src/components/atoms/chip/types.ts
+++ b/src/components/atoms/chip/types.ts
@@ -19,7 +19,8 @@ export const chipVariants = cva(
         secondary: '',
         success: '',
         warning: '',
-        danger: ''
+        danger: '',
+        info: ''
       },
 
       size: {
@@ -196,6 +197,35 @@ export const chipVariants = cva(
         color: 'danger',
         variant: 'light',
         class: 'text-red-800 dark:text-error data-[interactive=true]:hover:bg-error-tint'
+      },
+
+      {
+        color: 'info',
+        variant: 'solid',
+        class:
+          'bg-info-light text-white dark:bg-info dark:text-text-light data-[interactive=true]:hover:bg-blue dark:data-[interactive=true]:hover:bg-blue-light'
+      },
+      {
+        color: 'info',
+        variant: 'flat',
+        class:
+          'bg-info-surface-light text-text-light dark:bg-info-surface-dark dark:text-text-dark data-[interactive=true]:hover:bg-info-tint'
+      },
+      {
+        color: 'info',
+        variant: ['bordered', 'faded', 'dot'],
+        class:
+          'border-info-light text-info-light dark:border-info dark:text-info data-[interactive=true]:hover:border-blue dark:data-[interactive=true]:hover:border-blue-light'
+      },
+      {
+        color: 'info',
+        variant: ['faded', 'dot'],
+        class: 'bg-info-tint data-[interactive=true]:hover:bg-info-tint'
+      },
+      {
+        color: 'info',
+        variant: 'light',
+        class: 'text-info-light dark:text-info data-[interactive=true]:hover:bg-info-tint'
       }
     ],
 

--- a/src/components/atoms/chip/useChip.ts
+++ b/src/components/atoms/chip/useChip.ts
@@ -89,7 +89,8 @@ export function useChip(props: ChipProps) {
       'border-transparent bg-surface-raised-light text-text-light dark:bg-surface-raised-dark dark:text-text-dark',
     success: 'border-transparent bg-success-light text-text-light dark:bg-success dark:text-text-light',
     warning: 'border-transparent bg-warning-light text-text-light dark:bg-warning dark:text-text-light',
-    danger: 'border-transparent bg-error-light text-white dark:bg-error dark:text-white'
+    danger: 'border-transparent bg-error-light text-white dark:bg-error dark:text-white',
+    info: 'border-transparent bg-info-light text-white dark:bg-info dark:text-text-light'
   };
 
   const dotClassByColor: Record<NonNullable<ChipProps['color']>, string> = {
@@ -97,7 +98,8 @@ export function useChip(props: ChipProps) {
     secondary: 'bg-text-secondary-light dark:bg-text-secondary-dark',
     success: 'bg-success-light dark:bg-success',
     warning: 'bg-warning-light dark:bg-warning',
-    danger: 'bg-error-light dark:bg-error'
+    danger: 'bg-error-light dark:bg-error',
+    info: 'bg-info-light dark:bg-info'
   };
 
   const closeButtonHoverByColor: Record<NonNullable<ChipProps['color']>, string> = {
@@ -105,7 +107,8 @@ export function useChip(props: ChipProps) {
     secondary: 'hover:bg-surface-raised-light dark:hover:bg-surface-raised-dark',
     success: 'hover:bg-success-tint',
     warning: 'hover:bg-warning-tint',
-    danger: 'hover:bg-error-tint'
+    danger: 'hover:bg-error-tint',
+    info: 'hover:bg-info-tint'
   };
 
   const slots = {

--- a/src/components/atoms/input/Input.test.tsx
+++ b/src/components/atoms/input/Input.test.tsx
@@ -41,6 +41,17 @@ describe('useInput — logic', () => {
     expect(result.current.inputProps['aria-describedby']).toBe('email-hint');
   });
 
+  it('maps info hints to semantic info styling and icon tone', () => {
+    const { result } = renderHook(() =>
+      useInput({ id: 'email', label: 'Email', hint: { type: 'info', message: 'Helpful guidance' } })
+    );
+
+    expect(result.current.containerProps.className).toContain('border-info-light');
+    expect(result.current.containerProps.className).toContain('shadow-glow-input-info-light');
+    expect(result.current.hintMessageClassName).toContain('text-info-light');
+    expect(result.current.hintIconProps).toMatchObject({ name: 'info', tone: 'info' });
+  });
+
   it('uses placeholder as an accessible name when no label or aria name is provided', () => {
     const { result } = renderHook(() => useInput({ id: 'search', placeholder: 'Search products' }));
     expect(result.current.inputProps['aria-label']).toBe('Search products');

--- a/src/components/atoms/input/types.ts
+++ b/src/components/atoms/input/types.ts
@@ -45,7 +45,7 @@ export const inputVariants = cva(
           'border-warning-light shadow-glow-input-warning-light hover:!border-warning-light dark:border-warning dark:shadow-glow-input-warning dark:hover:!border-warning',
         success:
           'border-success-light shadow-glow-input-success-light hover:!border-success-light dark:border-success dark:shadow-glow-input-success dark:hover:!border-success',
-        info: ''
+        info: 'border-info-light shadow-glow-input-info-light hover:!border-info-light dark:border-info dark:shadow-glow-input-info dark:hover:!border-info'
       },
       focused: {
         true: '!border-brand-light/50 shadow-glow-input-focus-light dark:!border-brand-dark/50 dark:shadow-glow-input-focus',
@@ -71,6 +71,11 @@ export const inputVariants = cva(
         focused: true,
         status: 'success',
         class: '!border-success-light dark:!border-success'
+      },
+      {
+        focused: true,
+        status: 'info',
+        class: '!border-info-light dark:!border-info'
       }
     ],
     defaultVariants: {
@@ -170,7 +175,7 @@ export const inputInlineButtonVariants = cva(
 export const hintMessageVariants = cva('fs-small', {
   variants: {
     tone: {
-      info: 'text-text-secondary-light dark:text-text-secondary-dark',
+      info: 'text-info-light dark:text-info',
       warning: 'text-warning-text-light dark:text-warning',
       error: 'text-error-light dark:text-error',
       success: 'text-success-text-light dark:text-success'

--- a/src/components/atoms/input/useInput.ts
+++ b/src/components/atoms/input/useInput.ts
@@ -94,7 +94,7 @@ const getHintIconProps = (type?: InputHintType): HintIconProps | undefined => {
     case 'success':
       return { name: 'circle-check', tone: 'success', size: 16 };
     case 'info':
-      return { name: 'info', tone: 'muted', size: 16 };
+      return { name: 'info', tone: 'info', size: 16 };
     default:
       return undefined;
   }

--- a/src/components/atoms/popover/Popover.stories.tsx
+++ b/src/components/atoms/popover/Popover.stories.tsx
@@ -318,6 +318,16 @@ export const ColorAccents: Story = {
           <Popover.Body>Accent color applies to the header and related floating details.</Popover.Body>
         </Popover.Content>
       </Popover>
+
+      <Popover>
+        <Popover.Trigger>
+          <TriggerButton>info</TriggerButton>
+        </Popover.Trigger>
+        <Popover.Content color='info'>
+          <Popover.Header>info accent</Popover.Header>
+          <Popover.Body>Accent color applies to the header and related floating details.</Popover.Body>
+        </Popover.Content>
+      </Popover>
     </div>
   )
 };

--- a/src/components/atoms/popover/Popover.test.tsx
+++ b/src/components/atoms/popover/Popover.test.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { Popover } from './Popover';
+import { popoverArrowVariants, popoverContentVariants, popoverHeaderVariants } from './types';
 import { PopoverRootProvider, usePopoverContent, usePopoverRoot } from './usePopover';
 
 const HeaderSlot = ({ children }: { children: ReactNode }) => <>{children}</>;
@@ -94,6 +95,12 @@ describe('usePopoverContent — logic', () => {
 
     expect(result.current.contentProps['aria-labelledby']).toMatch(/^popover-/);
     expect(result.current.contentProps['aria-label']).toBeUndefined();
+  });
+
+  it('maps the info color to semantic content, header, and arrow classes', () => {
+    expect(popoverContentVariants({ color: 'info' })).toContain('border-info-light/30');
+    expect(popoverHeaderVariants({ color: 'info' })).toContain('text-info-light');
+    expect(popoverArrowVariants({ color: 'info' })).toContain('fill-info-light/15');
   });
 });
 

--- a/src/components/atoms/popover/types.ts
+++ b/src/components/atoms/popover/types.ts
@@ -29,6 +29,7 @@ export const popoverContentVariants = cva(
         neutral: 'border-border-light dark:border-border-dark',
         primary: 'border-brand-light/20 dark:border-brand-dark/30',
         secondary: 'border-indigo/20 dark:border-indigo-light/30',
+        info: 'border-info-light/30 dark:border-info/30',
         success: 'border-success-light/30 dark:border-success/30',
         warning: 'border-warning-light/30 dark:border-warning/30',
         danger: 'border-error-light/30 dark:border-error/30'
@@ -72,6 +73,7 @@ export const popoverHeaderVariants = cva('border-b px-4 font-semibold tracking-n
       neutral: 'border-border-light text-text-light dark:border-border-dark dark:text-text-dark',
       primary: 'border-border-light text-brand-light dark:border-border-dark dark:text-brand-dark',
       secondary: 'border-border-light text-indigo-dark dark:border-border-dark dark:text-indigo-light',
+      info: 'border-border-light text-info-light dark:border-border-dark dark:text-info',
       success: 'border-border-light text-success-light dark:border-border-dark dark:text-success',
       warning: 'border-border-light text-warning-light dark:border-border-dark dark:text-warning',
       danger: 'border-border-light text-error-light dark:border-border-dark dark:text-error'
@@ -125,6 +127,7 @@ export const popoverArrowVariants = cva('drop-shadow-sm', {
       neutral: 'fill-background-light dark:fill-surface-dark',
       primary: 'fill-brand-light/15 dark:fill-brand-dark/20',
       secondary: 'fill-indigo/15 dark:fill-indigo-light/20',
+      info: 'fill-info-light/15 dark:fill-info/20',
       success: 'fill-success-light/15 dark:fill-success/20',
       warning: 'fill-warning-light/15 dark:fill-warning/20',
       danger: 'fill-error-light/15 dark:fill-error/20'
@@ -144,6 +147,11 @@ export const popoverArrowVariants = cva('drop-shadow-sm', {
     {
       variant: 'frosted',
       color: 'secondary',
+      class: 'fill-navbar-light dark:fill-navbar-dark'
+    },
+    {
+      variant: 'frosted',
+      color: 'info',
       class: 'fill-navbar-light dark:fill-navbar-dark'
     },
     {

--- a/src/components/atoms/progress/Progress.stories.tsx
+++ b/src/components/atoms/progress/Progress.stories.tsx
@@ -54,10 +54,10 @@ export const Colors: Story = {
       <Progress value={50} color='default' label='Default' className='w-96' />
       <Progress value={50} color='primary' label='Primary' className='w-96' />
       <Progress value={50} color='secondary' label='Secondary' className='w-96' />
-      <Progress value={50} color='info' label='Info' className='w-96' />
       <Progress value={50} color='success' label='Success' className='w-96' />
       <Progress value={50} color='warning' label='Warning' className='w-96' />
       <Progress value={50} color='danger' label='Danger' className='w-96' />
+      <Progress value={50} color='info' label='Info' className='w-96' />
     </div>
   )
 };

--- a/src/components/atoms/select/Select.test.tsx
+++ b/src/components/atoms/select/Select.test.tsx
@@ -675,6 +675,17 @@ describe('Select — hint pattern', () => {
     expect(screen.getByText('Please select a country')).toBeInTheDocument();
   });
 
+  it('maps info hints to semantic info styling and icon tone', () => {
+    const { result } = renderHook(() =>
+      useSelect({ label: 'Country', options: defaultOptions, hint: { message: 'Helpful guidance', type: 'info' } })
+    );
+
+    expect(result.current.triggerClassName).toContain('border-info-light');
+    expect(result.current.triggerClassName).toContain('shadow-glow-input-info-light');
+    expect(result.current.hintMessageClassName).toContain('text-info-light');
+    expect(result.current.hintIconProps).toMatchObject({ name: 'info', tone: 'info' });
+  });
+
   it('derives error status from hint type', () => {
     render(<Select label='Country' options={defaultOptions} hint={{ message: 'Error', type: 'error' }} />);
     const trigger = screen.getByRole('combobox');

--- a/src/components/atoms/select/types.ts
+++ b/src/components/atoms/select/types.ts
@@ -76,7 +76,7 @@ export const selectTrigger = cva(
           'border-warning-light shadow-glow-input-warning-light hover:!border-warning-light focus-within:!border-warning-light dark:border-warning dark:shadow-glow-input-warning dark:hover:!border-warning dark:focus-within:!border-warning',
         success:
           'border-success-light shadow-glow-input-success-light hover:!border-success-light focus-within:!border-success-light dark:border-success dark:shadow-glow-input-success dark:hover:!border-success dark:focus-within:!border-success',
-        info: ''
+        info: 'border-info-light shadow-glow-input-info-light hover:!border-info-light focus-within:!border-info-light dark:border-info dark:shadow-glow-input-info dark:hover:!border-info dark:focus-within:!border-info'
       }
     },
     compoundVariants: [
@@ -97,6 +97,12 @@ export const selectTrigger = cva(
         status: 'success',
         class:
           'border-b-success-light dark:border-b-success shadow-glow-input-success-light dark:shadow-glow-input-success hover:!border-success-light dark:hover:!border-success'
+      },
+      {
+        variant: 'underlined',
+        status: 'info',
+        class:
+          'border-b-info-light dark:border-b-info shadow-glow-input-info-light dark:shadow-glow-input-info hover:!border-info-light dark:hover:!border-info'
       }
     ],
     defaultVariants: {

--- a/src/components/atoms/select/useSelect.ts
+++ b/src/components/atoms/select/useSelect.ts
@@ -34,7 +34,7 @@ const getHintIconProps = (type?: SelectHint['type']): HintIconProps | undefined 
     case 'success':
       return { name: 'circle-check', tone: 'success', size: 16 };
     case 'info':
-      return { name: 'info', tone: 'muted', size: 16 };
+      return { name: 'info', tone: 'info', size: 16 };
     default:
       return undefined;
   }

--- a/src/components/atoms/slider/Slider.stories.tsx
+++ b/src/components/atoms/slider/Slider.stories.tsx
@@ -216,6 +216,15 @@ export const Colors: Story = {
             onValueChange={action('danger-slider-change')}
           />
         </div>
+        <div className='flex flex-col gap-2'>
+          <span className='px-5 text-sm font-medium text-text-light dark:text-text-dark'>Info</span>
+          <Slider
+            ariaLabel='Info slider'
+            color='info'
+            defaultValue={[50]}
+            onValueChange={action('info-slider-change')}
+          />
+        </div>
       </>,
       'gap-6'
     )

--- a/src/components/atoms/slider/Slider.test.tsx
+++ b/src/components/atoms/slider/Slider.test.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { Slider as RootSlider } from '../../../index';
 import { Slider } from './Slider';
+import { sliderRangeVariants, sliderThumbVisualVariants, sliderTrackVariants } from './types';
 import { useSlider } from './useSlider';
 
 class ResizeObserverMock implements ResizeObserver {
@@ -109,6 +110,13 @@ describe('useSlider — logic', () => {
     const uncontrolled = renderHook(() => useSlider({ ariaLabel: 'Price', defaultValue: [80, 20] })).result.current
       .rootProps;
     expect(uncontrolled.defaultValue).toEqual([20, 80]);
+  });
+
+  it('maps the info color to semantic track, range, and thumb classes', () => {
+    expect(sliderTrackVariants({ color: 'info' })).toContain('bg-info-tint');
+    expect(sliderTrackVariants({ color: 'info' })).toContain('border-info-tint');
+    expect(sliderRangeVariants({ color: 'info' })).toContain('bg-info-light');
+    expect(sliderThumbVisualVariants({ color: 'info' })).toContain('border-info-light');
   });
 });
 

--- a/src/components/atoms/slider/types.ts
+++ b/src/components/atoms/slider/types.ts
@@ -23,6 +23,7 @@ export const sliderTrackVariants = cva(
         default: 'border-red-tint-low bg-red-tint-subtle dark:border-red-tint-active dark:bg-red-tint-low',
         primary: 'border-red-tint-active bg-red-tint-low dark:border-red-tint-strong dark:bg-red-tint-active',
         secondary: 'border-border-light bg-border-light dark:border-border-dark dark:bg-surface-raised-dark',
+        info: 'border-info-tint bg-info-tint',
         success: 'border-success-tint bg-success-tint',
         warning: 'border-warning-tint bg-warning-tint',
         danger: 'border-error-tint bg-error-tint'
@@ -45,6 +46,7 @@ export const sliderRangeVariants = cva('absolute h-full', {
       default: 'bg-brand-light dark:bg-brand-dark',
       primary: 'bg-brand-light-dark dark:bg-brand-dark-light',
       secondary: 'bg-text-secondary-light dark:bg-border-strong-dark',
+      info: 'bg-info-light dark:bg-info',
       success: 'bg-success-light dark:bg-success',
       warning: 'bg-warning-light dark:bg-warning',
       danger: 'bg-error-light dark:bg-error'
@@ -88,6 +90,7 @@ export const sliderThumbVisualVariants = cva(
           'border-brand-light-dark group-hover:border-brand-light-light dark:border-brand-dark-light dark:group-hover:border-brand-dark-lighter',
         secondary:
           'border-text-secondary-light group-hover:border-text-light dark:border-border-strong-dark dark:group-hover:border-text-secondary-dark',
+        info: 'border-info-light group-hover:border-info dark:border-info dark:group-hover:border-blue-light',
         success:
           'border-success-light group-hover:border-success dark:border-success dark:group-hover:border-green-light',
         warning:

--- a/src/components/atoms/text-area/TextArea.test.tsx
+++ b/src/components/atoms/text-area/TextArea.test.tsx
@@ -178,6 +178,24 @@ describe('useTextArea — logic', () => {
     expect(result.current.textareaProps['aria-invalid']).toBe('true');
   });
 
+  it('maps info hints to semantic info styling and icon tone', () => {
+    const { result } = renderHook(() =>
+      useTextArea(
+        {
+          id: 'message',
+          label: 'Message',
+          hint: { message: 'Helpful guidance', type: 'info' }
+        },
+        null
+      )
+    );
+
+    expect(result.current.surfaceProps.className).toContain('border-info-light');
+    expect(result.current.surfaceProps.className).toContain('shadow-glow-input-info-light');
+    expect(result.current.hintMessageClassName).toContain('text-info-light');
+    expect(result.current.hintIconProps).toMatchObject({ name: 'info', tone: 'info' });
+  });
+
   it('dedupes aria-describedby sources while preserving order', () => {
     const { result } = renderHook(() =>
       useTextArea(

--- a/src/components/atoms/text-area/types.ts
+++ b/src/components/atoms/text-area/types.ts
@@ -61,7 +61,7 @@ export const textAreaSurfaceVariants = cva(
           'border-warning-light shadow-glow-input-warning-light hover:!border-warning-light dark:border-warning dark:shadow-glow-input-warning dark:hover:!border-warning',
         success:
           'border-success-light shadow-glow-input-success-light hover:!border-success-light dark:border-success dark:shadow-glow-input-success dark:hover:!border-success',
-        info: ''
+        info: 'border-info-light shadow-glow-input-info-light hover:!border-info-light dark:border-info dark:shadow-glow-input-info dark:hover:!border-info'
       },
       focused: {
         true: '!border-brand-light/50 shadow-glow-input-focus-light dark:!border-brand-dark/50 dark:shadow-glow-input-focus',
@@ -87,6 +87,11 @@ export const textAreaSurfaceVariants = cva(
         focused: true,
         status: 'success',
         class: '!border-success-light dark:!border-success'
+      },
+      {
+        focused: true,
+        status: 'info',
+        class: '!border-info-light dark:!border-info'
       }
     ],
     defaultVariants: {

--- a/src/components/atoms/text-area/useTextArea.ts
+++ b/src/components/atoms/text-area/useTextArea.ts
@@ -105,7 +105,7 @@ const getHintIconProps = (type?: TextAreaHint['type']): HintIconProps | undefine
     case 'success':
       return { name: 'circle-check', tone: 'success', size: 16 };
     case 'info':
-      return { name: 'info', tone: 'muted', size: 16 };
+      return { name: 'info', tone: 'info', size: 16 };
     default:
       return undefined;
   }

--- a/src/components/atoms/tooltip/Tooltip.stories.tsx
+++ b/src/components/atoms/tooltip/Tooltip.stories.tsx
@@ -68,6 +68,9 @@ export const Colors: Story = {
       <Tooltip content='Warning tooltip' color='warning'>
         <Button text='Warning' />
       </Tooltip>
+      <Tooltip content='Info tooltip' color='info'>
+        <Button text='Info' />
+      </Tooltip>
       <Tooltip content='Transparent tooltip' color='transparent'>
         <Button text='Transparent' />
       </Tooltip>

--- a/src/components/atoms/tooltip/Tooltip.test.tsx
+++ b/src/components/atoms/tooltip/Tooltip.test.tsx
@@ -5,6 +5,7 @@ import { act, cleanup, fireEvent, render, renderHook, screen, waitFor } from '@t
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Tooltip } from './Tooltip';
+import { tooltipVariants } from './types';
 import { useTooltip } from './useTooltip';
 
 afterEach(() => {
@@ -61,6 +62,11 @@ describe('useTooltip — logic', () => {
     expect(result.current.enableHover).toBe(true);
     expect(result.current.enableFocus).toBe(true);
     expect(result.current.enableClick).toBe(false);
+  });
+
+  it('maps the info color to the semantic tooltip surface', () => {
+    expect(tooltipVariants({ color: 'info' })).toContain('bg-info-light');
+    expect(tooltipVariants({ color: 'info' })).toContain('dark:bg-info');
   });
 });
 

--- a/src/components/atoms/tooltip/types.ts
+++ b/src/components/atoms/tooltip/types.ts
@@ -13,6 +13,7 @@ export const tooltipVariants = cva(
         default:
           'border-border-light bg-surface-raised-light text-text-light dark:border-border-dark dark:bg-surface-raised-dark dark:text-text-dark',
         primary: 'border-transparent bg-btn-primary text-white',
+        info: 'border-transparent bg-info-light text-white dark:bg-info dark:text-text-light',
         success: 'border-transparent bg-success-light text-text-light dark:bg-success dark:text-text-light',
         warning: 'border-transparent bg-warning-light text-text-light dark:bg-warning dark:text-text-light',
         transparent:
@@ -43,7 +44,7 @@ export const tooltipVariants = cva(
   }
 );
 
-export type TooltipColor = 'default' | 'primary' | 'success' | 'warning' | 'transparent';
+export type TooltipColor = 'default' | 'primary' | 'info' | 'success' | 'warning' | 'transparent';
 export type TooltipComplement = 'default' | 'arrow-bottom' | 'arrow-left' | 'arrow-right' | 'arrow-top';
 export type TooltipWidth = 'default' | 'md' | 'xl';
 export type TooltipPosition =

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -285,6 +285,8 @@
   --glow-input-warning-light: 0 0 0 3px rgba(217, 119, 6, 0.15);
   --glow-input-success: 0 0 0 3px rgba(34, 197, 94, 0.12);
   --glow-input-success-light: 0 0 0 3px rgba(22, 163, 74, 0.15);
+  --glow-input-info: 0 0 0 3px rgba(59, 130, 246, 0.12);
+  --glow-input-info-light: 0 0 0 3px rgba(29, 78, 216, 0.15);
   --shadow-glow-input-focus: var(--glow-input-focus);
   --shadow-glow-input-focus-light: var(--glow-input-focus-light);
   --shadow-glow-input-error: var(--glow-input-error);
@@ -293,6 +295,8 @@
   --shadow-glow-input-warning-light: var(--glow-input-warning-light);
   --shadow-glow-input-success: var(--glow-input-success);
   --shadow-glow-input-success-light: var(--glow-input-success-light);
+  --shadow-glow-input-info: var(--glow-input-info);
+  --shadow-glow-input-info-light: var(--glow-input-info-light);
 
   /* Glow ámbar — GitHub stars */
   --glow-amber: 0 0 0 3px rgba(255, 185, 0, 0.12);


### PR DESCRIPTION
## Summary

- Adds first-class `info` semantic state/color support across token-backed component APIs.
- Wires `info` into input/select/text-area status styling, hint tone, tests, and semantic Storybook matrices.
- Aligns token docs and contributor/visual review checklists so `info` is reviewed with success/warning/danger states.

Closes #271

## Review scope

- Primary files/areas:
  - `src/styles/theme.css`
  - `src/components/atoms/{input,select,text-area,alert,badge,chip,progress,slider,popover,tooltip}`
  - `docs/DESIGN*.md`, `docs/COMPONENTS*.md`
  - `.atl/skills/component-contributor/SKILL.md`, `.atl/skills/visual-review/SKILL.md`
- Out of scope:
  - Renaming/removing existing tokens.
  - New component architecture changes.
  - Manual Storybook screenshot capture.
- Review workload: medium; 36 files, ~279 changed lines, below the 400-line review budget.

## Type of change

- [ ] New component
- [ ] Existing component update/refactor
- [ ] Bug fix
- [ ] Accessibility
- [x] Design tokens
- [ ] Storybook/docs
- [ ] Infrastructure/tooling
- [ ] NPM/dependencies

## Workflow gates

- [x] Linked issue is present with `Closes #NNN` or maintainer approved an exception.
- [x] Linked issue has label `status:approved` before implementation starts.
- [x] Linked issue assignee was checked before work started; if it was assigned to someone else, explicit reassignment permission is documented.
- [x] Work was started through the Project flow: assignee set, Project status `In progress`, branch/worktree recorded.
- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`.
- [x] Commits follow the same commitlint-enforced format.
- [x] Diff is focused; unrelated work is called out in Review scope.
- [x] MCP/runtime artifacts are absent: `.playwright-mcp`, `page-*.png`, `page-*.jpeg`, `*.md.playwright-output`.

## Component evidence (required for component changes)

- [x] Validated component spec is linked or quoted in the issue.
- [x] Accessibility contract from the spec was implemented or deviations are explained below.
- [x] Follows the 6-file pattern: `types.ts`, `use*.ts`, `Component.tsx`, `Component.test.tsx`, `Component.stories.tsx`, `index.ts`.
- [x] CVA variants live in `types.ts`; JSX component has no state, CVA calls, or business logic.
- [x] Public props with runtime defaults have matching `@default` JSDoc in `types.ts` (`node scripts/verify-prop-default-docs.mjs`).
- [x] Uses design tokens from `theme.css`; no hardcoded colors or arbitrary color utilities.
- [x] Storybook covers default, variants, documented states, edge cases, and dark mode when visually different.
- [x] Component audit result is PASS or accepted PASS WITH WARNINGS.
- [x] Visual review result is included when visuals changed.

## Accessibility evidence

- [x] Role/name semantics verified with Testing Library queries or equivalent.
- [x] Keyboard-only behavior verified: Tab / Shift+Tab, Enter / Space, Arrow keys, Escape, Home / End / typeahead where applicable.
- [x] Focus lifecycle verified: initial focus, roving/active descendant, focus restore, trap/portal behavior where applicable.
- [x] Disabled, required, invalid/error, loading, and empty states expose the expected semantics where applicable.
- [x] Reduced motion behavior is respected where motion changed.
- [x] Screen reader or axe/manual evidence is included below when applicable.

## Validation evidence

- TypeScript: `pnpm exec tsc --noEmit` passed.
- Unit tests: `pnpm test` passed — 35 files / 739 tests. Also passed during pre-push hook.
- Build/package: `node scripts/verify-prop-default-docs.mjs` passed. `git diff --check` passed.
- Storybook or visual check: Story matrices updated so `info` appears with semantic/state colors; manual screenshot capture not run in this environment.
- Accessibility check: Existing component interaction tests passed; this change preserves existing semantics and updates token-backed visual state classes.
- Security/dependency check: No dependency or lockfile changes. No shell scripts modified, so shellcheck is N/A.

## Screenshots or recordings

Not captured in this environment. Storybook matrices were updated for visual review.

## Notes for reviewer

- `src/styles/theme.css` remains the canonical source for info token values. `docs/DESIGN*.md` was aligned to shipped token values rather than changing runtime colors.
- `Alert` keeps `CustomColor` as a custom token-backed override example; `info` is now included in the semantic `VariantSolid`, `VariantBordered`, and `VariantFlat` stories.
- Fresh review found no blockers after the story placement correction.
