### PR TITLE
feat(tokens): standardize interactive control sizing

### DIFF
--- a/.atl/skills/_shared/component-contract.md
+++ b/.atl/skills/_shared/component-contract.md
@@ -66,7 +66,7 @@ Only Radix UI primitives are allowed as base primitives. When Radix is used:
 ## Visual and accessibility gates
 
 - Visual rules live in `.atl/skills/visual-review/SKILL.md`; load it for state, glow, transition, gradient-border, contrast, and focus checks.
-- Default interactive controls target `44×44px`. Compact/dense variants may go smaller only when explicitly documented, visually approved, native-control based, keyboard accessible, and focus-visible.
+- Comparable action controls use the shared visual `control` scale (`24/32/40/48px`) when applicable. Labeled form fields such as `Input`/`Select` use the semantic `form-field` scale (`48/56/64px`) when label/floating-label layout affects alignment. `touch-target-min` (`44px`) is contextual guidance for touch-first surfaces or hit-area wrappers, not a universal visual height. Compact/dense variants may stay smaller only when explicitly documented, native-control based, keyboard accessible, and focus-visible.
 - Focus styling uses visible `box-shadow`; `outline: none` is valid only with an alternative focus ring.
 - Motion/transforms respect `prefers-reduced-motion`.
 

--- a/.atl/skills/component-contributor/SKILL.md
+++ b/.atl/skills/component-contributor/SKILL.md
@@ -86,6 +86,8 @@ Map the component to the design system before coding:
 
 - surface pattern: opaque, raised, tinted, or floating/frosted;
 - relevant tokens from `theme.css`;
+- action control-height scale (`control-xs|sm|md|lg`) for comparable action controls, or semantic form-field scale (`form-field-sm|md|lg`) when the component behaves like `Input`/`Select` with label/floating-label layout;
+- whether the component uses visual control height tokens, form-field sizing, a separate `touch-target-min`, or a documented compact exception;
 - base/hover/focus/active/disabled/loading/error/info states;
 - focus ring, disabled treatment, touch target, contrast, reduced motion;
 - allowed Radix primitive, if any.

--- a/.atl/skills/components-auditor/SKILL.md
+++ b/.atl/skills/components-auditor/SKILL.md
@@ -43,6 +43,7 @@ Audit against `.atl/skills/_shared/component-contract.md`:
 - Public prop JSDoc/default parity: compare `types.ts` props against CVA `defaultVariants`, hook/component destructuring defaults, alias/coalesced fallbacks, and boolean fallback chains; fail missing or stale `@default` docs.
 - CVA placement and hook/component responsibilities;
 - token usage and Tailwind v4 custom fractional naming;
+- sizing consistency: comparable action controls use `control-*` tokens, form fields like `Input`/`Select` use `form-field-*` tokens when label/floating-label layout affects alignment, touch-target wrappers use `touch-target-min` when required, and compact exceptions are explicitly documented;
 - named export and type export pattern;
 - Radix primitive rules when applicable;
 - accessibility gates and reduced motion.
@@ -64,7 +65,7 @@ Use the Storybook and testing references as the single source of truth. In parti
 
 ### 4 — Visual audit
 
-Run the `visual-review` protocol for state completeness, glow, blur/gradient, transitions, gradient borders, focus, contrast, touch target, and reduced motion.
+Run the `visual-review` protocol for state completeness, glow, blur/gradient, transitions, gradient borders, focus, contrast, touch target, reduced motion, and consistency between shared control-height tokens versus documented compact exceptions.
 
 ### 5 — Severity and verdict
 

--- a/.atl/skills/visual-review/SKILL.md
+++ b/.atl/skills/visual-review/SKILL.md
@@ -113,7 +113,8 @@ For every interactive component, check ALL of the following sections.
 ### 6. Accessibility
 
 **Buttons:**
-- [ ] Default action height is `44px`; compact/dense component variants may go below `44px` only when explicitly documented, visually approved, implemented on native controls, and still keyboard/focus accessible
+- [ ] Visual height follows the shared `control` scale (`24px`, `32px`, `40px`, `48px`) for comparable action controls; compact/dense exceptions must be explicitly documented
+- [ ] `touch-target-min` (`44px`) is required only for touch-first surfaces or hit-area wrappers; do not flag every visual height under `44px` as wrong by default
 - [ ] Focus ring: `box-shadow: 0 0 0 3px rgba(255, 0, 54, 0.40)` dark / `0 0 0 3px rgba(219, 20, 60, 0.35)` light
 - [ ] Focus ring **merged** with existing `box-shadow` — adds as outermost layer, never replaces
 - [ ] `outline: none` must ALWAYS be paired with a visible `box-shadow` focus ring — never naked
@@ -124,7 +125,9 @@ For every interactive component, check ALL of the following sections.
 - [ ] `role="button"` if implemented as non-`<button>` element
 
 **Inputs:**
-- [ ] Minimum height `44px`
+- [ ] Form fields such as `Input` and `Select` use the semantic form-field height scale (`sm=h-form-field-sm`, `md=h-form-field-md`, `lg=h-form-field-lg`) because label/floating-label layout and field alignment are part of the pattern
+- [ ] Do not force `h-control-*` onto labeled form fields; reserve `control-*` for comparable action controls like Button/IconButton/CTA Link
+- [ ] Apply `touch-target-min` only when the context requires a larger touch surface than the visual control itself
 - [ ] Focus ring softer than button: `box-shadow: 0 0 0 3px rgba(255, 0, 54, 0.12)` — 12%, not 40%
 - [ ] Error state changes border + shadow only — NOT input text color
 - [ ] Info state changes border + shadow only, using semantic blue tokens instead of neutral helper styling
@@ -164,9 +167,9 @@ For every interactive component, check ALL of the following sections.
 
 When reporting issues, classify every finding with:
 
-- **CRITICAL** — Accessibility failure: missing focus ring, insufficient contrast, no disabled state, undocumented interactive element below the required target size, `outline: none` without alternative
+- **CRITICAL** — Accessibility failure: missing focus ring, insufficient contrast, no disabled state, missing required touch target in a touch-first context, or `outline: none` without alternative
 - **MAJOR** — Compositional rule violation: blur+gradient on same element, wrong glow layer count, flat border where gradient required, `border-image` used, `transition: all` used, layout property animated
-- **MINOR** — Inconsistency with spec: wrong duration (e.g. 300ms instead of 250ms for button), missing transition property (e.g. `border-color` absent on secondary), hover tint value off
+- **MINOR** — Inconsistency with spec: wrong duration (e.g. 300ms instead of 250ms for button), missing transition property (e.g. `border-color` absent on secondary), hover tint value off, or undocumented deviation from the shared control sizing scale
 - **SUGGESTION** — Enhancement opportunity: adding `will-change` to entrance animations, using token variable instead of raw value
 
 ---

