### PR TITLE
perf(storybook): improve deployed build performance

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 *.ts whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol
 *.tsx whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol
 *.css whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol
+*.js whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol
+*.mjs whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol
+*.json whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -43,20 +43,14 @@ const config: StorybookConfig = {
       cache: false,
       build: {
         rollupOptions: {
-          treeshake: false,
           output: {
-            assetFileNames: (assetInfo: { name?: string }) => {
-              if (assetInfo.name?.includes('preview') && assetInfo.name?.endsWith('.css')) {
-                return 'assets/preview.css';
-              }
-              return assetInfo.name ? `assets/${assetInfo.name}` : 'assets/[name].[hash][extname]';
-            }
+            assetFileNames: 'assets/[name]-[hash][extname]'
           }
         }
       },
       css: {
         preprocessorOptions: {
-          postcss: true // Asegúrate de que PostCSS esté habilitado
+          postcss: true // Ensure PostCSS stays enabled for Storybook styles.
         }
       }
     });

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,3 +1,2 @@
 <title>@egdev6 Design System</title>
 <link rel="icon" href="/images/favicon.svg" type="image/svg+xml">
-<link href="../src/styles/global.css" rel="stylesheet">

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,27 @@
 [build]
   command = "pnpm run storybook-build"
   publish = "storybook-static"
