### PR TITLE
fix(toast): respect queue strategy overflow

### DIFF
--- a/src/components/organisms/toast/Toast.stories.tsx
+++ b/src/components/organisms/toast/Toast.stories.tsx
@@ -39,11 +39,13 @@ const queueDemoToasts = (strategy: ToastQueueStrategy) => {
       id: `queue-${strategy}-demo-${index}`,
       title: `${strategy.toUpperCase()} notification ${index}`,
       description:
-        index <= 2
-          ? strategy === 'fifo'
-            ? 'Queued after notification 4 arrives. FIFO promotes notification 1 before notification 2.'
-            : 'Queued after notification 4 arrives. LIFO promotes notification 2 before notification 1.'
-          : 'Visible after the four-toast batch because the stack keeps the latest items on screen.'
+        strategy === 'fifo'
+          ? index <= 2
+            ? 'Remains visible when notifications 3 and 4 arrive. Closing a visible toast promotes notification 3 before notification 4.'
+            : 'Queued once the FIFO visible slots are full. Notification 3 promotes before notification 4.'
+          : index <= 2
+            ? 'Moves into the hidden queue as newer notifications arrive. Notification 2 promotes before notification 1.'
+            : 'Remains visible after the four-toast batch because LIFO keeps the newest notifications on screen.'
     });
   }
 };