--- a/.atl/skills/visual-review/compact-rules.md
+++ b/.atl/skills/visual-review/compact-rules.md
@@ -37,5 +37,8 @@
 ### Timing Reference
 - Buttons: 250ms ease | Cards: 300ms ease | Dropdowns: 150ms ease | Links: 200ms ease | Scroll fade-in: 560ms cubic-bezier(0.2, 0.8, 0.2, 1)
 
-### Minimum Touch Targets
-- Default interactive elements target `44×44px`; documented compact/dense variants may go below this when visually approved and still native-button, keyboard, focus-ring, and ARIA accessible
+### Control height and touch targets
+- Comparable action controls use the shared visual `control` scale (`24/32/40/48px`) when applicable.
+- Labeled form fields such as `Input`/`Select` use the semantic `form-field` scale (`48/56/64px`) when label/floating-label layout affects alignment.
+- `touch-target-min` (`44px`) is required for touch-first surfaces or hit-area wrappers, not every visual height.
+- Documented compact/dense variants may stay visually smaller when they remain native-button/control based, keyboard accessible, focus-visible, and ARIA accessible.

--- a/docs/COMPONENTS.en.md
+++ b/docs/COMPONENTS.en.md
@@ -76,11 +76,15 @@ Never use `outline: none` without an alternative visible focus indicator.
 **Rule 9 — Gradient borders use `::before` pseudo-element, never `border-image`.**
 `border-image` does not work with `border-radius` — the gradient clips to a rectangle, destroying the pill shape. The correct technique uses `::before` absolutely positioned with `inset: -1.5px` and `z-index: -1`, with the gradient as its `background` and `border-radius: inherit`.
 
-**Rule 10 — Default touch target is 44×44px for interactive elements.**
-Buttons and action-style links use a default minimum `height: 44px` from `sm` upward. Nav links: minimum `44px` high area. Dropdown items: `padding: 7px 12px` minimum with 14px font. Component-specific compact/dense size scales may go below 44px only when explicitly approved, documented on the prop/story, implemented on native controls, and still keyboard/focus accessible; use the default scale when touch-first targets are required. Calendar is an approved dense component scale because date grids need compact scanning density.
+**Rule 10 — Visual control height and touch target are not the same thing.**
+The shared visual scale for comparable action controls is `xs | sm | md | lg` = `24px | 32px | 40px | 48px`, exposed through `--spacing-control-*` and Tailwind utilities `h-control-*` / `w-control-*`. `Button`, `IconButton`, and CTA `Link` (`button` / `outlined`) should consume that scale so their visual heights do not drift. `Link` `regular` remains inline typographic navigation.
+
+`Input` and `Select` are form controls: their height accounts for label, floating label, adornments, and alignment between fields, so they use the semantic `form-field` scale (`--spacing-form-field-sm|md|lg` = `48px | 56px | 64px`) instead of the visual action scale. If more fields share that logic, align them with `Input`/`Select`, not `Button`.
+
+`--spacing-touch-target-min` (`44px`) is touch-target guidance for touch-first surfaces, primary mobile CTAs, or hit-area wrappers. It is not a universal visual height for every web control. Compact or dense components may stay below `44px` when that is documented, they still use native controls, and keyboard/focus behavior remains accessible. `Checkbox` and `Switch` are examples where the hit area can grow without changing the visible shape; `TextArea`, `Chip`, and `Badge` are intentional exceptions with different semantics.
 
 **Action size scale — `xs | sm | md | lg`.**
-For `Button`, `IconButton`, and Link variants used as actions (`button` / `outlined`), `xs` is the dense compact size: reduce typography, icon size, gap, horizontal padding, and height so it is visibly smaller than `sm`. `Link` `regular` remains inline typography-only, while CTA-style `sm` and above keep the 44px target.
+For `Button`, `IconButton`, and Link variants used as actions (`button` / `outlined`), `xs` is the compact dense size. `sm`, `md`, and `lg` follow the same shared semantic visual scale, while touch target is evaluated separately by context.
 
 **Rule 11 — Never animate layout-forcing properties.**
 Do not animate `width`, `height`, `top`, `left`, `margin`, `padding`. These trigger layout reflow on every frame. For position animations use `transform: translateY/translateX`. For size animations use `transform: scale`.
@@ -118,7 +122,7 @@ font-size: 1rem; /* body size; button--lg adds more padding */
 letter-spacing: 0.01em;
 line-height: 1.6;
 padding: 10px 20px; /* minimum; button--lg typically 0.65rem 1.75rem */
-min-height: 44px;
+height: var(--spacing-control-md); /* default visual control height; use touch-target-min only for touch-first hit areas */
 cursor: pointer;
 box-shadow:
   0 0 0 1.5px rgba(255, 60, 90, 0.5),
@@ -200,7 +204,7 @@ font-size: 1rem;
 letter-spacing: 0.01em;
 line-height: 1.6;
 padding: 10px 20px;
-min-height: 44px;
+height: var(--spacing-control-md); /* default visual control height; use touch-target-min only for touch-first hit areas */
 cursor: pointer;
 box-shadow:
   0 0 8px 2px rgba(255, 0, 54, 0.15),
@@ -289,7 +293,7 @@ color: #ffffff;
 font-weight: 600;
 letter-spacing: 0.01em;
 padding: 10px 20px;
-min-height: 44px;
+height: var(--spacing-control-md); /* default visual control height; use touch-target-min only for touch-first hit areas */
 transition:
   background 0.2s ease,
   border-color 0.2s ease,
@@ -346,7 +350,7 @@ font-family: "Space Grotesk Variable", system-ui, sans-serif;
 font-size: 1rem;
 font-weight: 500;
 padding: 10px 14px;
-min-height: 44px;
+height: var(--spacing-form-field-md); /* form-field md height; Input/Select align by field layout */
 width: 100%;
 transition:
   border-color 0.2s ease,