+
+[[headers]]
+  for = "/"
+
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/index.html"
+
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/iframe.html"
+
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/assets/*"
+
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "biome-staged": "biome check --write --no-errors-on-unmatched --files-ignore-unknown=true",
     "storybook": "storybook dev -p 6006",
     "storybook-build": "storybook build && node scripts/inject-preview-head.js",
+    "storybook-report": "node scripts/report-storybook-build.mjs",
     "storybook-clean-cache": "node -e \"require('fs').rmSync('node_modules/.cache/storybook',{recursive:true,force:true})\"",
     "pre-commit": "pnpm run biome-staged && tsc",
     "test": "vitest run",

--- a/scripts/inject-preview-head.js
+++ b/scripts/inject-preview-head.js
@@ -37,14 +37,12 @@ if (previewHeadContent) {
   indexContent = indexContent.replace(/<link rel="icon".*?>/g, '');
   indexContent = indexContent.replace(/@font-face {[^}]*?Nunito Sans[^}]*?}/g, '');
 
-  // Inject the preview-head.html contents into the index.html head.
+  // Inject the preview-head.html metadata into the index.html head.
   const updatedIndexContent = indexContent.replace('</head>', `${previewHeadContent}\n</head>`);
 
   // Write the changes to index.html.
   fs.writeFileSync(indexPath, updatedIndexContent, 'utf-8');
-  console.log(
-    'Styles from preview-head.html and captured CSS link have been injected into index.html, and unwanted content has been removed.'
-  );
+  console.log('Injected preview-head metadata into index.html and removed Storybook default head entries.');
 
   // Read the contents of iframe.html.
   let iframeContent = fs.readFileSync(iframePath, 'utf-8');
@@ -55,9 +53,7 @@ if (previewHeadContent) {
   // Write the changes to iframe.html.
   const updatedIframeContent = iframeContent;
   fs.writeFileSync(iframePath, updatedIframeContent, 'utf-8');
-  console.log(
-    'Styles from preview-head.html have been injected into iframe.html, and unwanted content has been removed.'
-  );
+  console.log('Normalized iframe.html head entries after Storybook build.');
 } else {
-  console.warn('preview-head.html not found or is empty. No changes made to index.html.');
+  console.warn('preview-head.html not found or empty. Skipped index.html metadata injection.');
 }

--- a/scripts/report-storybook-build.mjs
+++ b/scripts/report-storybook-build.mjs
@@ -1,0 +1,69 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const outputDir = path.resolve(process.cwd(), process.argv[2] ?? 'storybook-static');
+
+if (!fs.existsSync(outputDir)) {
+  console.error(`Storybook output directory not found: ${outputDir}`);
+  process.exit(1);
+}
+
+const formatBytes = (bytes) => {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+
+  const units = ['KiB', 'MiB', 'GiB'];
+  let value = bytes;
+  let unitIndex = -1;
+
+  do {
+    value /= 1024;
+    unitIndex += 1;
+  } while (value >= 1024 && unitIndex < units.length - 1);
+
+  return `${value.toFixed(value >= 10 ? 1 : 2)} ${units[unitIndex]}`;
+};
+
+const walk = (dir) => {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+  return entries.flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      return walk(fullPath);
+    }
+
+    return [fullPath];
+  });
+};
+
+const files = walk(outputDir).map((fullPath) => {
+  const stats = fs.statSync(fullPath);
+
+  return {
+    fullPath,
+    relativePath: path.relative(outputDir, fullPath),
+    size: stats.size
+  };
+});
+
+const totalBytes = files.reduce((sum, file) => sum + file.size, 0);
+const jsFiles = files.filter((file) => file.relativePath.endsWith('.js'));
+const jsBytes = jsFiles.reduce((sum, file) => sum + file.size, 0);
+const topAssets = files
+  .filter((file) => file.relativePath.startsWith('assets/'))
+  .sort((a, b) => b.size - a.size)
+  .slice(0, 10);
+
+console.log('Storybook build report');
+console.log(`Directory: ${outputDir}`);
+console.log(`Total size: ${formatBytes(totalBytes)} (${totalBytes} bytes)`);
+console.log(`JavaScript files: ${jsFiles.length}`);
+console.log(`Raw JavaScript size: ${formatBytes(jsBytes)} (${jsBytes} bytes)`);
+console.log('Top assets:');
+
+for (const asset of topAssets) {
+  console.log(`- ${formatBytes(asset.size)}  ${asset.relativePath}`);
+}


### PR DESCRIPTION
## Summary

- Removes the deployed Storybook startup request for `../src/styles/global.css` while keeping the runtime preview CSS import.
- Restores Storybook build treeshaking and hashed asset output so generated assets can be cached safely.
- Adds Netlify cache headers and a repeatable Storybook build-size report command.

Closes #273

## Review scope

- Primary files/areas: Storybook build config, Storybook head post-processing, Netlify headers, build reporting script.
- Out of scope: removing/gating Storybook addons, rewriting component stories, changing component runtime code.
- Review workload: small; focused infra/config/script diff.

## Type of change

- [ ] New component
- [ ] Existing component update/refactor
- [ ] Bug fix
- [ ] Accessibility
- [ ] Design tokens
- [ ] Storybook/docs
- [x] Infrastructure/tooling
- [ ] NPM/dependencies

## Workflow gates

- [x] Linked issue is present with `Closes #NNN` or maintainer approved an exception.
- [x] Linked issue has label `status:approved` before implementation starts.
- [x] Linked issue assignee was checked before work started; if it was assigned to someone else, explicit reassignment permission is documented.
- [x] Work was started through the Project flow: assignee set, Project status `In progress`, branch/worktree recorded.
- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`.
- [x] Commits follow the same commitlint-enforced format.
- [x] Diff is focused; unrelated work is called out in Review scope.
- [x] MCP/runtime artifacts are absent: `.playwright-mcp`, `page-*.png`, `page-*.jpeg`, `*.md.playwright-output`.

## Component evidence (required for component changes)

- [ ] Validated component spec is linked or quoted in the issue.
- [ ] Accessibility contract from the spec was implemented or deviations are explained below.
- [ ] Follows the 6-file pattern: `types.ts`, `use*.ts`, `Component.tsx`, `Component.test.tsx`, `Component.stories.tsx`, `index.ts`.
- [ ] CVA variants live in `types.ts`; JSX component has no state, CVA calls, or business logic.
- [ ] Public props with runtime defaults have matching `@default` JSDoc in `types.ts` (`node scripts/verify-prop-default-docs.mjs`).
- [ ] Uses design tokens from `theme.css`; no hardcoded colors or arbitrary color utilities.
- [ ] Storybook covers default, variants, documented states, edge cases, and dark mode when visually different.
- [ ] Component audit result is PASS or accepted PASS WITH WARNINGS.
- [ ] Visual review result is included when visuals changed.

N/A — no component runtime changes.

## Accessibility evidence

- [ ] Role/name semantics verified with Testing Library queries or equivalent.
- [ ] Keyboard-only behavior verified: Tab / Shift+Tab, Enter / Space, Arrow keys, Escape, Home / End / typeahead where applicable.
- [ ] Focus lifecycle verified: initial focus, roving/active descendant, focus restore, trap/portal behavior where applicable.
- [ ] Disabled, required, invalid/error, loading, and empty states expose the expected semantics where applicable.
- [ ] Reduced motion behavior is respected where motion changed.
- [ ] Screen reader or axe/manual evidence is included below when applicable.

N/A — no component behavior or accessibility contract changed. Storybook a11y addon remains enabled.

## Validation evidence

- TypeScript: `pnpm exec tsc --noEmit` ✅
- Unit tests: `pnpm test` via pre-push hook ✅ — 35 files / 745 tests passed
- Build/package: `pnpm run storybook-build` ✅
- Storybook or visual check:
  - `pnpm run storybook-report` ✅
  - No built/head-fragment `../src/styles/global.css` reference ✅
  - Preview CSS import remains in `.storybook/preview.tsx` ✅
  - Baseline raw JS: 9,449,330 bytes / 1856 files
  - Updated raw JS: 8,917,497 bytes / 1847 files (`-531,833`, `-5.63%`)
- Accessibility check: Storybook a11y addon preserved; no component a11y behavior changed.
- Security/dependency check: N/A — no dependency or lockfile changes.

## Screenshots or recordings

N/A — config/build change. Deploy smoke check should verify headers and network requests on the Netlify preview.

## Notes for reviewer

- Netlify headers still need verification on the deployed preview for `/`, `/index.html`, `/iframe.html`, and one hashed `/assets/*` file.
- Heavy addons intentionally remain in scope-preserving mode; further addon gating can be handled in a follow-up if desired.
- Maintainer approval to proceed was captured in the working session before implementation; GitHub `status:approved`, assignee, and Project `In progress` were updated before opening this PR.