@@ -418,8 +420,8 @@ const QueueStrategyDemo = (args: ComponentProps<typeof ToastProvider>) => {
 };
 
 /**
- * Demonstrates the queue promotion difference when the visible stack frees a slot.
- * Queue four toasts: the latest two stay visible, while notifications 1 and 2 move into the queue. Close one visible toast; FIFO promotes notification 1 first, while LIFO promotes notification 2 first.
+ * Demonstrates how `queueStrategy` changes both overflow handling and promotion order.
+ * With `fifo`, notifications 1 and 2 stay visible while notifications 3 and 4 wait in the queue. With `lifo`, notifications 3 and 4 stay visible while notifications 1 and 2 move into the queue. Closing a visible toast then promotes the next queued toast from the strategy-specific end.
  */
 export const QueueStrategy: Story = {
   render: (args) => <QueueStrategyDemo {...args} />

--- a/src/components/organisms/toast/Toast.test.tsx
+++ b/src/components/organisms/toast/Toast.test.tsx
@@ -455,51 +455,78 @@ describe('Toast — timers, queueing, and helper state', () => {
     expect(screen.queryByRole('alertdialog', { name: 'Created in background' })).not.toBeInTheDocument();
   });
 
-  it('keeps the latest toasts visible while demoting older visible toasts into the queue', () => {
-    renderWithProvider({ maxVisible: 3 });
+  it('keeps existing visible toasts on screen and queues newer overflow toasts when using FIFO', () => {
+    renderWithProvider({ maxVisible: 2 });
 
-    runInAct(() => toast('First queued'));
-    runInAct(() => toast('Second visible'));
-    runInAct(() => toast('Third visible'));
-    const latestId = runInAct(() => toast('Fourth visible'));
+    runInAct(() => toast('First visible'));
+    const secondId = runInAct(() => toast('Second visible'));
+    runInAct(() => toast('Third queued'));
+    runInAct(() => toast('Fourth queued'));
 
-    expect(screen.queryByRole('alertdialog', { name: 'First queued' })).not.toBeInTheDocument();
+    expect(screen.getByRole('alertdialog', { name: 'First visible' })).toBeInTheDocument();
     expect(screen.getByRole('alertdialog', { name: 'Second visible' })).toBeInTheDocument();
-    expect(screen.getByRole('alertdialog', { name: 'Third visible' })).toBeInTheDocument();
-    expect(screen.getByRole('alertdialog', { name: 'Fourth visible' })).toBeInTheDocument();
+    expect(screen.queryByRole('alertdialog', { name: 'Third queued' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('alertdialog', { name: 'Fourth queued' })).not.toBeInTheDocument();
 
     act(() => {
-      toast.close(latestId);
+      toast.close(secondId);
     });
 
-    expect(screen.getByRole('alertdialog', { name: 'First queued' })).toBeInTheDocument();
+    expect(screen.getByRole('alertdialog', { name: 'First visible' })).toBeInTheDocument();
+    expect(screen.getByRole('alertdialog', { name: 'Third queued' })).toBeInTheDocument();
+    expect(screen.queryByRole('alertdialog', { name: 'Fourth queued' })).not.toBeInTheDocument();
   });
 
-  it('promotes queued toasts using FIFO ordering by default', () => {
+  it('queues overflow toasts in FIFO order by default when maxVisible is 1', () => {
     renderWithProvider({ maxVisible: 1 });
 
-    runInAct(() => toast('First queued'));
-    runInAct(() => toast('Second queued'));
-    const thirdId = runInAct(() => toast('Third visible'));
+    const firstId = runInAct(() => toast('Toast A'));
+    const secondId = runInAct(() => toast('Toast B'));
+    runInAct(() => toast('Toast C'));
 
-    expect(screen.getByRole('alertdialog', { name: 'Third visible' })).toBeInTheDocument();
-    expect(screen.queryByRole('alertdialog', { name: 'First queued' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('alertdialog', { name: 'Second queued' })).not.toBeInTheDocument();
+    expect(screen.getByRole('alertdialog', { name: 'Toast A' })).toBeInTheDocument();
+    expect(screen.queryByRole('alertdialog', { name: 'Toast B' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('alertdialog', { name: 'Toast C' })).not.toBeInTheDocument();
 
     act(() => {
-      toast.close(thirdId);
+      toast.close(firstId);
     });
 
-    expect(screen.getByRole('alertdialog', { name: 'First queued' })).toBeInTheDocument();
-    expect(screen.queryByRole('alertdialog', { name: 'Second queued' })).not.toBeInTheDocument();
+    expect(screen.getByRole('alertdialog', { name: 'Toast B' })).toBeInTheDocument();
+    expect(screen.queryByRole('alertdialog', { name: 'Toast C' })).not.toBeInTheDocument();
+
+    act(() => {
+      toast.close(secondId);
+    });
+
+    expect(screen.getByRole('alertdialog', { name: 'Toast C' })).toBeInTheDocument();
+  });
+
+  it('keeps queued toast ordering stable when a FIFO overflow toast is closed before promotion', () => {
+    renderWithProvider({ maxVisible: 1 });
+
+    const firstId = runInAct(() => toast('Visible toast'));
+    const secondId = runInAct(() => toast('Queued toast B'));
+    runInAct(() => toast('Queued toast C'));
+
+    act(() => {
+      toast.close(secondId);
+    });
+
+    act(() => {
+      toast.close(firstId);
+    });
+
+    expect(screen.getByRole('alertdialog', { name: 'Queued toast C' })).toBeInTheDocument();
+    expect(screen.queryByRole('alertdialog', { name: 'Queued toast B' })).not.toBeInTheDocument();
   });
 
   it('keeps queued toasts paused when they are promoted while the window is blurred', () => {
     vi.useFakeTimers();
     renderWithProvider({ maxVisible: 1 });
 
-    runInAct(() => toast({ title: 'Promoted in background' }));
     const blockingToastId = runInAct(() => toast({ title: 'Blocking toast', duration: 0 }));
+    runInAct(() => toast({ title: 'Promoted in background' }));
 
     fireEvent(window, new Event('blur'));
 
@@ -543,19 +570,51 @@ describe('Toast — timers, queueing, and helper state', () => {
     expect(screen.getByRole('alertdialog', { name: 'Demoted timer toast' })).toBeInTheDocument();
   });
 
-  it('promotes queued toasts using LIFO ordering when configured', () => {
+  it('keeps the newest toasts visible and promotes overflow in LIFO order when configured', () => {
+    renderWithProvider({ maxVisible: 2, queueStrategy: 'lifo' });
+
+    runInAct(() => toast('Toast A'));
+    runInAct(() => toast('Toast B'));
+    runInAct(() => toast('Toast C'));
+    const fourthId = runInAct(() => toast('Toast D'));
+
+    expect(screen.queryByRole('alertdialog', { name: 'Toast A' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('alertdialog', { name: 'Toast B' })).not.toBeInTheDocument();
+    expect(screen.getByRole('alertdialog', { name: 'Toast C' })).toBeInTheDocument();
+    expect(screen.getByRole('alertdialog', { name: 'Toast D' })).toBeInTheDocument();
+
+    act(() => {
+      toast.close(fourthId);
+    });
+
+    expect(screen.getByRole('alertdialog', { name: 'Toast B' })).toBeInTheDocument();
+    expect(screen.getByRole('alertdialog', { name: 'Toast C' })).toBeInTheDocument();
+    expect(screen.queryByRole('alertdialog', { name: 'Toast A' })).not.toBeInTheDocument();
+  });
+
+  it('promotes queued toasts using LIFO ordering when maxVisible is 1', () => {
     renderWithProvider({ maxVisible: 1, queueStrategy: 'lifo' });
 
-    runInAct(() => toast('First queued'));
-    runInAct(() => toast('Second queued'));
-    const thirdId = runInAct(() => toast('Third visible'));
+    runInAct(() => toast('Toast A'));
+    const secondId = runInAct(() => toast('Toast B'));
+    const thirdId = runInAct(() => toast('Toast C'));
+
+    expect(screen.getByRole('alertdialog', { name: 'Toast C' })).toBeInTheDocument();
+    expect(screen.queryByRole('alertdialog', { name: 'Toast A' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('alertdialog', { name: 'Toast B' })).not.toBeInTheDocument();
 
     act(() => {
       toast.close(thirdId);
     });
 
-    expect(screen.getByRole('alertdialog', { name: 'Second queued' })).toBeInTheDocument();
-    expect(screen.queryByRole('alertdialog', { name: 'First queued' })).not.toBeInTheDocument();
+    expect(screen.getByRole('alertdialog', { name: 'Toast B' })).toBeInTheDocument();
+    expect(screen.queryByRole('alertdialog', { name: 'Toast A' })).not.toBeInTheDocument();
+
+    act(() => {
+      toast.close(secondId);
+    });
+
+    expect(screen.getByRole('alertdialog', { name: 'Toast A' })).toBeInTheDocument();
   });
 });
 

--- a/src/components/organisms/toast/toastStore.ts
+++ b/src/components/organisms/toast/toastStore.ts
@@ -457,6 +457,12 @@ const enqueueToast = (toastItem: InternalToast) => {
   }
 
   if (state.visible.length >= state.config.maxVisible) {
+    if (state.config.queueStrategy === 'fifo') {
+      state.queue.push(toastItem);
+      notify();
+      return toastItem.id;
+    }
+
     demoteOldestVisibleToast();
   }
 

--- a/src/components/organisms/toast/types.ts
+++ b/src/components/organisms/toast/types.ts
@@ -198,6 +198,11 @@ export type ToastStatus = NonNullable<ToastVariantProps['status']>;
 export type ToastVariant = NonNullable<ToastVariantProps['variant']>;
 export type ToastSize = NonNullable<ToastVariantProps['size']>;
 export type ToastMotionState = NonNullable<ToastVariantProps['motionState']>;
+/**
+ * Controls toast overflow handling and promotion order.
+ * `fifo` keeps current visible toasts on screen and queues newer overflow toasts.
+ * `lifo` keeps the newest toast visible by demoting the oldest visible toast into the queue.
+ */
 export type ToastQueueStrategy = 'fifo' | 'lifo';
 export type ToastMotion = 'default' | 'none';
 export type ToastSwipeDirection = 'right' | 'left' | 'up' | 'down';
@@ -393,6 +398,9 @@ export type ToastProviderProps = NativeProviderProps & {
    */
   maxVisible?: number;
   /**
+   * Controls toast overflow handling and promotion order.
+   * `fifo` keeps current visible toasts on screen and queues newer overflow toasts.
+   * `lifo` keeps the newest toast visible by demoting the oldest visible toast into the queue.
    * @control select
    * @default fifo
    */


### PR DESCRIPTION
## Summary

- Fixes Toast `queueStrategy` overflow semantics so FIFO keeps current visible toasts and queues newer overflow toasts.
- Preserves LIFO latest-first overflow behavior while keeping promotion order strategy-aware.
- Updates regression coverage and Storybook/type docs for FIFO/LIFO behavior.

Closes #274

## Review scope

- Primary files/areas:
  - `src/components/organisms/toast/toastStore.ts`
  - `src/components/organisms/toast/Toast.test.tsx`
  - `src/components/organisms/toast/Toast.stories.tsx`
  - `src/components/organisms/toast/types.ts`
- Out of scope: broader Toast API changes, visual redesign, accessibility semantics.
- Review workload: small (~110 insertions / 35 deletions).

## Type of change

- [ ] New component
- [ ] Existing component update/refactor
- [x] Bug fix
- [ ] Accessibility
- [ ] Design tokens
- [x] Storybook/docs
- [ ] Infrastructure/tooling
- [ ] NPM/dependencies

## Workflow gates

- [x] Linked issue is present with `Closes #NNN` or maintainer approved an exception.
- [x] Linked issue has label `status:approved` before implementation starts.
- [x] Linked issue assignee was checked before work started; if it was assigned to someone else, explicit reassignment permission is documented.
- [x] Work was started through the Project flow: assignee set, Project status `In progress`, branch/worktree recorded.
- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`.
- [x] Commits follow the same commitlint-enforced format.
- [x] Diff is focused; unrelated work is called out in Review scope.
- [x] MCP/runtime artifacts are absent: `.playwright-mcp`, `page-*.png`, `page-*.jpeg`, `*.md.playwright-output`.

## Component evidence (required for component changes)

- [x] Validated component spec is linked or quoted in the issue.
- [x] Accessibility contract from the spec was implemented or deviations are explained below.
- [x] Follows the 6-file pattern: `types.ts`, `use*.ts`, `Component.tsx`, `Component.test.tsx`, `Component.stories.tsx`, `index.ts`.
- [x] CVA variants live in `types.ts`; JSX component has no state, CVA calls, or business logic.
- [x] Public props with runtime defaults have matching `@default` JSDoc in `types.ts` (`node scripts/verify-prop-default-docs.mjs`).
- [x] Uses design tokens from `theme.css`; no hardcoded colors or arbitrary color utilities.
- [x] Storybook covers default, variants, documented states, edge cases, and dark mode when visually different.
- [x] Component audit result is PASS or accepted PASS WITH WARNINGS.
- [x] Visual review result is included when visuals changed.

## Accessibility evidence

- [x] Role/name semantics verified with Testing Library queries or equivalent.
- [x] Keyboard-only behavior verified: Tab / Shift+Tab, Enter / Space, Arrow keys, Escape, Home / End / typeahead where applicable.
- [x] Focus lifecycle verified: initial focus, roving/active descendant, focus restore, trap/portal behavior where applicable.
- [x] Disabled, required, invalid/error, loading, and empty states expose the expected semantics where applicable.
- [x] Reduced motion behavior is respected where motion changed.
- [x] Screen reader or axe/manual evidence is included below when applicable.

## Validation evidence

- TypeScript: `pnpm exec tsc --noEmit` ✅
- Unit tests:
  - `pnpm vitest run src/components/organisms/toast/Toast.test.tsx` ✅ — 48 tests passed
  - pre-push `pnpm run test` ✅ — 35 files / 741 tests passed
- Build/package: not run; package exports were not changed.
- Storybook or visual check: `pnpm run storybook-build` ✅
- Accessibility check: behavior verified with Testing Library role/name queries; no semantic/a11y behavior changed.
- Security/dependency check: N/A — no dependency changes.
- Additional checks:
  - `node scripts/verify-prop-default-docs.mjs` ✅
  - `pnpm exec biome check src/components/organisms/toast/toastStore.ts src/components/organisms/toast/Toast.test.tsx src/components/organisms/toast/Toast.stories.tsx src/components/organisms/toast/types.ts` ✅
  - `git diff --check` ✅
  - Fresh pre-PR review ✅ — no blockers.

## Screenshots or recordings

N/A — this is queue-order behavior plus docs/test coverage; Storybook build passed.

## Notes for reviewer

FIFO now queues new overflow toasts and keeps current visible slots stable. LIFO keeps the previous latest-first behavior by demoting the oldest visible toast before showing the new one. Promotion after close remains strategy-aware through the existing queue promotion path.