@@ -1140,7 +1144,7 @@ background: linear-gradient(
 
 ### Buttons
 
-- [ ] Minimum height `44px`
+- [ ] Visual height aligns with the `control` scale (`h-control-xs|sm|md|lg`) for the size prop
 - [ ] Focus ring: `box-shadow: 0 0 0 3px rgba(255, 0, 54, 0.40)` dark / `0 0 0 3px rgba(219, 20, 60, 0.35)` light
 - [ ] Focus ring merged with existing `box-shadow` — never replaces it
 - [ ] Focus ring never hidden: no `outline: none` without alternative
@@ -1148,12 +1152,12 @@ background: linear-gradient(
 - [ ] Primary: white `#ffffff` text over red gradient — contrast passes in both modes
 - [ ] Secondary dark: `color: #ffffff` over `rgba(255,0,54,0.06)` — visually dark background context; border defines the affordance
 - [ ] Secondary light: `color: #cc0030` — NEVER `#ff0036` in light mode (insufficient contrast over white)
-- [ ] Touch target remains at least `44px` for default action sizes; explicitly approved compact/dense variants may use reduced visual targets when documented and keyboard/focus accessible
+- [ ] Touch target is evaluated by context: use `touch-target-min` (`44px`) on touch-first surfaces or hit-area wrappers; documented compact/dense variants may keep smaller visual height when keyboard/focus accessible
 - [ ] `role="button"` if implemented as non-`<button>` element
 
 ### Inputs
 
-- [ ] Minimum height `44px`
+- [ ] Visual height aligns with the `form-field` scale (`h-form-field-sm|md|lg`) and stays consistent between fields like `Input` and `Select`; do not force `h-control-*` when label/floating-label layout is part of the pattern
 - [ ] Placeholder text `#6a6b6c` — WCAG exempts placeholder from contrast (informational, not functional)
 - [ ] Error state: border + shadow change, NOT color of input text
 - [ ] Info state: border + shadow change with `--color-info-light` in light mode and `--color-info` in dark mode; never treat it as neutral helper styling
@@ -1172,7 +1176,7 @@ background: linear-gradient(
 
 ### Dropdown / nav items
 
-- [ ] Each item `padding: 7px 12px` minimum — 14px font achieves ~28px height; wrap in container with `min-height: 44px` if needed
+- [ ] Each item `padding: 7px 12px` minimum — 14px font achieves ~28px height; use `touch-target-min` wrappers when the menu is touch-first
 - [ ] Active item: `color: #ff0036` — contrast 4.96:1 on `#0B131E` surface ✅
 - [ ] Hover: background change + color change — two simultaneous signals (not hover-only)
 - [ ] Keyboard navigation: dropdown must be traversable with Tab/Arrow keys

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -76,11 +76,15 @@ Aplicar `opacity: 0.4` a todo el componente comunica el estado disabled. Nunca c
 **Regla 9 — Los bordes con degradado usan un pseudo-elemento `::before`, nunca `border-image`.**
 `border-image` no funciona con `border-radius`: el degradado se recorta como un rectángulo y rompe la forma de píldora. La técnica correcta usa un `::before` posicionado de forma absoluta con `inset: -1.5px` y `z-index: -1`, usando el degradado como `background` y `border-radius: inherit`.
 
-**Regla 10 — El objetivo táctil predeterminado para elementos interactivos es de 44×44px.**
-Los botones y links de acción usan un mínimo predeterminado de `height: 44px` desde `sm` en adelante. Los nav links deben ofrecer al menos un área de `44px` de alto. Los items de dropdown usan como mínimo `padding: 7px 12px` con tipografía de 14px. Las escalas compactas o densas de componentes concretos pueden bajar de 44px solo cuando estén explícitamente aprobadas, documentadas en la prop o la story, implementadas sobre controles nativos y sigan siendo accesibles por teclado y focus; usa la escala predeterminada cuando el caso requiera objetivos touch-first. Calendar es una excepción densa aprobada porque las cuadrículas de fechas necesitan una densidad de escaneo compacta.
+**Regla 10 — La altura visual del control y el objetivo táctil no son lo mismo.**
+La escala visual compartida para controles de acción comparables es `xs | sm | md | lg` = `24px | 32px | 40px | 48px`, expuesta vía `--spacing-control-*` y utilidades Tailwind `h-control-*` / `w-control-*`. `Button`, `IconButton` y `Link` CTA (`button` / `outlined`) deben consumir esa escala para no divergir entre sí. `Link` `regular` sigue siendo una variante tipográfica inline.
+
+`Input` y `Select` son controles de formulario: su altura considera label, floating label, adornments y alineación entre campos, por lo que usan la escala semántica `form-field` (`--spacing-form-field-sm|md|lg` = `48px | 56px | 64px`) en vez de la escala visual de acciones. Si más campos comparten esa lógica, deben alinearse con `Input`/`Select`, no con `Button`.
+
+`--spacing-touch-target-min` (`44px`) es una guía de target táctil para superficies touch-first, CTA primarios en mobile o wrappers de hit area. No es una altura visual universal para todo control web. Los componentes compactos o densos pueden quedar por debajo de `44px` cuando eso está documentado, siguen usando controles nativos y mantienen foco/teclado accesibles. `Checkbox` y `Switch` son ejemplos donde el hit area puede crecer sin cambiar la forma visible; `TextArea`, `Chip` y `Badge` son excepciones intencionales con una semántica distinta.
 
 **Escala de tamaño de acción: `xs | sm | md | lg`.**
-En `Button`, `IconButton` y las variantes de Link usadas como acciones (`button` / `outlined`), `xs` es el tamaño compacto y denso: reduce tipografía, tamaño de icono, separación, padding horizontal y altura para que se vea claramente más pequeño que `sm`. `Link` `regular` sigue siendo una variante tipográfica inline, mientras que los CTA `sm` y superiores conservan el objetivo de 44px.
+En `Button`, `IconButton` y las variantes de Link usadas como acciones (`button` / `outlined`), `xs` es el tamaño compacto y denso. `sm`, `md` y `lg` siguen la misma escala visual semántica compartida, mientras que el target táctil se evalúa aparte según contexto.
 
 **Regla 11 — No animes propiedades que fuerzan layout.**
 No animes `width`, `height`, `top`, `left`, `margin` ni `padding`. Estas propiedades fuerzan reflow en cada frame. Para animaciones de posición usa `transform: translateY/translateX`. Para animaciones de tamaño usa `transform: scale`.
@@ -118,7 +122,7 @@ font-size: 1rem; /* body size; button--lg adds more padding */
 letter-spacing: 0.01em;
 line-height: 1.6;
 padding: 10px 20px; /* minimum; button--lg typically 0.65rem 1.75rem */
-min-height: 44px;
+height: var(--spacing-control-md); /* 40px visual height; use touch-target-min only when the surface is touch-first */
 cursor: pointer;
 box-shadow:
   0 0 0 1.5px rgba(255, 60, 90, 0.5),
@@ -200,7 +204,7 @@ font-size: 1rem;
 letter-spacing: 0.01em;
 line-height: 1.6;
 padding: 10px 20px;
-min-height: 44px;
+height: var(--spacing-control-md); /* 40px visual height; use touch-target-min only when the surface is touch-first */
 cursor: pointer;
 box-shadow:
   0 0 8px 2px rgba(255, 0, 54, 0.15),
@@ -289,7 +293,7 @@ color: #ffffff;
 font-weight: 600;
 letter-spacing: 0.01em;
 padding: 10px 20px;
-min-height: 44px;
+height: var(--spacing-control-md); /* CTA visual height */
 transition:
   background 0.2s ease,
   border-color 0.2s ease,
@@ -346,7 +350,7 @@ font-family: "Space Grotesk Variable", system-ui, sans-serif;
 font-size: 1rem;
 font-weight: 500;
 padding: 10px 14px;
-min-height: 44px;
+height: var(--spacing-form-field-md); /* form-field md height; Input/Select align by field layout */
 width: 100%;
 transition:
   border-color 0.2s ease,
@@ -1140,7 +1144,7 @@ background: linear-gradient(
 
 ### Botones
 
-- [ ] Altura mínima `44px`
+- [ ] Altura visual alineada con la escala `control` (`h-control-xs|sm|md|lg`) según el size prop
 - [ ] Anillo de enfoque: `box-shadow: 0 0 0 3px rgba(255, 0, 54, 0.40)` oscuro / `0 0 0 3px rgba(219, 20, 60, 0.35)` claro
 - [ ] Anillo de enfoque fusionado con `box-shadow` existente; nunca lo reemplaza
 - [ ] Anillo de enfoque nunca oculto: no `outline: none` sin alternativa
@@ -1148,12 +1152,12 @@ background: linear-gradient(
 - [ ] Primary: texto `#ffffff` blanco sobre degradado rojo; el contraste pasa en ambos modos
 - [ ] Secondary en oscuro: `color: #ffffff` sobre `rgba(255,0,54,0.06)` — el contexto de fondo ya es oscuro y el borde comunica la señal visual
 - [ ] Secondary en claro: `color: #cc0030` — nunca `#ff0036` en modo claro (contraste insuficiente sobre blanco)
-- [ ] El objetivo táctil permanece al menos `44px` para los tamaños de acción predeterminados; Las variantes compactas/densas aprobadas explícitamente pueden utilizar objetivos visuales reducidos cuando están documentadas y son accesibles mediante teclado/enfoque.
+- [ ] El objetivo táctil se evalúa por contexto: usa `touch-target-min` (`44px`) en superficies touch-first o wrappers de hit area; las variantes compactas/densas documentadas pueden mantener una altura visual menor si siguen siendo accesibles.
 - [ ] `role="button"` si se implementa como elemento no `<button>`
 
 ### Entradas
 
-- [ ] Altura mínima `44px`
+- [ ] Altura visual alineada con la escala `form-field` (`h-form-field-sm|md|lg`) y consistente entre campos como `Input` y `Select`; no forzar `h-control-*` cuando el label/floating label forma parte del patrón
 - [ ] Texto del marcador de posición `#6a6b6c` — WCAG exime el marcador de posición del contraste (informativo, no funcional)
 - [ ] Estado Error: cambio de borde + sombra, color NOT del texto de entrada
 - [ ] Estado Info: cambio de borde + sombra con `--color-info-light` en claro y `--color-info` en oscuro; no tratarlo como helper neutral
@@ -1172,7 +1176,7 @@ background: linear-gradient(
 
 ### Dropdown / elementos de navegación
 
-- [ ] Cada elemento usa como mínimo `padding: 7px 12px`; con fuente de 14px eso da ~28px de alto, así que envuélvelo en un contenedor con `min-height: 44px` si hace falta
+- [ ] Cada elemento usa como mínimo `padding: 7px 12px`; en superficies touch-first o mobile, envuélvelo en un contenedor o item con `min-h-touch-target-min` si hace falta ampliar el hit area
 - [ ] Elemento activo: `color: #ff0036` — contraste 4.96:1 en la superficie `#0B131E` ✅
 - [ ] Pasar el cursor: cambio de fondo + cambio de color: dos señales simultáneas (no hover-only)
 - [ ] Navegación con teclado: el menú desplegable debe poder recorrerse con las teclas Tabulador/Flecha

--- a/docs/CONTRIBUTING.en.md
+++ b/docs/CONTRIBUTING.en.md
@@ -168,6 +168,7 @@ Before requesting a review, verify:
 - [ ] The pre-PR component review has passed or is documented.
 - [ ] Tokens from `theme.css` are used (no hardcoded colors; arbitrary sizing/typography only in approved compact/dense CVA variants).
 - [ ] ARIA attributes are implemented for interactable elements.
+- [ ] Visual height aligns with the semantic scale that applies (`control` for actions, `form-field` for fields); `touch-target-min` (`44px`) is reserved for touch-first surfaces or hit-area wrappers. Documented compact/dense variants may be smaller if they keep keyboard/focus accessibility.
 - [ ] Conventional Commits are used for commit messages and the PR title.
 - [ ] Security checks pass, or any false positives are documented in the PR.
 - [ ] MCP cleanup ran before commit/review: `rm -rf .playwright-mcp page-*.png page-*.jpeg *.md.playwright-output`.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -173,7 +173,7 @@ Antes de pedir revisión, verifica:
 - [ ] Focus ring via `box-shadow` — nunca `outline` sin alternativa visible.
 - [ ] Disabled via `opacity: 0.4` — sin sustitución de color.
 - [ ] Sin `transition: all` — propiedades específicas enumeradas.
-- [ ] Touch target mínimo `44×44px` en controles interactivos por defecto; variantes compactas/densas explícitamente aprobadas pueden ser menores si conservan accesibilidad por teclado/focus.
+- [ ] Altura visual alineada con la escala semántica que aplique (`control` para acciones, `form-field` para campos); `touch-target-min` (`44px`) reservado para superficies touch-first o wrappers de hit area. Variantes compactas/densas documentadas pueden ser menores si conservan accesibilidad por teclado/focus.
 - [ ] Limpieza MCP hecha antes de commit/review: `rm -rf .playwright-mcp page-*.png page-*.jpeg *.md.playwright-output`.
 
 ### Checks de seguridad

--- a/docs/CONTRIBUTOR-FLOW.en.md
+++ b/docs/CONTRIBUTOR-FLOW.en.md
@@ -339,7 +339,7 @@ It must verify:
 
 - base, hover, focus, active/pressed, disabled;
 - focus-visible with `box-shadow`, never naked `outline`;
-- minimum `44×44px` touch target on default variants; explicitly approved compact/dense variants may be smaller if they keep keyboard accessibility and focus;
+- visual height aligned with the semantic scale that applies (`control` for actions, `form-field` for fields), and `touch-target-min` (`44px`) only for touch-first surfaces or hit-area wrappers; documented compact/dense variants may be smaller if they keep keyboard accessibility and focus;
 - contrast in light/dark;
 - explicit transitions, never `transition-all`;
 - no layout-property animation;

--- a/docs/CONTRIBUTOR-FLOW.md
+++ b/docs/CONTRIBUTOR-FLOW.md
@@ -338,7 +338,7 @@ Debe verificar:
 
 - base, hover, focus, active/pressed, disabled;
 - focus visible con `box-shadow`, nunca `outline` desnudo;
-- touch target mínimo `44×44px` en variantes por defecto; las variantes compactas/densas explícitamente aprobadas pueden ser menores si conservan accesibilidad por teclado y focus;
+- altura visual alineada con la escala semántica que aplique (`control` para acciones, `form-field` para campos), y `touch-target-min` (`44px`) solo para superficies touch-first o wrappers de hit area; las variantes compactas/densas documentadas pueden ser menores si conservan accesibilidad por teclado y focus;
 - contraste en light/dark;
 - transiciones específicas, nunca `transition-all`;
 - no animar propiedades de layout;

--- a/docs/DESIGN.en.md
+++ b/docs/DESIGN.en.md
@@ -642,11 +642,13 @@ All text values on their respective backgrounds meet at least WCAG AA (4.5:1). P
 > ⚠️ `#6a6b6c` (disabled/muted) does not meet AA on dark backgrounds — that is acceptable: WCAG explicitly exempts `disabled` states from the contrast requirement.
 
 ### Touch targets
-- Pill buttons: default minimum height `44px`
-- Action scale `xs | sm | md | lg`: `xs` is the dense compact variant for `Button`, `IconButton`, and CTA `Link` (`button` / `outlined`), with lower height and padding; use `sm` or above when you need to preserve the `44px` target
-- `Link` `regular` remains typographic and inline; CTA `sm` and above keep the minimum `44px` area
-- Nav links: minimum `44px` height including padding
-- Menu items: minimum `padding: 7px 12px` with 14px font
+- Shared visual control height uses the `control` scale: `xs = 24px`, `sm = 32px`, `md = 40px`, `lg = 48px`.
+- Tailwind v4 tokens: `--spacing-control-xs|sm|md|lg` generate `h-control-*` and `w-control-*`; `--spacing-form-field-sm|md|lg` generate `h-form-field-*`; `--spacing-touch-target-min` generates `min-h-touch-target-min`, `min-w-touch-target-min`, and `size-touch-target-min`.
+- `Button`, `IconButton`, and CTA `Link` (`button` / `outlined`) use that shared visual scale. `Link` `regular` remains typographic and inline.
+- `Input` and `Select` use the semantic `form-field` scale: `sm = 48px`, `md = 56px`, `lg = 64px`, because their height accounts for label, floating label, adornments, and field-to-field alignment.
+- `--spacing-touch-target-min` (`44px`) is touch-target guidance, not a universal visual height. Use it for touch-first surfaces or to expand the hit area of compact controls like `Checkbox` and `Switch` without enlarging their visible shape.
+- Other documented exceptions: `TextArea` stays multiline/content-driven; `Chip` keeps a compact tag/token scale; `Badge` remains informational, not a general interactive control.
+- Nav links and menu items should still provide a comfortable area in touch-first contexts, even when their visual height does not necessarily use the `control` scale.
 
 ### Focus visible
 - All interactive elements use `focus-visible` with `box-shadow: 0 0 0 3px rgba(255,0,54,0.4)` in dark mode and `box-shadow: 0 0 0 3px rgba(219,20,60,0.35)` in light mode

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -652,11 +652,13 @@ Todos los valores de texto sobre sus respectivos fondos cumplen WCAG AA (4.5:1) 
 > ⚠️ `#6a6b6c` (disabled/muted) no cumple AA sobre los fondos dark — es correcto: WCAG exime explícitamente los estados `disabled` del requisito de contraste.
 
 ### Targets táctiles
-- Botones pill: altura mínima por defecto `44px`
-- Escala de acciones `xs | sm | md | lg`: `xs` es la variante compacta densa para `Button`, `IconButton` y `Link` CTA (`button` / `outlined`), con menor altura y padding; usá `sm` o superior cuando necesitás conservar el target de `44px`
-- `Link` `regular` sigue siendo tipográfico e inline; los CTA `sm` y superiores mantienen el área mínima de `44px`
-- Nav links: área mínima `44px` de alto incluyendo padding
-- Elementos de menú: `padding: 7px 12px` mínimo con font 14px
+- La altura visual de los controles compartidos se define con la escala `control`: `xs = 24px`, `sm = 32px`, `md = 40px`, `lg = 48px`.
+- Tokens Tailwind v4: `--spacing-control-xs|sm|md|lg` generan utilidades `h-control-*` y `w-control-*`; `--spacing-form-field-sm|md|lg` generan `h-form-field-*`; `--spacing-touch-target-min` genera `min-h-touch-target-min`, `min-w-touch-target-min` y `size-touch-target-min`.
+- `Button`, `IconButton` y `Link` CTA (`button` / `outlined`) usan esa escala visual compartida. `Link` `regular` sigue siendo tipográfico e inline.
+- `Input` y `Select` usan la escala semántica `form-field`: `sm = 48px`, `md = 56px`, `lg = 64px`, porque su altura contempla label, floating label, adornments y alineación entre campos.
+- `--spacing-touch-target-min` (`44px`) es una guía de target táctil, no una altura visual universal. Úsalo para superficies touch-first o para ampliar el hit area de controles compactos como `Checkbox` y `Switch` sin agrandar su forma visible.
+- Otras excepciones documentadas: `TextArea` sigue siendo multiline/content-driven; `Chip` conserva una escala compacta de tag/token; `Badge` sigue siendo informativo, no un control interactivo general.
+- Nav links y elementos de menú deben seguir ofreciendo un área cómoda en contextos touch-first, aunque su altura visual no use necesariamente la escala `control`.
 
 ### Focus visible
 - Todos los elementos interactivos tienen `focus-visible` con `box-shadow: 0 0 0 3px rgba(255,0,54,0.4)` en dark y `box-shadow: 0 0 0 3px rgba(219,20,60,0.35)` en light

--- a/src/components/atoms/button/Button.test.tsx
+++ b/src/components/atoms/button/Button.test.tsx
@@ -113,7 +113,7 @@ describe('useButton — logic', () => {
 
   it('derives compact classes from size xs', () => {
     const { result } = renderHook(() => useButton({ text: 'Button', size: 'xs' }));
-    expect(result.current.className).toContain('h-9');
+    expect(result.current.className).toContain('h-control-xs');
     expect(result.current.className).toContain('px-2');
     expect(result.current.contentClassName).toContain('gap-1');
   });

--- a/src/components/atoms/button/types.ts
+++ b/src/components/atoms/button/types.ts
@@ -53,10 +53,10 @@ export const buttonVariants = cva(
         false: ''
       },
       size: {
-        xs: 'h-9 px-2 fs-xs',
-        sm: 'px-sm h-11 fs-small',
-        md: 'px-md h-11 fs-base',
-        lg: 'px-lg h-12 fs-h6'
+        xs: 'h-control-xs px-2 fs-xs',
+        sm: 'px-sm h-control-sm fs-small',
+        md: 'px-md h-control-md fs-base',
+        lg: 'px-lg h-control-lg fs-h6'
       },
       fullWidth: {
         true: 'w-full',

--- a/src/components/atoms/checkbox/Checkbox.test.tsx
+++ b/src/components/atoms/checkbox/Checkbox.test.tsx
@@ -138,6 +138,8 @@ describe('useCheckbox — logic', () => {
     const { result } = renderHook(() => useCheckbox({ label: 'Accept terms' }));
 
     expect(result.current.inputProps.className).toContain('peer');
+    expect(result.current.inputProps.className).toContain('h-touch-target-min');
+    expect(result.current.inputProps.className).toContain('w-touch-target-min');
     expect(result.current.controlClassName).toContain('peer-hover:bg-surface-raised-light');
     expect(result.current.controlClassName).toContain('peer-active:scale-[0.98]');
     expect(result.current.controlClassName).toContain('peer-focus-visible:shadow-glow-focus-light');

--- a/src/components/atoms/checkbox/types.ts
+++ b/src/components/atoms/checkbox/types.ts
@@ -38,7 +38,7 @@ export const checkboxHitArea = cva('relative inline-flex shrink-0 items-center j
 });
 
 export const checkboxInput = cva(
-  'peer absolute top-1/2 right-0 z-10 m-0 h-11 w-11 -translate-y-1/2 appearance-none rounded-xs opacity-0',
+  'peer absolute top-1/2 right-0 z-10 m-0 h-touch-target-min w-touch-target-min -translate-y-1/2 appearance-none rounded-xs opacity-0',
   {
     variants: {
       disabled: {

--- a/src/components/atoms/icon-button/IconButton.stories.tsx
+++ b/src/components/atoms/icon-button/IconButton.stories.tsx
@@ -10,7 +10,7 @@ import { IconButton } from './IconButton';
  * Uses Lucide dynamic icons for the visual glyph.
  *
  * ## Usage Guide
- * Provide a meaningful accessible name with `title`, `ariaLabel`, or `aria-label`. Use `xs` for dense, visibly shorter controls and `sm` or above for the 44px action target; legacy numeric sizes keep the exact icon size and map the button target to the closest named size. Use `emphasis='flat'` when a quiet context needs to reduce decorative glow without removing accessible focus feedback. Use `aria-pressed` only to announce toggle-button state to assistive technology.
+ * Provide a meaningful accessible name with `title`, `ariaLabel`, or `aria-label`. Named sizes use the shared `control` scale (`xs` 24px, `sm` 32px, `md` 40px, `lg` 48px); use touch-first wrappers or `lg` when target size matters. Legacy numeric sizes keep the exact icon size and map the button target to the closest named size. Use `emphasis='flat'` when a quiet context needs to reduce decorative glow without removing accessible focus feedback. Use `aria-pressed` only to announce toggle-button state to assistive technology.
  */
 const meta: Meta<typeof IconButton> = {
   title: 'Atoms/IconButton',

--- a/src/components/atoms/icon-button/IconButton.test.tsx
+++ b/src/components/atoms/icon-button/IconButton.test.tsx
@@ -58,8 +58,8 @@ describe('useIconButton — logic', () => {
     expect(smallResult.current.size).toBe('sm');
     expect(largeResult.current.iconSize).toBe(24);
     expect(largeResult.current.size).toBe('lg');
-    expect(compactResult.current.className).toContain('h-9');
-    expect(compactResult.current.className).toContain('w-9');
+    expect(compactResult.current.className).toContain('h-control-xs');
+    expect(compactResult.current.className).toContain('w-control-xs');
     expect(compactResult.current.className).not.toBe(largeResult.current.className);
   });
 

--- a/src/components/atoms/icon-button/types.ts
+++ b/src/components/atoms/icon-button/types.ts
@@ -49,10 +49,10 @@ export const iconButtonVariants = cva(
         flat: ''
       },
       size: {
-        xs: 'h-9 w-9',
-        sm: 'h-11 w-11',
-        md: 'h-12 w-12',
-        lg: 'h-14 w-14'
+        xs: 'h-control-xs w-control-xs',
+        sm: 'h-control-sm w-control-sm',
+        md: 'h-control-md w-control-md',
+        lg: 'h-control-lg w-control-lg'
       }
     },
     compoundVariants: [

--- a/src/components/atoms/input/Input.test.tsx
+++ b/src/components/atoms/input/Input.test.tsx
@@ -94,10 +94,19 @@ describe('useInput — logic', () => {
     expect(result.current.wrapperClassName).toContain('w-full');
   });
 
+  it.each([
+    ['sm', 'h-form-field-sm'],
+    ['md', 'h-form-field-md'],
+    ['lg', 'h-form-field-lg']
+  ] as const)('maps %s size to the form-field height scale', (size, heightClassName) => {
+    const { result } = renderHook(() => useInput({ id: 'email', label: 'Email', size, startContent: '$' }));
+
+    expect(result.current.containerProps.className).toContain(heightClassName);
+  });
+
   it('uses compact content spacing for the small size', () => {
     const { result } = renderHook(() => useInput({ id: 'email', label: 'Email', size: 'sm', startContent: '$' }));
 
-    expect(result.current.containerProps.className).toContain('h-12');
     expect(result.current.containerProps.className).toContain('px-3');
     expect(result.current.contentClassName).toContain('gap-2');
     expect(result.current.adornmentClassName).toContain('fs-small');

--- a/src/components/atoms/input/types.ts
+++ b/src/components/atoms/input/types.ts
@@ -33,9 +33,9 @@ export const inputVariants = cva(
         false: 'rounded-md'
       },
       size: {
-        sm: 'h-12 px-3 fs-small',
-        md: 'h-14 px-4 fs-base',
-        lg: 'h-16 px-4 fs-h6'
+        sm: 'h-form-field-sm px-3 fs-small',
+        md: 'h-form-field-md px-4 fs-base',
+        lg: 'h-form-field-lg px-4 fs-h6'
       },
       status: {
         default: '',

--- a/src/components/atoms/link/Link.stories.tsx
+++ b/src/components/atoms/link/Link.stories.tsx
@@ -19,7 +19,7 @@ const VariantRow = ({ children }: { children: ReactNode }) => (
  * Uses `lucide-react/dynamic.js` when the optional `icon` prop is provided.
  *
  * ## Usage Guide
- * Use `regular` for inline navigation, `outlined` for secondary call-to-action links, and `button` when a link must visually match a primary action while preserving link semantics when `href` is present. `size='xs'` makes action links denser through smaller type, icon, gap, padding, and height; use `sm` or above when the 44px action target is required. Use `emphasis='flat'` to reduce decorative glow on CTA variants without removing accessible focus feedback. When `href` is omitted, Link behaves as a local action control with button semantics and keyboard activation.
+ * Use `regular` for inline navigation, `outlined` for secondary call-to-action links, and `button` when a link must visually match a primary action while preserving link semantics when `href` is present. CTA link sizes use the shared `control` visual-height scale (`xs` 24px, `sm` 32px, `md` 40px, `lg` 48px); evaluate the 44px touch target separately for touch-first contexts. Use `emphasis='flat'` to reduce decorative glow on CTA variants without removing accessible focus feedback. When `href` is omitted, Link behaves as a local action control with button semantics and keyboard activation.
  */
 const meta: Meta<typeof Link> = {
   title: 'Atoms/Link',

--- a/src/components/atoms/link/Link.test.tsx
+++ b/src/components/atoms/link/Link.test.tsx
@@ -79,13 +79,13 @@ describe('useLink — logic', () => {
     expect(result.current.iconWidth).toBe(16);
   });
 
-  it('makes CTA-style xs visibly shorter while keeping sm at the 44px target height', () => {
+  it('maps CTA-style links to the shared control-height scale', () => {
     const { result: compactResult } = renderHook(() => useLink({ children: 'Docs', variant: 'button', size: 'xs' }));
     const { result: smallResult } = renderHook(() => useLink({ children: 'Docs', variant: 'outlined', size: 'sm' }));
 
-    expect(compactResult.current.className).toContain('h-9');
+    expect(compactResult.current.className).toContain('h-control-xs');
     expect(compactResult.current.className).toContain('px-2');
-    expect(smallResult.current.className).toContain('h-11');
+    expect(smallResult.current.className).toContain('h-control-sm');
   });
 
   it('suppresses decorative glow when emphasis is flat on CTA variants', () => {

--- a/src/components/atoms/link/types.ts
+++ b/src/components/atoms/link/types.ts
@@ -46,10 +46,10 @@ export const linkVariants = cva(
       }
     },
     compoundVariants: [
-      { variant: ['button', 'outlined'], size: 'xs', class: 'h-9 gap-0-75 px-2' },
-      { variant: ['button', 'outlined'], size: 'sm', class: 'h-11 gap-1 px-sm' },
-      { variant: ['button', 'outlined'], size: 'md', class: 'h-11 gap-1.5 px-md' },
-      { variant: ['button', 'outlined'], size: 'lg', class: 'h-12 gap-2 px-lg' },
+      { variant: ['button', 'outlined'], size: 'xs', class: 'h-control-xs gap-0-75 px-2' },
+      { variant: ['button', 'outlined'], size: 'sm', class: 'h-control-sm gap-1 px-sm' },
+      { variant: ['button', 'outlined'], size: 'md', class: 'h-control-md gap-1.5 px-md' },
+      { variant: ['button', 'outlined'], size: 'lg', class: 'h-control-lg gap-2 px-lg' },
       {
         variant: 'button',
         emphasis: 'default',

--- a/src/components/atoms/select/Select.test.tsx
+++ b/src/components/atoms/select/Select.test.tsx
@@ -131,6 +131,7 @@ describe('Select — render', () => {
 
     await user.click(screen.getByRole('combobox'));
     expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveClass('min-h-11');
     expect(screen.getByTestId('select-spinner')).toBeInTheDocument();
     expect(screen.getByText('Loading countries')).toBeInTheDocument();
   });
@@ -635,10 +636,16 @@ describe('Select — accessibility', () => {
 });
 
 describe('Select — size and variant smoke coverage', () => {
-  it.each(['sm', 'md', 'lg'] as const)('renders %s size as an accessible combobox', (size) => {
-    render(<Select label='Country' options={defaultOptions} size={size} placeholder='Select...' />);
+  it.each([
+    ['sm', 'h-form-field-sm'],
+    ['md', 'h-form-field-md'],
+    ['lg', 'h-form-field-lg']
+  ] as const)('maps %s size to the form-field height scale', (size, heightClassName) => {
+    const { result } = renderHook(() =>
+      useSelect({ label: 'Country', options: defaultOptions, size, placeholder: 'Select...' })
+    );
 
-    expect(screen.getByRole('combobox', { name: 'Country' })).toBeInTheDocument();
+    expect(result.current.triggerClassName).toContain(heightClassName);
   });
 
   it.each([

--- a/src/components/atoms/select/Select.test.tsx
+++ b/src/components/atoms/select/Select.test.tsx
@@ -131,7 +131,7 @@ describe('Select — render', () => {
 
     await user.click(screen.getByRole('combobox'));
     expect(screen.getByRole('listbox')).toBeInTheDocument();
-    expect(screen.getByRole('status')).toHaveClass('min-h-11');
+    expect(screen.getByRole('status')).toHaveClass('min-h-touch-target-min');
     expect(screen.getByTestId('select-spinner')).toBeInTheDocument();
     expect(screen.getByText('Loading countries')).toBeInTheDocument();
   });

--- a/src/components/atoms/select/types.ts
+++ b/src/components/atoms/select/types.ts
@@ -64,9 +64,9 @@ export const selectTrigger = cva(
         ]
       },
       size: {
-        sm: 'h-12 px-3 fs-small gap-2',
-        md: 'h-14 px-4 fs-base gap-3',
-        lg: 'h-16 px-4 fs-h6 gap-3'
+        sm: 'h-form-field-sm px-3 fs-small gap-2',
+        md: 'h-form-field-md px-4 fs-base gap-3',
+        lg: 'h-form-field-lg px-4 fs-h6 gap-3'
       },
       status: {
         default: '',

--- a/src/components/atoms/select/types.ts
+++ b/src/components/atoms/select/types.ts
@@ -252,7 +252,7 @@ export const selectLabel = cva(
 );
 
 export const selectLoadingVariants = cva(
-  'flex min-h-11 items-center justify-center gap-2 px-3 py-2 text-sm text-text-secondary-light dark:text-text-secondary-dark'
+  'flex min-h-touch-target-min items-center justify-center gap-2 px-3 py-2 text-sm text-text-secondary-light dark:text-text-secondary-dark'
 );
 
 export const selectClearButton = cva([

--- a/src/components/atoms/switch/Switch.test.tsx
+++ b/src/components/atoms/switch/Switch.test.tsx
@@ -45,6 +45,8 @@ describe('useSwitch — logic', () => {
   it('returns computed class names without exposing CVA logic to the component', () => {
     const { result } = renderHook(() => useSwitch({ label: 'Notifications' }));
     expect(result.current.rootClassName).toEqual(expect.any(String));
+    expect(result.current.switchWrapper).toContain('min-h-touch-target-min');
+    expect(result.current.switchWrapper).toContain('min-w-touch-target-min');
     expect(result.current.switchTrack).toEqual(expect.any(String));
     expect(result.current.switchThumb).toEqual(expect.any(String));
   });

--- a/src/components/atoms/switch/types.ts
+++ b/src/components/atoms/switch/types.ts
@@ -29,7 +29,7 @@ export const switchBase = cva(
 
 export const switchWrapper = cva(
   [
-    'relative inline-flex min-h-11 min-w-11 shrink-0 items-center justify-center',
+    'relative inline-flex min-h-touch-target-min min-w-touch-target-min shrink-0 items-center justify-center',
     'cursor-pointer transition-opacity duration-200 ease-out'
   ],
   {

--- a/src/components/molecules/snippet/Snippet.test.tsx
+++ b/src/components/molecules/snippet/Snippet.test.tsx
@@ -206,7 +206,7 @@ describe('Snippet — component behavior', () => {
     const code = screen.getByText('pnpm install');
 
     expect(button).toHaveAttribute('aria-controls', 'install-snippet-content');
-    expect(button).toHaveClass('h-9', 'w-9');
+    expect(button).toHaveClass('h-control-xs', 'w-control-xs');
     expect(screen.getByTestId('snippet-icon')).toHaveAttribute('data-size', '14');
     expect(code.closest('pre')).toHaveAttribute('id', 'install-snippet-content');
     expect(screen.getByText('pnpm install').parentElement?.parentElement).not.toHaveAttribute(

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -411,6 +411,14 @@
   --spacing-8: 2rem; /* 32px */
   --spacing-10: 2.5rem; /* 40px */
   --spacing-12: 3rem; /* 48px */
+  --spacing-control-xs: 1.5rem; /* 24px */
+  --spacing-control-sm: 2rem; /* 32px */
+  --spacing-control-md: 2.5rem; /* 40px */
+  --spacing-control-lg: 3rem; /* 48px */
+  --spacing-form-field-sm: 3rem; /* 48px */
+  --spacing-form-field-md: 3.5rem; /* 56px */
+  --spacing-form-field-lg: 4rem; /* 64px */
+  --spacing-touch-target-min: 2.75rem; /* 44px */
   --spacing-16: 4rem; /* 64px */
   --spacing-20: 5rem; /* 80px */
   --spacing-24: 6rem; /* 96px */


### PR DESCRIPTION
## Summary

- Adds semantic sizing tokens for action controls, form fields, and contextual touch targets.
- Aligns Button, IconButton, and CTA Link to `control-*` sizing while keeping Input/Select on `form-field-*` sizing.
- Updates docs, stories, tests, and agent skills so future component work follows the same sizing model.

Closes #272

## Review scope

- Primary files/areas:
  - `src/styles/theme.css`
  - `src/components/atoms/{button,icon-button,link,input,select,checkbox,switch}/`
  - `docs/COMPONENTS*.md`, `docs/DESIGN*.md`, `docs/CONTRIBUTING*.md`, `docs/CONTRIBUTOR-FLOW*.md`
  - `.atl/skills/*`
- Out of scope:
  - visual variant redesigns, color/token cleanup beyond sizing, public API changes, and forcing every control to be 44px tall.
- Review workload: medium; 31 focused files touched, mostly token/class mappings, tests, and mirrored docs/skills.

## Type of change

- [ ] New component
- [x] Existing component update/refactor
- [ ] Bug fix
- [ ] Accessibility
- [x] Design tokens
- [x] Storybook/docs
- [ ] Infrastructure/tooling
- [ ] NPM/dependencies

## Workflow gates

- [x] Linked issue is present with `Closes #NNN` or maintainer approved an exception.
- [x] Linked issue has label `status:approved` before implementation starts.
- [x] Linked issue assignee was checked before work started; if it was assigned to someone else, explicit reassignment permission is documented.
- [x] Work was started through the Project flow: assignee set, Project status `In progress`, branch/worktree recorded.
- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`.
- [x] Commits follow the same commitlint-enforced format.
- [x] Diff is focused; unrelated work is called out in Review scope.
- [x] MCP/runtime artifacts are absent: `.playwright-mcp`, `page-*.png`, `page-*.jpeg`, `*.md.playwright-output`.

## Component evidence (required for component changes)

- [x] Validated component spec is linked or quoted in the issue.
- [x] Accessibility contract from the spec was implemented or deviations are explained below.
- [x] Follows the 6-file pattern: existing component file structure preserved.
- [x] CVA variants live in `types.ts`; JSX component has no state, CVA calls, or business logic.
- [x] Public props with runtime defaults have matching `@default` JSDoc in `types.ts` (`node scripts/verify-prop-default-docs.mjs`).
- [x] Uses design tokens from `theme.css`; no hardcoded colors or arbitrary color utilities.
- [x] Storybook covers affected sizing guidance for action components.
- [x] Component audit result is PASS from fresh review.
- [x] Visual review result is included: Storybook dev server loaded after cache reset; user visual inspection requested.

## Accessibility evidence

- [x] Role/name semantics verified with Testing Library queries or equivalent.
- [x] Keyboard-only behavior verified by existing component interaction tests.
- [x] Focus lifecycle verified by existing component tests and unchanged focus classes.
- [x] Disabled, required, invalid/error, loading, and empty states expose the expected semantics where applicable.
- [x] Reduced motion behavior is respected where motion changed. N/A: no motion behavior changed.
- [x] Screen reader or axe/manual evidence is included below when applicable. N/A: sizing/token change only; semantics unchanged.

## Validation evidence

- TypeScript: `pnpm exec tsc --noEmit` passed.
- Unit tests:
  - `pnpm vitest run src/components/atoms/input/Input.test.tsx src/components/atoms/select/Select.test.tsx` passed: 113 tests.
  - `pnpm test` passed post-rebase: 35 files / 742 tests.
  - pre-push hook reran `pnpm test`: 35 files / 742 tests passed.
- Build/package: `pnpm build` passed post-rebase.
- Storybook or visual check: `pnpm run storybook` loaded at `http://localhost:6006/` after clearing Storybook Vite cache; only harmless `favicon.svg` 404 remained.
- Accessibility check: focused tests verify semantics remain intact; `Checkbox`/`Switch` hit areas now use `touch-target-min` without changing compact visual controls.
- Security/dependency check: not applicable; no dependency or script changes.

## Screenshots or recordings

Not attached. Storybook was run locally for visual inspection.

## Notes for reviewer

Sizing model is now explicit:

- `control-*` tokens: action controls (`Button`, `IconButton`, CTA `Link`).
- `form-field-*` tokens: labeled form fields (`Input`, `Select`) and future field-like components.
- `touch-target-min`: contextual hit area guidance for touch-first surfaces or wrappers.

The branch was rebased onto `origin/main` after #276. One conflict in `.atl/skills/component-contributor/SKILL.md` was resolved by preserving both info-state guidance and the new sizing preflight guidance; a fresh post-rebase audit passed.