### PR TITLE
feat(autocomplete): implement searchable single-select component

### DIFF
--- a/src/components/atoms/autocomplete/Autocomplete.stories.tsx
+++ b/src/components/atoms/autocomplete/Autocomplete.stories.tsx
@@ -269,13 +269,3 @@ export const WithDisabledOptions: Story = {
     ]
   }
 };
-
-/**
- * Shows the single-result Enter flow by narrowing the list to one expected match through the initial data set.
- */
-export const SingleMatchEnter: Story = {
-  args: {
-    ...Default.args,
-    options: countryOptions
-  }
-};

--- a/src/components/atoms/autocomplete/Autocomplete.stories.tsx
+++ b/src/components/atoms/autocomplete/Autocomplete.stories.tsx
@@ -1,0 +1,281 @@
+import { action } from '@storybook/addon-actions';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Autocomplete } from './Autocomplete';
+
+const countryOptions = [
+  { key: 'ar', label: 'Argentina', description: 'Buenos Aires' },
+  { key: 'br', label: 'Brazil', description: 'Brasília' },
+  { key: 'cl', label: 'Chile', description: 'Santiago' },
+  { key: 'co', label: 'Colombia', description: 'Bogotá' },
+  { key: 'mx', label: 'Mexico', description: 'Mexico City' },
+  { key: 'uy', label: 'Uruguay', description: 'Montevideo' }
+];
+
+const longCountryOptions = [
+  { key: 'argentina', label: 'Argentina', description: 'Buenos Aires' },
+  { key: 'australia', label: 'Australia', description: 'Canberra' },
+  { key: 'austria', label: 'Austria', description: 'Vienna' },
+  { key: 'belgium', label: 'Belgium', description: 'Brussels' },
+  { key: 'bolivia', label: 'Bolivia', description: 'Sucre' },
+  { key: 'brazil', label: 'Brazil', description: 'Brasília' },
+  { key: 'canada', label: 'Canada', description: 'Ottawa' },
+  { key: 'chile', label: 'Chile', description: 'Santiago' },
+  { key: 'china', label: 'China', description: 'Beijing' },
+  { key: 'colombia', label: 'Colombia', description: 'Bogotá' },
+  { key: 'costa-rica', label: 'Costa Rica', description: 'San José' },
+  { key: 'croatia', label: 'Croatia', description: 'Zagreb' },
+  { key: 'cuba', label: 'Cuba', description: 'Havana' },
+  { key: 'denmark', label: 'Denmark', description: 'Copenhagen' },
+  { key: 'dominican-republic', label: 'Dominican Republic', description: 'Santo Domingo' },
+  { key: 'ecuador', label: 'Ecuador', description: 'Quito' },
+  { key: 'egypt', label: 'Egypt', description: 'Cairo' },
+  { key: 'el-salvador', label: 'El Salvador', description: 'San Salvador' },
+  { key: 'finland', label: 'Finland', description: 'Helsinki' },
+  { key: 'france', label: 'France', description: 'Paris' },
+  { key: 'germany', label: 'Germany', description: 'Berlin' },
+  { key: 'greece', label: 'Greece', description: 'Athens' },
+  { key: 'guatemala', label: 'Guatemala', description: 'Guatemala City' },
+  { key: 'honduras', label: 'Honduras', description: 'Tegucigalpa' },
+  { key: 'hungary', label: 'Hungary', description: 'Budapest' },
+  { key: 'india', label: 'India', description: 'New Delhi' },
+  { key: 'indonesia', label: 'Indonesia', description: 'Jakarta' },
+  { key: 'ireland', label: 'Ireland', description: 'Dublin' },
+  { key: 'italy', label: 'Italy', description: 'Rome' },
+  { key: 'japan', label: 'Japan', description: 'Tokyo' },
+  { key: 'mexico', label: 'Mexico', description: 'Mexico City' },
+  { key: 'netherlands', label: 'Netherlands', description: 'Amsterdam' },
+  { key: 'new-zealand', label: 'New Zealand', description: 'Wellington' },
+  { key: 'norway', label: 'Norway', description: 'Oslo' },
+  { key: 'panama', label: 'Panama', description: 'Panama City' },
+  { key: 'paraguay', label: 'Paraguay', description: 'Asunción' },
+  { key: 'peru', label: 'Peru', description: 'Lima' },
+  { key: 'poland', label: 'Poland', description: 'Warsaw' },
+  { key: 'portugal', label: 'Portugal', description: 'Lisbon' },
+  { key: 'romania', label: 'Romania', description: 'Bucharest' },
+  { key: 'south-africa', label: 'South Africa', description: 'Pretoria' },
+  { key: 'south-korea', label: 'South Korea', description: 'Seoul' },
+  { key: 'spain', label: 'Spain', description: 'Madrid' },
+  { key: 'sweden', label: 'Sweden', description: 'Stockholm' },
+  { key: 'switzerland', label: 'Switzerland', description: 'Bern' },
+  { key: 'thailand', label: 'Thailand', description: 'Bangkok' },
+  { key: 'united-kingdom', label: 'United Kingdom', description: 'London' },
+  { key: 'united-states', label: 'United States', description: 'Washington, D.C.' },
+  { key: 'uruguay', label: 'Uruguay', description: 'Montevideo' },
+  { key: 'venezuela', label: 'Venezuela', description: 'Caracas' }
+];
+
+/**
+ * ## Description
+ * Autocomplete lets users search and select a single option from a popover-backed list while keeping the
+ * trigger visually aligned with `Select`. The trigger opens the popover and the internal search input owns
+ * the combobox relationship for filtering and keyboard navigation.
+ *
+ * ## Usage Guide
+ * Use this component when people need help narrowing down a long single-select list without switching to a
+ * full inline combobox. Keep the option labels concise, provide a visible label when possible, and rely on
+ * `searchAriaLabel` only when the trigger label is not enough context for the search field.
+ */
+const meta: Meta<typeof Autocomplete> = {
+  title: 'Atoms/Autocomplete',
+  component: Autocomplete,
+  parameters: {
+    docs: {
+      autodocs: true
+    }
+  },
+  tags: ['autodocs']
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Autocomplete>;
+
+/**
+ * Demonstrates the baseline searchable select with the default visual variants and public API.
+ */
+export const Default: Story = {
+  args: {
+    label: 'Country',
+    placeholder: 'Select a country',
+    searchPlaceholder: 'Search countries',
+    options: countryOptions,
+    onChange: action('change'),
+    onClear: action('clear'),
+    onOpenChange: action('open-change')
+  }
+};
+
+/**
+ * Demonstrates the size scale so reviewers can compare spacing, touch target, and label behavior.
+ */
+export const Sizes: Story = {
+  render: () => (
+    <div className='flex flex-wrap items-end gap-6'>
+      <div className='w-56'>
+        <Autocomplete
+          label='Small'
+          size='sm'
+          placeholder='Search…'
+          options={countryOptions}
+          onChange={action('sm-change')}
+        />
+      </div>
+      <div className='w-56'>
+        <Autocomplete
+          label='Medium'
+          size='md'
+          placeholder='Search…'
+          options={countryOptions}
+          onChange={action('md-change')}
+        />
+      </div>
+      <div className='w-56'>
+        <Autocomplete
+          label='Large'
+          size='lg'
+          placeholder='Search…'
+          options={countryOptions}
+          onChange={action('lg-change')}
+        />
+      </div>
+    </div>
+  )
+};
+
+/**
+ * Shows the non-interactive disabled state that relies on opacity instead of alternate disabled colors.
+ */
+export const Disabled: Story = {
+  args: {
+    ...Default.args,
+    isDisabled: true
+  }
+};
+
+/**
+ * Shows the loading experience where the popover replaces the search input and options with a status row.
+ */
+export const Loading: Story = {
+  args: {
+    ...Default.args,
+    isLoading: true,
+    loadingLabel: 'Loading countries...'
+  }
+};
+
+/**
+ * Shows the clear action when a selected value is already present.
+ */
+export const Clearable: Story = {
+  render: () => {
+    const [value, setValue] = useState<string | null>('ar');
+    return (
+      <div className='w-56'>
+        <Autocomplete
+          label='Country'
+          placeholder='Select a country'
+          searchPlaceholder='Search countries'
+          options={countryOptions}
+          value={value}
+          isClearable={true}
+          onChange={(key) => setValue(key)}
+          onClear={() => setValue(null)}
+        />
+      </div>
+    );
+  }
+};
+
+/**
+ * Shows helper text placed above the trigger for supporting field context.
+ */
+export const WithDescription: Story = {
+  args: {
+    ...Default.args,
+    description: 'We use this to localize content and pricing.'
+  }
+};
+
+/**
+ * Shows all hint tones (error, warning, success, info) side by side so reviewers can compare semantic feedback states.
+ */
+export const Hints: Story = {
+  render: () => (
+    <div className='flex flex-wrap items-start gap-6'>
+      <div className='w-56'>
+        <Autocomplete
+          label='Error'
+          placeholder='Search…'
+          options={countryOptions}
+          hint={{ message: 'Country is required.', type: 'error' }}
+          onChange={action('error-change')}
+        />
+      </div>
+      <div className='w-56'>
+        <Autocomplete
+          label='Warning'
+          placeholder='Search…'
+          options={countryOptions}
+          hint={{ message: 'Double-check the selected market.', type: 'warning' }}
+          onChange={action('warning-change')}
+        />
+      </div>
+      <div className='w-56'>
+        <Autocomplete
+          label='Success'
+          placeholder='Search…'
+          options={countryOptions}
+          hint={{ message: 'Selection looks good.', type: 'success' }}
+          onChange={action('success-change')}
+        />
+      </div>
+      <div className='w-56'>
+        <Autocomplete
+          label='Info'
+          placeholder='Search…'
+          options={countryOptions}
+          hint={{ message: 'Pick the market used for reporting.', type: 'info' }}
+          onChange={action('info-change')}
+        />
+      </div>
+    </div>
+  )
+};
+
+/**
+ * Shows filtering over a long option list so maintainers can verify the component still reads as a form control, not a menu wall.
+ */
+export const LongListFiltering: Story = {
+  args: {
+    ...Default.args,
+    options: longCountryOptions
+  }
+};
+
+/**
+ * Shows disabled options mixed with enabled ones so reviewers can verify the visual treatment and keyboard skip behavior.
+ */
+export const WithDisabledOptions: Story = {
+  args: {
+    ...Default.args,
+    options: [
+      { key: 'ar', label: 'Argentina', description: 'Buenos Aires', disabled: true },
+      { key: 'br', label: 'Brazil', description: 'Brasília' },
+      { key: 'cl', label: 'Chile', description: 'Santiago', disabled: true },
+      { key: 'co', label: 'Colombia', description: 'Bogotá' },
+      { key: 'mx', label: 'Mexico', description: 'Mexico City', disabled: true },
+      { key: 'uy', label: 'Uruguay', description: 'Montevideo' }
+    ]
+  }
+};
+
+/**
+ * Shows the single-result Enter flow by narrowing the list to one expected match through the initial data set.
+ */
+export const SingleMatchEnter: Story = {
+  args: {
+    ...Default.args,
+    options: countryOptions
+  }
+};

--- a/src/components/atoms/autocomplete/Autocomplete.test.tsx
+++ b/src/components/atoms/autocomplete/Autocomplete.test.tsx
@@ -240,13 +240,45 @@ describe('Autocomplete — component behavior', () => {
       <Autocomplete label='Country' options={defaultOptions} value='ar' isClearable={true} onClear={handleClear} />
     );
 
-    await user.click(screen.getByRole('button', { name: 'Country' }));
+    const trigger = screen.getByRole('button', { name: 'Country' });
+    await user.click(trigger);
     expect(screen.getByRole('listbox')).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Clear selection' }));
 
     expect(handleClear).toHaveBeenCalledTimes(1);
     expect(screen.getByRole('listbox')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(trigger).toHaveFocus();
+    });
+  });
+
+  it('keeps the clear button keyboard reachable and clears without opening the popover', async () => {
+    const user = userEvent.setup();
+    const handleClear = vi.fn();
+    render(
+      <div>
+        <Autocomplete label='Country' options={defaultOptions} value='ar' isClearable={true} onClear={handleClear} />
+        <button type='button'>Next field</button>
+      </div>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Country' });
+    const clearButton = screen.getByRole('button', { name: 'Clear selection' });
+
+    await user.tab();
+    expect(trigger).toHaveFocus();
+
+    await user.tab();
+    expect(clearButton).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+
+    expect(handleClear).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(trigger).toHaveFocus();
+    });
   });
 
   it('navigates to first/last option with Home/End keys without prior arrow press', async () => {
@@ -344,7 +376,7 @@ describe('Autocomplete — component behavior', () => {
     expect(screen.getByRole('button', { name: 'Next field' })).toHaveFocus();
   });
 
-  it('closes on outside click and restores focus to the trigger', async () => {
+  it('closes on outside click and keeps focus on the clicked control', async () => {
     const user = userEvent.setup();
     render(
       <div>
@@ -354,12 +386,13 @@ describe('Autocomplete — component behavior', () => {
     );
 
     const trigger = screen.getByRole('button', { name: 'Country' });
+    const outsideButton = screen.getByRole('button', { name: 'Outside' });
     await user.click(trigger);
-    await user.click(screen.getByRole('button', { name: 'Outside' }));
+    await user.click(outsideButton);
 
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
     await waitFor(() => {
-      expect(trigger).toHaveFocus();
+      expect(outsideButton).toHaveFocus();
     });
   });
 

--- a/src/components/atoms/autocomplete/Autocomplete.test.tsx
+++ b/src/components/atoms/autocomplete/Autocomplete.test.tsx
@@ -1,0 +1,349 @@
+import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('lucide-react/dynamic.js', () => ({
+  // biome-ignore lint/style/useNamingConvention: must match library export name
+  DynamicIcon: () => null
+}));
+
+vi.mock('spinners-react', () => ({
+  // biome-ignore lint/style/useNamingConvention: must match library export name
+  SpinnerCircular: () => <span data-testid='autocomplete-spinner' />
+}));
+
+import { Autocomplete } from './Autocomplete';
+import type { AutocompleteOption } from './types';
+import { useAutocomplete } from './useAutocomplete';
+
+const defaultOptions: AutocompleteOption[] = [
+  { key: 'ar', label: 'Argentina' },
+  { key: 'br', label: 'Brazil' },
+  { key: 'uy', label: 'Uruguay' }
+];
+
+beforeEach(() => {
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback: FrameRequestCallback) => {
+    callback(0);
+    return 1;
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useAutocomplete — logic', () => {
+  it('returns unselected state by default', () => {
+    const { result } = renderHook(() => useAutocomplete({ options: defaultOptions, label: 'Country' }));
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.hasValue).toBe(false);
+    expect(result.current.selectedOption).toBeUndefined();
+    expect(result.current.activeOptionKey).toBeNull();
+  });
+
+  it('returns the defaultValue for uncontrolled state', () => {
+    const { result } = renderHook(() =>
+      useAutocomplete({ options: defaultOptions, label: 'Country', defaultValue: 'ar' })
+    );
+
+    expect(result.current.hasValue).toBe(true);
+    expect(result.current.selectedOption?.key).toBe('ar');
+  });
+
+  it('keeps value controlled by the value prop', () => {
+    const { result } = renderHook(() => useAutocomplete({ options: defaultOptions, label: 'Country', value: 'br' }));
+
+    expect(result.current.selectedOption?.key).toBe('br');
+  });
+
+  it('filters options from the search input change handler', () => {
+    const { result } = renderHook(() => useAutocomplete({ options: defaultOptions, label: 'Country' }));
+
+    act(() => {
+      result.current.searchInputProps.onChange?.({
+        target: { value: 'bra' }
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    expect(result.current.filteredOptions.map((option) => option.key)).toEqual(['br']);
+  });
+
+  it('opens from the trigger container click and keeps trigger free of listbox ownership attrs', () => {
+    const { result } = renderHook(() => useAutocomplete({ options: defaultOptions, label: 'Country' }));
+
+    act(() => {
+      result.current.containerProps.onClick?.({
+        defaultPrevented: false
+      } as React.MouseEvent<HTMLDivElement>);
+    });
+
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.triggerProps['aria-controls']).toBeUndefined();
+    expect(result.current.triggerProps['aria-activedescendant']).toBeUndefined();
+  });
+});
+
+describe('Autocomplete — component behavior', () => {
+  it('renders a trigger button with visible label and placeholder', () => {
+    render(<Autocomplete label='Country' options={defaultOptions} placeholder='Select a country' />);
+
+    expect(screen.getByRole('button', { name: 'Country' })).toBeInTheDocument();
+    expect(screen.getByText('Select a country')).toBeInTheDocument();
+  });
+
+  it('opens the popover and focuses the search input', async () => {
+    const user = userEvent.setup();
+    render(<Autocomplete label='Country' options={defaultOptions} placeholder='Select a country' />);
+
+    await user.click(screen.getByRole('button', { name: 'Country' }));
+
+    const searchInput = screen.getByRole('combobox', { name: 'Search options' });
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(searchInput).toHaveFocus();
+    });
+    expect(searchInput).not.toHaveAttribute('aria-activedescendant');
+  });
+
+  it('filters the visible options while typing', async () => {
+    const user = userEvent.setup();
+    render(<Autocomplete label='Country' options={defaultOptions} placeholder='Select a country' />);
+
+    await user.click(screen.getByRole('button', { name: 'Country' }));
+    await user.type(screen.getByRole('combobox', { name: 'Search options' }), 'bra');
+
+    expect(screen.getByRole('option', { name: 'Brazil' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Argentina' })).not.toBeInTheDocument();
+  });
+
+  it('renders the empty message when options are empty from the start', async () => {
+    const user = userEvent.setup();
+    render(<Autocomplete label='Country' options={[]} emptyMessage='No countries yet' />);
+
+    await user.click(screen.getByRole('button', { name: 'Country' }));
+
+    expect(screen.getByText('No countries yet')).toBeInTheDocument();
+    expect(screen.queryByRole('option')).not.toBeInTheDocument();
+  });
+
+  it('selects the only enabled filtered option when pressing Enter from the search input', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(<Autocomplete label='Country' options={defaultOptions} onChange={handleChange} />);
+
+    await user.click(screen.getByRole('button', { name: 'Country' }));
+    const searchInput = screen.getByRole('combobox', { name: 'Search options' });
+    await user.type(searchInput, 'bra');
+    await user.keyboard('{Enter}');
+
+    expect(handleChange).toHaveBeenCalledWith('br');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('does not select when the only visible result is disabled', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <Autocomplete
+        label='Country'
+        options={[
+          { key: 'ar', label: 'Argentina', disabled: true },
+          { key: 'br', label: 'Brazil' }
+        ]}
+        onChange={handleChange}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Country' }));
+    const searchInput = screen.getByRole('combobox', { name: 'Search options' });
+    await user.type(searchInput, 'arg');
+    await user.keyboard('{Enter}');
+
+    expect(handleChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('keeps disabled visible options out of arrow navigation', async () => {
+    const user = userEvent.setup();
+    render(
+      <Autocomplete
+        label='Country'
+        options={[
+          { key: 'ar', label: 'Argentina', disabled: true },
+          { key: 'br', label: 'Brazil', disabled: true }
+        ]}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Country' }));
+    const searchInput = screen.getByRole('combobox', { name: 'Search options' });
+    await user.keyboard('{ArrowDown}');
+
+    expect(searchInput).not.toHaveAttribute('aria-activedescendant');
+    expect(screen.getByRole('option', { name: 'Argentina' })).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByRole('option', { name: 'Brazil' })).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('shows loading state without rendering the search input', async () => {
+    const user = userEvent.setup();
+    render(<Autocomplete label='Country' options={defaultOptions} isLoading={true} loadingLabel='Loading countries' />);
+
+    await user.click(screen.getByRole('button', { name: 'Country' }));
+
+    expect(screen.getByTestId('autocomplete-spinner')).toBeInTheDocument();
+    expect(screen.getByText('Loading countries')).toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: 'Search options' })).not.toBeInTheDocument();
+  });
+
+  it('renders and wires the clear button without toggling the popover', async () => {
+    const user = userEvent.setup();
+    const handleClear = vi.fn();
+    render(
+      <Autocomplete label='Country' options={defaultOptions} value='ar' isClearable={true} onClear={handleClear} />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Country' }));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Clear selection' }));
+
+    expect(handleClear).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('navigates to first/last option with Home/End keys without prior arrow press', async () => {
+    const user = userEvent.setup();
+    render(<Autocomplete label='Country' options={defaultOptions} />);
+
+    await user.click(screen.getByRole('button', { name: 'Country' }));
+    const searchInput = screen.getByRole('combobox', { name: 'Search options' });
+
+    await user.keyboard('{End}');
+    expect(searchInput).toHaveAttribute('aria-activedescendant', expect.stringContaining('uy'));
+
+    await user.keyboard('{Home}');
+    expect(searchInput).toHaveAttribute('aria-activedescendant', expect.stringContaining('ar'));
+  });
+
+  it('renders empty state with correct ARIA attributes', async () => {
+    const user = userEvent.setup();
+    render(<Autocomplete label='Country' options={[]} emptyMessage='No results' />);
+
+    await user.click(screen.getByRole('button', { name: 'Country' }));
+    const emptyDiv = screen.getByText('No results');
+    expect(emptyDiv).toHaveAttribute('role', 'status');
+    expect(emptyDiv).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('warns in development when neither label nor ariaLabel is provided', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    render(<Autocomplete options={defaultOptions} />);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Provide either `label`, `ariaLabel`, or `aria-label`')
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('computes needsScopedDarkPortal after mount', async () => {
+    const user = userEvent.setup();
+    render(
+      <div className='dark'>
+        <Autocomplete label='Country' options={defaultOptions} />
+      </div>
+    );
+    await user.click(screen.getByRole('button', { name: 'Country' }));
+    const portalWrapper = document.querySelector('[style="display: contents;"]');
+    expect(portalWrapper).toHaveClass('dark');
+  });
+
+  it('closes on Escape and restores focus to the trigger', async () => {
+    const user = userEvent.setup();
+    render(<Autocomplete label='Country' options={defaultOptions} />);
+
+    const trigger = screen.getByRole('button', { name: 'Country' });
+    await user.click(trigger);
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(trigger).toHaveFocus();
+    });
+  });
+
+  it('closes on Tab without refocusing the trigger', async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <Autocomplete label='Country' options={defaultOptions} />
+        <button type='button'>Next field</button>
+      </div>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Country' });
+    await user.click(trigger);
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', { name: 'Search options' })).toHaveFocus();
+    });
+
+    await user.tab();
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(trigger).not.toHaveFocus();
+    expect(screen.getByRole('button', { name: 'Next field' })).toHaveFocus();
+  });
+
+  it('closes on outside click and restores focus to the trigger', async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <Autocomplete label='Country' options={defaultOptions} />
+        <button type='button'>Outside</button>
+      </div>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Country' });
+    await user.click(trigger);
+    await user.click(screen.getByRole('button', { name: 'Outside' }));
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(trigger).toHaveFocus();
+    });
+  });
+
+  it('assigns combobox ownership attrs to the search input only', async () => {
+    const user = userEvent.setup();
+    render(<Autocomplete label='Country' options={defaultOptions} />);
+
+    const trigger = screen.getByRole('button', { name: 'Country' });
+    await user.click(trigger);
+
+    const searchInput = screen.getByRole('combobox', { name: 'Search options' });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'listbox');
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(trigger).not.toHaveAttribute('aria-controls');
+    expect(trigger).not.toHaveAttribute('aria-activedescendant');
+    expect(searchInput).toHaveAttribute('aria-controls');
+    expect(searchInput).toHaveAttribute('aria-autocomplete', 'list');
+  });
+
+  it('serializes the selected key through the hidden input when a name is provided', () => {
+    render(<Autocomplete label='Country' options={defaultOptions} value='ar' name='country' />);
+
+    const hiddenInput = document.querySelector('input[type="hidden"]');
+    expect(hiddenInput).toHaveValue('ar');
+    expect(hiddenInput).toHaveAttribute('name', 'country');
+  });
+
+  it('warns in development for deprecated props', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    render(
+      <Autocomplete label='Country' options={defaultOptions} errorMessage='Required' isInvalid={true} variant='faded' />
+    );
+
+    expect(warnSpy).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/components/atoms/autocomplete/Autocomplete.test.tsx
+++ b/src/components/atoms/autocomplete/Autocomplete.test.tsx
@@ -197,6 +197,42 @@ describe('Autocomplete — component behavior', () => {
     expect(screen.queryByRole('combobox', { name: 'Search options' })).not.toBeInTheDocument();
   });
 
+  it('closes the loading popover on Escape from the trigger', async () => {
+    const user = userEvent.setup();
+    render(<Autocomplete label='Country' options={defaultOptions} isLoading={true} loadingLabel='Loading countries' />);
+
+    const trigger = screen.getByRole('button', { name: 'Country' });
+    await user.click(trigger);
+
+    expect(screen.getByText('Loading countries')).toBeInTheDocument();
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByText('Loading countries')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(trigger).toHaveFocus();
+    });
+  });
+
+  it('closes the loading popover on Tab and moves focus out of the component', async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <Autocomplete label='Country' options={defaultOptions} isLoading={true} loadingLabel='Loading countries' />
+        <button type='button'>Next field</button>
+      </div>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Country' });
+    await user.click(trigger);
+
+    expect(screen.getByText('Loading countries')).toBeInTheDocument();
+
+    await user.tab();
+
+    expect(screen.queryByText('Loading countries')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next field' })).toHaveFocus();
+  });
+
   it('renders and wires the clear button without toggling the popover', async () => {
     const user = userEvent.setup();
     const handleClear = vi.fn();
@@ -235,6 +271,20 @@ describe('Autocomplete — component behavior', () => {
     const emptyDiv = screen.getByText('No results');
     expect(emptyDiv).toHaveAttribute('role', 'status');
     expect(emptyDiv).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('renders an empty listbox that matches the search input aria-controls', async () => {
+    const user = userEvent.setup();
+    render(<Autocomplete label='Country' options={[]} emptyMessage='No results' />);
+
+    await user.click(screen.getByRole('button', { name: 'Country' }));
+    const searchInput = screen.getByRole('combobox', { name: 'Search options' });
+    const listboxId = searchInput.getAttribute('aria-controls');
+
+    expect(listboxId).toBeTruthy();
+    const listbox = document.getElementById(listboxId ?? '');
+    expect(listbox).toBeInTheDocument();
+    expect(listbox).toHaveAttribute('role', 'listbox');
   });
 
   it('warns in development when neither label nor ariaLabel is provided', () => {
@@ -345,5 +395,20 @@ describe('Autocomplete — component behavior', () => {
     );
 
     expect(warnSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not submit the form when pressing Enter with the popover open and no resolved selection', async () => {
+    const user = userEvent.setup();
+    const handleSubmit = vi.fn();
+    render(
+      <form onSubmit={handleSubmit}>
+        <Autocomplete label='Country' options={[]} emptyMessage='No results' />
+      </form>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Country' }));
+    await user.keyboard('{Enter}');
+
+    expect(handleSubmit).not.toHaveBeenCalled();
   });
 });

--- a/src/components/atoms/autocomplete/Autocomplete.tsx
+++ b/src/components/atoms/autocomplete/Autocomplete.tsx
@@ -140,9 +140,17 @@ export const Autocomplete: FC<AutocompleteProps> = (props) => {
                   </div>
 
                   {shouldShowEmptyState && (
-                    <div className={emptyMessageClassName} role='status' aria-live='polite'>
-                      {emptyMessage}
-                    </div>
+                    <>
+                      <div
+                        role='listbox'
+                        id={`${triggerProps.id}-listbox`}
+                        aria-label={label ?? listboxAriaLabel}
+                        className={filterContainerClassName}
+                      />
+                      <div className={emptyMessageClassName} role='status' aria-live='polite'>
+                        {emptyMessage}
+                      </div>
+                    </>
                   )}
 
                   {shouldShowList && (

--- a/src/components/atoms/autocomplete/Autocomplete.tsx
+++ b/src/components/atoms/autocomplete/Autocomplete.tsx
@@ -119,7 +119,12 @@ export const Autocomplete: FC<AutocompleteProps> = (props) => {
               ref={popoverRef as React.RefObject<HTMLDivElement>}
               className={popoverClassName}
               style={popoverStyle}
-              onMouseDown={(e) => e.preventDefault()}
+              onMouseDown={(e) => {
+                const target = e.target as HTMLElement;
+                if (!target.closest('input, textarea, [contenteditable]')) {
+                  e.preventDefault();
+                }
+              }}
             >
               {isLoading ? (
                 <div className={selectLoadingVariants()} role='status' aria-live='polite'>

--- a/src/components/atoms/autocomplete/Autocomplete.tsx
+++ b/src/components/atoms/autocomplete/Autocomplete.tsx
@@ -93,6 +93,7 @@ export const Autocomplete: FC<AutocompleteProps> = (props) => {
           {showClearButton && (
             <button
               type='button'
+              tabIndex={-1}
               aria-label={clearAriaLabel}
               className={clearButtonClassName}
               onClick={(event) => {

--- a/src/components/atoms/autocomplete/Autocomplete.tsx
+++ b/src/components/atoms/autocomplete/Autocomplete.tsx
@@ -1,0 +1,181 @@
+import type { FC } from 'react';
+import { createPortal } from 'react-dom';
+import { SpinnerCircular } from 'spinners-react';
+import { Icon } from '../icon';
+import type { AutocompleteProps } from './types';
+import { selectDescription, selectLoadingVariants, selectPlaceholder } from './types';
+import { useAutocomplete } from './useAutocomplete';
+
+export const Autocomplete: FC<AutocompleteProps> = (props) => {
+  const {
+    isOpen,
+    filteredOptions,
+    selectedOption,
+    hasValue,
+    showClearButton,
+    isLoading,
+    isRequired,
+    clearAriaLabel,
+    loadingLabel,
+    emptyMessage,
+    label,
+    description,
+    placeholder,
+    triggerClassName,
+    popoverClassName,
+    contentClassName,
+    nativeTriggerClassName,
+    valueClassName,
+    actionGroupClassName,
+    indicatorClassName,
+    clearButtonClassName,
+    labelClassName,
+    baseClassName,
+    searchInputClassName,
+    emptyMessageClassName,
+    filterContainerClassName,
+    getOptionClassName,
+    popoverStyle,
+    triggerProps,
+    searchInputProps,
+    getOptionProps,
+    labelProps,
+    descriptionProps,
+    hiddenInputProps,
+    containerProps,
+    handleClear,
+    hasHint,
+    hintIconProps,
+    hintMessage,
+    hintMessageClassName,
+    needsScopedDarkPortal,
+    portalContainer,
+    listboxAriaLabel,
+    popoverRef
+  } = useAutocomplete(props);
+
+  const shouldShowEmptyState = !isLoading && filteredOptions.length === 0;
+  const shouldShowList = !isLoading && filteredOptions.length > 0;
+
+  return (
+    <div className={baseClassName}>
+      {description && (
+        <div {...descriptionProps} className={selectDescription()}>
+          {description}
+        </div>
+      )}
+
+      <div {...containerProps} className={triggerClassName}>
+        {label && (
+          <label {...labelProps} className={labelClassName}>
+            {label}
+            {isRequired && (
+              <span aria-hidden={true} className='text-brand-light dark:text-brand-dark'>
+                {' *'}
+              </span>
+            )}
+          </label>
+        )}
+
+        <div className={contentClassName}>
+          <button {...triggerProps} className={nativeTriggerClassName}>
+            <span className={valueClassName}>
+              {hasValue && selectedOption ? (
+                selectedOption.label
+              ) : (
+                <span className={selectPlaceholder()}>{placeholder}</span>
+              )}
+            </span>
+          </button>
+        </div>
+
+        <div className={actionGroupClassName}>
+          {showClearButton && (
+            <button
+              type='button'
+              aria-label={clearAriaLabel}
+              className={clearButtonClassName}
+              onClick={(event) => {
+                handleClear(event);
+              }}
+            >
+              <Icon name='x' size={16} decorative={true} />
+            </button>
+          )}
+
+          <span className={indicatorClassName}>
+            <Icon name='chevron-down' size={20} decorative={true} />
+          </span>
+        </div>
+      </div>
+
+      <input {...hiddenInputProps} />
+
+      {isOpen &&
+        portalContainer &&
+        createPortal(
+          <div className={needsScopedDarkPortal ? 'dark' : undefined} style={{ display: 'contents' }}>
+            <div
+              ref={popoverRef as React.RefObject<HTMLDivElement>}
+              className={popoverClassName}
+              style={popoverStyle}
+              onMouseDown={(e) => e.preventDefault()}
+            >
+              {isLoading ? (
+                <div className={selectLoadingVariants()} role='status' aria-live='polite'>
+                  <span aria-hidden='true' className='inline-flex text-brand-light dark:text-brand-dark'>
+                    <SpinnerCircular color='currentColor' thickness={200} size='1.25em' />
+                  </span>
+                  <span>{loadingLabel}</span>
+                </div>
+              ) : (
+                <>
+                  <div className='shrink-0 px-2 py-1.5'>
+                    <input {...searchInputProps} className={searchInputClassName} />
+                  </div>
+
+                  {shouldShowEmptyState && (
+                    <div className={emptyMessageClassName} role='status' aria-live='polite'>
+                      {emptyMessage}
+                    </div>
+                  )}
+
+                  {shouldShowList && (
+                    <div
+                      role='listbox'
+                      id={`${triggerProps.id}-listbox`}
+                      aria-label={label ?? listboxAriaLabel}
+                      className={filterContainerClassName}
+                    >
+                      {filteredOptions.map((option) => (
+                        <div key={option.key} className={getOptionClassName(option)} {...getOptionProps(option)}>
+                          {option.startContent}
+                          <div className='flex-1 min-w-0'>
+                            <span className='block truncate'>{option.label}</span>
+                            {option.description && (
+                              <span className='block text-xs text-text-muted-light dark:text-text-muted-dark truncate'>
+                                {option.description}
+                              </span>
+                            )}
+                          </div>
+                          {option.endContent}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          </div>,
+          portalContainer
+        )}
+
+      {hasHint && (
+        <div id={`${triggerProps.id}-hint`} className='flex items-center gap-2 py-0.5'>
+          {hintIconProps && <Icon {...hintIconProps} decorative={true} />}
+          <span className={hintMessageClassName}>{hintMessage}</span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/atoms/autocomplete/Autocomplete.tsx
+++ b/src/components/atoms/autocomplete/Autocomplete.tsx
@@ -3,7 +3,6 @@ import { createPortal } from 'react-dom';
 import { SpinnerCircular } from 'spinners-react';
 import { Icon } from '../icon';
 import type { AutocompleteProps } from './types';
-import { selectDescription, selectLoadingVariants, selectPlaceholder } from './types';
 import { useAutocomplete } from './useAutocomplete';
 
 export const Autocomplete: FC<AutocompleteProps> = (props) => {
@@ -34,6 +33,13 @@ export const Autocomplete: FC<AutocompleteProps> = (props) => {
     searchInputClassName,
     emptyMessageClassName,
     filterContainerClassName,
+    descriptionClassName,
+    placeholderClassName,
+    loadingClassName,
+    portalScopeClassName,
+    shouldShowEmptyState,
+    shouldShowList,
+    listboxId,
     getOptionClassName,
     popoverStyle,
     triggerProps,
@@ -44,23 +50,20 @@ export const Autocomplete: FC<AutocompleteProps> = (props) => {
     hiddenInputProps,
     containerProps,
     handleClear,
+    handlePopoverMouseDown,
     hasHint,
     hintIconProps,
     hintMessage,
     hintMessageClassName,
-    needsScopedDarkPortal,
     portalContainer,
     listboxAriaLabel,
     popoverRef
   } = useAutocomplete(props);
 
-  const shouldShowEmptyState = !isLoading && filteredOptions.length === 0;
-  const shouldShowList = !isLoading && filteredOptions.length > 0;
-
   return (
     <div className={baseClassName}>
       {description && (
-        <div {...descriptionProps} className={selectDescription()}>
+        <div {...descriptionProps} className={descriptionClassName}>
           {description}
         </div>
       )}
@@ -83,7 +86,7 @@ export const Autocomplete: FC<AutocompleteProps> = (props) => {
               {hasValue && selectedOption ? (
                 selectedOption.label
               ) : (
-                <span className={selectPlaceholder()}>{placeholder}</span>
+                <span className={placeholderClassName}>{placeholder}</span>
               )}
             </span>
           </button>
@@ -91,15 +94,7 @@ export const Autocomplete: FC<AutocompleteProps> = (props) => {
 
         <div className={actionGroupClassName}>
           {showClearButton && (
-            <button
-              type='button'
-              tabIndex={-1}
-              aria-label={clearAriaLabel}
-              className={clearButtonClassName}
-              onClick={(event) => {
-                handleClear(event);
-              }}
-            >
+            <button type='button' aria-label={clearAriaLabel} className={clearButtonClassName} onClick={handleClear}>
               <Icon name='x' size={16} decorative={true} />
             </button>
           )}
@@ -115,20 +110,15 @@ export const Autocomplete: FC<AutocompleteProps> = (props) => {
       {isOpen &&
         portalContainer &&
         createPortal(
-          <div className={needsScopedDarkPortal ? 'dark' : undefined} style={{ display: 'contents' }}>
+          <div className={portalScopeClassName} style={{ display: 'contents' }}>
             <div
-              ref={popoverRef as React.RefObject<HTMLDivElement>}
+              ref={popoverRef}
               className={popoverClassName}
               style={popoverStyle}
-              onMouseDown={(e) => {
-                const target = e.target as HTMLElement;
-                if (!target.closest('input, textarea, [contenteditable]')) {
-                  e.preventDefault();
-                }
-              }}
+              onMouseDown={handlePopoverMouseDown}
             >
               {isLoading ? (
-                <div className={selectLoadingVariants()} role='status' aria-live='polite'>
+                <div className={loadingClassName} role='status' aria-live='polite'>
                   <span aria-hidden='true' className='inline-flex text-brand-light dark:text-brand-dark'>
                     <SpinnerCircular color='currentColor' thickness={200} size='1.25em' />
                   </span>
@@ -144,7 +134,7 @@ export const Autocomplete: FC<AutocompleteProps> = (props) => {
                     <>
                       <div
                         role='listbox'
-                        id={`${triggerProps.id}-listbox`}
+                        id={listboxId}
                         aria-label={label ?? listboxAriaLabel}
                         className={filterContainerClassName}
                       />
@@ -157,7 +147,7 @@ export const Autocomplete: FC<AutocompleteProps> = (props) => {
                   {shouldShowList && (
                     <div
                       role='listbox'
-                      id={`${triggerProps.id}-listbox`}
+                      id={listboxId}
                       aria-label={label ?? listboxAriaLabel}
                       className={filterContainerClassName}
                     >

--- a/src/components/atoms/autocomplete/index.ts
+++ b/src/components/atoms/autocomplete/index.ts
@@ -1,0 +1,2 @@
+export { Autocomplete } from './Autocomplete';
+export * from './types';

--- a/src/components/atoms/autocomplete/types.ts
+++ b/src/components/atoms/autocomplete/types.ts
@@ -1,0 +1,429 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { ComponentProps, ReactNode } from 'react';
+import { hintMessageVariants as inputHintMessageVariants, inputVariants } from '@/components/atoms/input/types';
+
+/** Re-exported from Input for consistency — avoids API drift. */
+export const hintMessageVariants = inputHintMessageVariants;
+
+export const selectBase = cva('relative flex max-w-full flex-col gap-2', {
+  variants: {
+    fullWidth: {
+      true: 'w-full',
+      false: 'w-56'
+    }
+  },
+  defaultVariants: {
+    fullWidth: false
+  }
+});
+
+const selectLineVariantClasses = [
+  'bg-transparent border-t-transparent border-l-transparent border-r-transparent rounded-none!',
+  'border-b-border-light hover:border-b-border-strong-light',
+  'dark:border-b-border-dark dark:hover:border-b-border-strong-dark'
+];
+
+export const selectTrigger = cva(
+  [
+    'relative flex w-full max-w-full justify-between overflow-hidden border py-2 cursor-pointer rounded-md',
+    'text-text-light dark:text-text-dark',
+    'motion-safe:transition-[background,border-color,box-shadow] motion-safe:duration-200 motion-safe:ease-[ease]',
+    '[&:has(:focus-visible)]:focus-ring focus-within:!border-brand-light/50',
+    'dark:focus-within:!border-brand-dark/50'
+  ],
+  {
+    variants: {
+      variant: {
+        regular: [
+          'bg-surface-light border-border-light hover:bg-surface-raised-light hover:border-border-strong-light',
+          'dark:bg-surface-dark dark:border-border-dark dark:hover:bg-surface-raised-dark dark:hover:border-border-strong-dark'
+        ],
+        bordered: [
+          'bg-surface-light border-border-strong-light hover:bg-surface-raised-light',
+          'dark:bg-surface-dark dark:border-border-strong-dark dark:hover:bg-surface-raised-dark'
+        ],
+        faded: selectLineVariantClasses,
+        line: selectLineVariantClasses,
+        underlined: [
+          'bg-transparent border-border-light hover:border-border-strong-light',
+          'dark:border-border-dark dark:hover:border-border-strong-dark'
+        ]
+      },
+      size: {
+        sm: 'h-form-field-sm px-3 fs-small gap-2',
+        md: 'h-form-field-md px-4 fs-base gap-3',
+        lg: 'h-form-field-lg px-4 fs-h6 gap-3'
+      },
+      status: {
+        default: '',
+        error:
+          'border-error-light shadow-glow-input-error-light hover:!border-error-light focus-within:!border-error-light dark:border-error dark:shadow-glow-input-error dark:hover:!border-error dark:focus-within:!border-error',
+        warning:
+          'border-warning-light shadow-glow-input-warning-light hover:!border-warning-light focus-within:!border-warning-light dark:border-warning dark:shadow-glow-input-warning dark:hover:!border-warning dark:focus-within:!border-warning',
+        success:
+          'border-success-light shadow-glow-input-success-light hover:!border-success-light focus-within:!border-success-light dark:border-success dark:shadow-glow-input-success dark:hover:!border-success dark:focus-within:!border-success',
+        info: 'border-info-light shadow-glow-input-info-light hover:!border-info-light focus-within:!border-info-light dark:border-info dark:shadow-glow-input-info dark:hover:!border-info dark:focus-within:!border-info'
+      }
+    },
+    compoundVariants: [
+      {
+        variant: 'underlined',
+        status: 'error',
+        class:
+          'border-b-error-light dark:border-b-error shadow-glow-input-error-light dark:shadow-glow-input-error hover:!border-error-light dark:hover:!border-error'
+      },
+      {
+        variant: 'underlined',
+        status: 'warning',
+        class:
+          'border-b-warning-light dark:border-b-warning shadow-glow-input-warning-light dark:shadow-glow-input-warning hover:!border-warning-light dark:hover:!border-warning'
+      },
+      {
+        variant: 'underlined',
+        status: 'success',
+        class:
+          'border-b-success-light dark:border-b-success shadow-glow-input-success-light dark:shadow-glow-input-success hover:!border-success-light dark:hover:!border-success'
+      },
+      {
+        variant: 'underlined',
+        status: 'info',
+        class:
+          'border-b-info-light dark:border-b-info shadow-glow-input-info-light dark:shadow-glow-input-info hover:!border-info-light dark:hover:!border-info'
+      }
+    ],
+    defaultVariants: {
+      variant: 'regular',
+      size: 'md',
+      status: 'default'
+    }
+  }
+);
+
+export const selectContent = cva('flex min-w-0 flex-1', {
+  variants: {
+    hasLabel: {
+      true: 'items-end',
+      false: 'items-center'
+    }
+  },
+  defaultVariants: {
+    hasLabel: false
+  }
+});
+
+export const selectNativeTrigger = cva([
+  'flex min-w-0 w-full flex-1 items-end border-none bg-transparent p-0 text-left outline-none font-medium',
+  'text-text-light dark:text-text-dark disabled:cursor-not-allowed'
+]);
+
+export const selectValue = cva('block min-w-0 flex-1 text-left truncate');
+
+export const selectActionGroup = cva('flex shrink-0 items-center self-stretch', {
+  variants: {
+    size: {
+      sm: 'gap-1',
+      md: 'gap-1.5',
+      lg: 'gap-1.5'
+    }
+  },
+  defaultVariants: {
+    size: 'md'
+  }
+});
+
+export const selectIndicator = cva(
+  'grid size-5 shrink-0 place-items-center text-brand-light dark:text-brand-dark origin-center leading-none motion-safe:transition-transform motion-safe:duration-300 motion-safe:ease-out',
+  {
+    variants: {
+      isOpen: {
+        true: 'rotate-90',
+        false: 'rotate-0'
+      }
+    },
+    defaultVariants: {
+      isOpen: false
+    }
+  }
+);
+
+export const selectPopover = cva([
+  'fixed z-50 overflow-auto max-h-60',
+  'bg-surface-light dark:bg-surface-dark',
+  'border border-border-light dark:border-border-dark',
+  'rounded-md',
+  'shadow-dropdown-light dark:shadow-dropdown',
+  'py-1'
+]);
+
+export const selectItem = cva(
+  [
+    'relative flex items-center cursor-pointer',
+    'motion-safe:transition-[background,color] motion-safe:duration-150 motion-safe:ease-out',
+    'text-text-light dark:text-text-dark',
+    'hover:bg-surface-raised-light dark:hover:bg-white-tint-mid',
+    'data-[focused=true]:bg-brand-light/10 data-[focused=true]:text-brand-light',
+    'dark:data-[focused=true]:bg-brand-dark/10 dark:data-[focused=true]:text-brand-dark'
+  ],
+  {
+    variants: {
+      size: {
+        sm: 'px-2.5 py-2 text-sm gap-1.5',
+        md: 'px-3 py-2 text-base gap-2',
+        lg: 'px-4 py-2.5 text-lg gap-2'
+      },
+      isSelected: {
+        true: 'bg-brand-light/10 dark:bg-brand-dark/10 text-brand-light dark:text-brand-dark',
+        false: ''
+      },
+      isDisabled: {
+        true: 'opacity-40 cursor-not-allowed pointer-events-none',
+        false: ''
+      }
+    },
+    compoundVariants: [
+      {
+        isSelected: true,
+        class: 'hover:bg-brand-light/15 dark:hover:bg-brand-dark/15'
+      }
+    ],
+    defaultVariants: {
+      size: 'md',
+      isSelected: false,
+      isDisabled: false
+    }
+  }
+);
+
+export const selectLabel = cva(
+  [
+    'absolute w-auto line-clamp-1 pt-0.5 text-text-light dark:text-text-dark',
+    'motion-safe:transition-[top,font-size,color] motion-safe:duration-200 motion-safe:ease-[ease]'
+  ],
+  {
+    variants: {
+      size: {
+        sm: 'left-3 font-medium',
+        md: 'left-4 font-medium',
+        lg: 'left-4 font-medium'
+      },
+      state: {
+        resting: 'top-1/2 -translate-y-1/2',
+        floatingSm: 'top-0.5 fs-xs font-semibold',
+        floatingMd: 'top-1.5 fs-small font-semibold',
+        floatingLg: 'top-2 fs-small font-semibold'
+      }
+    },
+    compoundVariants: [
+      {
+        size: 'sm',
+        state: 'resting',
+        class: 'fs-small'
+      },
+      {
+        size: 'md',
+        state: 'resting',
+        class: 'fs-base'
+      },
+      {
+        size: 'lg',
+        state: 'resting',
+        class: 'fs-h6'
+      }
+    ],
+    defaultVariants: {
+      size: 'md',
+      state: 'resting'
+    }
+  }
+);
+
+export const selectLoadingVariants = cva(
+  'flex min-h-touch-target-min items-center justify-center gap-2 px-3 py-2 text-sm text-text-secondary-light dark:text-text-secondary-dark'
+);
+
+export const selectClearButton = cva([
+  'inline-flex items-center justify-center p-0.5 rounded-full shrink-0',
+  'border-none bg-transparent cursor-pointer',
+  'text-text-secondary-light dark:text-text-secondary-dark',
+  'hover:bg-white-tint-mid dark:hover:bg-white-tint-mid',
+  'focus-visible:focus-ring'
+]);
+
+export const selectDescription = cva('text-sm text-text-secondary-light dark:text-text-secondary-dark');
+
+export const selectPlaceholder = cva('text-text-secondary-light dark:text-text-secondary-dark');
+
+export type AutocompleteOption = {
+  key: string;
+  label: string;
+  disabled?: boolean;
+  description?: string;
+  startContent?: ReactNode;
+  endContent?: ReactNode;
+};
+
+export type AutocompleteHint = {
+  message: string;
+  type: 'error' | 'warning' | 'success' | 'info';
+};
+
+export const autocompleteSearchInput = cva(
+  [
+    inputVariants({
+      variant: 'regular',
+      rounded: false,
+      fullWidth: false,
+      status: 'default'
+    }),
+    'focus-visible:focus-ring'
+  ],
+  {
+    variants: {
+      size: {
+        sm: 'h-search-input-sm px-3 fs-small',
+        md: 'h-search-input-md px-4 fs-base',
+        lg: 'h-search-input-lg px-4 fs-h6'
+      }
+    },
+    defaultVariants: {
+      size: 'sm'
+    }
+  }
+);
+
+export const autocompleteEmptyMessage = cva(
+  'flex min-h-11 items-center justify-center px-3 py-2 text-sm text-text-secondary-light dark:text-text-secondary-dark'
+);
+
+export const autocompleteFilterContainer = cva('flex flex-col overflow-y-auto flex-1 min-h-0');
+
+type AutocompleteVariantProps = VariantProps<typeof selectTrigger>;
+type NativeAutocompleteTriggerProps = Omit<
+  ComponentProps<'button'>,
+  'children' | 'className' | 'defaultValue' | 'disabled' | 'onChange' | 'value'
+>;
+
+export type AutocompleteProps = NativeAutocompleteTriggerProps &
+  AutocompleteVariantProps & {
+    /** @control object */
+    options: AutocompleteOption[];
+    /** @control text */
+    value?: string | null;
+    /**
+     * @control text
+     * @default null
+     */
+    defaultValue?: string | null;
+    /**
+     * Callback fired when the selected value changes.
+     * @param key The key of the newly selected option.
+     */
+    onChange?: (key: string) => void;
+    /** Callback fired when the clear button is activated. */
+    onClear?: () => void;
+    /** Callback fired when the popover opens or closes. */
+    onOpenChange?: (isOpen: boolean) => void;
+    /**
+     * @control text
+     * @default Search...
+     */
+    searchPlaceholder?: string;
+    /**
+     * @control text
+     * @default Search options
+     */
+    searchAriaLabel?: string;
+    /**
+     * @control text
+     * @default Options
+     */
+    listboxAriaLabel?: string;
+    /**
+     * @control text
+     * @default No results found.
+     */
+    emptyMessage?: string;
+    /**
+     * Custom filter function invoked for each option against the current search query.
+     * @default Matches the option label with a case-insensitive substring comparison.
+     */
+    filterFn?: (option: AutocompleteOption, query: string) => boolean;
+    /** @control text */
+    placeholder?: string;
+    /** @control text */
+    label?: string;
+    /** @control text */
+    description?: string;
+    /**
+     * @control text
+     * @deprecated Use `hint` instead. `errorMessage` maps to `hint: { message: errorMessage, type: 'error' }`.
+     */
+    errorMessage?: string;
+    /**
+     * @control boolean
+     * @default false
+     * @deprecated Use `hint` instead. `isInvalid` maps to the effective error state when no explicit `hint` is provided.
+     */
+    isInvalid?: boolean;
+    /** @control text */
+    ariaLabel?: string;
+    /**
+     * @control text
+     * @default Clear selection
+     */
+    clearAriaLabel?: string;
+    /**
+     * @control text
+     * @default Loading options...
+     */
+    loadingLabel?: string;
+    /**
+     * @control boolean
+     * @default false
+     */
+    isDisabled?: boolean;
+    /**
+     * @control boolean
+     * @default false
+     */
+    isRequired?: boolean;
+    /**
+     * @control boolean
+     * @default false
+     */
+    isLoading?: boolean;
+    /**
+     * @control boolean
+     * @default false
+     */
+    isClearable?: boolean;
+    /**
+     * @control boolean
+     * @default false
+     */
+    isFullWidth?: boolean;
+    /** @control text */
+    name?: string;
+    /** @control text */
+    id?: string;
+    /** @control text */
+    className?: string;
+    /** @control object */
+    classNames?: {
+      base?: string;
+      trigger?: string;
+      container?: string;
+      value?: string;
+      indicator?: string;
+      popover?: string;
+      item?: string;
+      clearButton?: string;
+      label?: string;
+      errorMessage?: string;
+      hint?: string;
+      searchInput?: string;
+      emptyMessage?: string;
+    };
+    /** @control object */
+    hint?: AutocompleteHint;
+  };

--- a/src/components/atoms/autocomplete/types.ts
+++ b/src/components/atoms/autocomplete/types.ts
@@ -1,4 +1,4 @@
-import { cva, type VariantProps } from 'class-variance-authority';
+import { cva } from 'class-variance-authority';
 import type { ComponentProps, ReactNode } from 'react';
 import { hintMessageVariants as inputHintMessageVariants, inputVariants } from '@/components/atoms/input/types';
 
@@ -286,7 +286,7 @@ export const autocompleteSearchInput = cva(
       }
     },
     defaultVariants: {
-      size: 'sm'
+      size: 'md'
     }
   }
 );
@@ -297,133 +297,141 @@ export const autocompleteEmptyMessage = cva(
 
 export const autocompleteFilterContainer = cva('flex flex-col overflow-y-auto flex-1 min-h-0');
 
-type AutocompleteVariantProps = VariantProps<typeof selectTrigger>;
 type NativeAutocompleteTriggerProps = Omit<
   ComponentProps<'button'>,
   'children' | 'className' | 'defaultValue' | 'disabled' | 'onChange' | 'value'
 >;
 
-export type AutocompleteProps = NativeAutocompleteTriggerProps &
-  AutocompleteVariantProps & {
-    /** @control object */
-    options: AutocompleteOption[];
-    /** @control text */
-    value?: string | null;
-    /**
-     * @control text
-     * @default null
-     */
-    defaultValue?: string | null;
-    /**
-     * Callback fired when the selected value changes.
-     * @param key The key of the newly selected option.
-     */
-    onChange?: (key: string) => void;
-    /** Callback fired when the clear button is activated. */
-    onClear?: () => void;
-    /** Callback fired when the popover opens or closes. */
-    onOpenChange?: (isOpen: boolean) => void;
-    /**
-     * @control text
-     * @default Search...
-     */
-    searchPlaceholder?: string;
-    /**
-     * @control text
-     * @default Search options
-     */
-    searchAriaLabel?: string;
-    /**
-     * @control text
-     * @default Options
-     */
-    listboxAriaLabel?: string;
-    /**
-     * @control text
-     * @default No results found.
-     */
-    emptyMessage?: string;
-    /**
-     * Custom filter function invoked for each option against the current search query.
-     * @default Matches the option label with a case-insensitive substring comparison.
-     */
-    filterFn?: (option: AutocompleteOption, query: string) => boolean;
-    /** @control text */
-    placeholder?: string;
-    /** @control text */
+export type AutocompleteProps = NativeAutocompleteTriggerProps & {
+  /** Visual appearance of the trigger.
+   * @control select
+   * @default 'regular'
+   */
+  variant?: 'regular' | 'bordered' | 'faded' | 'line' | 'underlined';
+  /** Size scale for the trigger, label, and list items.
+   * @control select
+   * @default 'md'
+   */
+  size?: 'sm' | 'md' | 'lg';
+  /** @control object */
+  options: AutocompleteOption[];
+  /** @control text */
+  value?: string | null;
+  /**
+   * @control text
+   * @default null
+   */
+  defaultValue?: string | null;
+  /**
+   * Callback fired when the selected value changes.
+   * @param key The key of the newly selected option.
+   */
+  onChange?: (key: string) => void;
+  /** Callback fired when the clear button is activated. */
+  onClear?: () => void;
+  /** Callback fired when the popover opens or closes. */
+  onOpenChange?: (isOpen: boolean) => void;
+  /**
+   * @control text
+   * @default Search...
+   */
+  searchPlaceholder?: string;
+  /**
+   * @control text
+   * @default Search options
+   */
+  searchAriaLabel?: string;
+  /**
+   * @control text
+   * @default Options
+   */
+  listboxAriaLabel?: string;
+  /**
+   * @control text
+   * @default No results found.
+   */
+  emptyMessage?: string;
+  /**
+   * Custom filter function invoked for each option against the current search query.
+   * @default Matches the option label with a case-insensitive substring comparison.
+   */
+  filterFn?: (option: AutocompleteOption, query: string) => boolean;
+  /** @control text */
+  placeholder?: string;
+  /** @control text */
+  label?: string;
+  /** @control text */
+  description?: string;
+  /**
+   * @control text
+   * @deprecated Use `hint` instead. `errorMessage` maps to `hint: { message: errorMessage, type: 'error' }`.
+   */
+  errorMessage?: string;
+  /**
+   * @control boolean
+   * @default false
+   * @deprecated Use `hint` instead. `isInvalid` maps to the effective error state when no explicit `hint` is provided.
+   */
+  isInvalid?: boolean;
+  /** @control text */
+  ariaLabel?: string;
+  /**
+   * @control text
+   * @default Clear selection
+   */
+  clearAriaLabel?: string;
+  /**
+   * @control text
+   * @default Loading options...
+   */
+  loadingLabel?: string;
+  /**
+   * @control boolean
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
+   * @control boolean
+   * @default false
+   */
+  isRequired?: boolean;
+  /**
+   * @control boolean
+   * @default false
+   */
+  isLoading?: boolean;
+  /**
+   * @control boolean
+   * @default false
+   */
+  isClearable?: boolean;
+  /**
+   * @control boolean
+   * @default false
+   */
+  isFullWidth?: boolean;
+  /** @control text */
+  name?: string;
+  /** @control text */
+  id?: string;
+  /** @control text */
+  className?: string;
+  /** @control object */
+  classNames?: {
+    base?: string;
+    trigger?: string;
+    container?: string;
+    value?: string;
+    indicator?: string;
+    popover?: string;
+    item?: string;
+    clearButton?: string;
     label?: string;
-    /** @control text */
-    description?: string;
-    /**
-     * @control text
-     * @deprecated Use `hint` instead. `errorMessage` maps to `hint: { message: errorMessage, type: 'error' }`.
-     */
     errorMessage?: string;
-    /**
-     * @control boolean
-     * @default false
-     * @deprecated Use `hint` instead. `isInvalid` maps to the effective error state when no explicit `hint` is provided.
-     */
-    isInvalid?: boolean;
-    /** @control text */
-    ariaLabel?: string;
-    /**
-     * @control text
-     * @default Clear selection
-     */
-    clearAriaLabel?: string;
-    /**
-     * @control text
-     * @default Loading options...
-     */
-    loadingLabel?: string;
-    /**
-     * @control boolean
-     * @default false
-     */
-    isDisabled?: boolean;
-    /**
-     * @control boolean
-     * @default false
-     */
-    isRequired?: boolean;
-    /**
-     * @control boolean
-     * @default false
-     */
-    isLoading?: boolean;
-    /**
-     * @control boolean
-     * @default false
-     */
-    isClearable?: boolean;
-    /**
-     * @control boolean
-     * @default false
-     */
-    isFullWidth?: boolean;
-    /** @control text */
-    name?: string;
-    /** @control text */
-    id?: string;
-    /** @control text */
-    className?: string;
-    /** @control object */
-    classNames?: {
-      base?: string;
-      trigger?: string;
-      container?: string;
-      value?: string;
-      indicator?: string;
-      popover?: string;
-      item?: string;
-      clearButton?: string;
-      label?: string;
-      errorMessage?: string;
-      hint?: string;
-      searchInput?: string;
-      emptyMessage?: string;
-    };
-    /** @control object */
-    hint?: AutocompleteHint;
+    hint?: string;
+    searchInput?: string;
+    emptyMessage?: string;
   };
+  /** @control object */
+  hint?: AutocompleteHint;
+};

--- a/src/components/atoms/autocomplete/types.ts
+++ b/src/components/atoms/autocomplete/types.ts
@@ -275,7 +275,8 @@ export const autocompleteSearchInput = cva(
       fullWidth: false,
       status: 'default'
     }),
-    'focus-visible:focus-ring'
+    'focus-visible:focus-ring',
+    'text-text-light dark:text-text-dark'
   ],
   {
     variants: {
@@ -292,7 +293,7 @@ export const autocompleteSearchInput = cva(
 );
 
 export const autocompleteEmptyMessage = cva(
-  'flex min-h-11 items-center justify-center px-3 py-2 text-sm text-text-secondary-light dark:text-text-secondary-dark'
+  'flex min-h-touch-target-min items-center justify-center px-3 py-2 text-sm text-text-secondary-light dark:text-text-secondary-dark'
 );
 
 export const autocompleteFilterContainer = cva('flex flex-col overflow-y-auto flex-1 min-h-0');

--- a/src/components/atoms/autocomplete/useAutocomplete.ts
+++ b/src/components/atoms/autocomplete/useAutocomplete.ts
@@ -489,6 +489,36 @@ export const useAutocomplete = (props: AutocompleteProps): UseAutocompleteReturn
     [onClickProp]
   );
 
+  const handleTriggerKeyDown: NonNullable<ComponentProps<'button'>['onKeyDown']> = useCallback(
+    (event) => {
+      rest.onKeyDown?.(event);
+
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      if (!isOpen || !isLoading) {
+        return;
+      }
+
+      switch (event.key) {
+        case 'Escape': {
+          event.preventDefault();
+          closePopover('escape');
+          break;
+        }
+        case 'Tab': {
+          closePopover('tab');
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+    },
+    [closePopover, isLoading, isOpen, rest]
+  );
+
   const handleContainerClick = useCallback(
     (event: MouseEvent<HTMLDivElement>) => {
       if (effectiveDisabled || event.defaultPrevented) {
@@ -677,7 +707,8 @@ export const useAutocomplete = (props: AutocompleteProps): UseAutocompleteReturn
     disabled: effectiveDisabled,
     'aria-disabled': effectiveDisabled || undefined,
     onMouseDown: handleTriggerMouseDown,
-    onClick: handleTriggerClick
+    onClick: handleTriggerClick,
+    onKeyDown: handleTriggerKeyDown
   };
 
   const searchInputProps: ComponentProps<'input'> = {

--- a/src/components/atoms/autocomplete/useAutocomplete.ts
+++ b/src/components/atoms/autocomplete/useAutocomplete.ts
@@ -13,10 +13,13 @@ import {
   selectBase,
   selectClearButton,
   selectContent,
+  selectDescription,
   selectIndicator,
   selectItem,
   selectLabel,
+  selectLoadingVariants,
   selectNativeTrigger,
+  selectPlaceholder,
   selectPopover,
   selectTrigger,
   selectValue
@@ -65,6 +68,13 @@ type UseAutocompleteReturn = {
   searchInputClassName: string;
   emptyMessageClassName: string;
   filterContainerClassName: string;
+  descriptionClassName: string;
+  placeholderClassName: string;
+  loadingClassName: string;
+  portalScopeClassName: string | undefined;
+  shouldShowEmptyState: boolean;
+  shouldShowList: boolean;
+  listboxId: string;
   getOptionClassName: (option: AutocompleteOption) => string;
   popoverStyle: CSSProperties;
   triggerProps: ComponentProps<'button'>;
@@ -75,6 +85,7 @@ type UseAutocompleteReturn = {
   hiddenInputProps: ComponentProps<'input'>;
   containerProps: ComponentProps<'div'>;
   handleClear: (e: MouseEvent<HTMLElement>) => void;
+  handlePopoverMouseDown: NonNullable<ComponentProps<'div'>['onMouseDown']>;
   hasHint: boolean;
   hintIconProps?: HintIconProps;
   hintMessage?: string;
@@ -249,11 +260,7 @@ export const useAutocomplete = (props: AutocompleteProps): UseAutocompleteReturn
       onOpenChange?.(false);
       setIsOpen(false);
 
-      if (reason === 'outside') {
-        setTimeout(() => {
-          triggerRef.current?.focus();
-        }, 0);
-      } else if (reason !== 'tab') {
+      if (reason !== 'tab' && reason !== 'outside') {
         triggerRef.current?.focus();
       }
     },
@@ -643,6 +650,9 @@ export const useAutocomplete = (props: AutocompleteProps): UseAutocompleteReturn
   );
 
   const hasFloatingLabel = Boolean(label) && (isOpen || hasValue || Boolean(placeholder));
+  const shouldShowEmptyState = !isLoading && filteredOptions.length === 0;
+  const shouldShowList = !isLoading && filteredOptions.length > 0;
+  const listboxId = `${id}-listbox`;
   const portalContainer = typeof document === 'undefined' ? null : document.body;
 
   const baseClassName = cn(selectBase({ fullWidth: isFullWidth }), className, classNames?.base);
@@ -674,6 +684,10 @@ export const useAutocomplete = (props: AutocompleteProps): UseAutocompleteReturn
   );
   const emptyMessageClassName = cn(autocompleteEmptyMessage(), classNames?.emptyMessage);
   const filterContainerClassName = autocompleteFilterContainer();
+  const descriptionClassName = selectDescription();
+  const placeholderClassName = selectPlaceholder();
+  const loadingClassName = selectLoadingVariants();
+  const portalScopeClassName = needsScopedDarkPortal ? 'dark' : undefined;
 
   const getOptionClassName = useCallback(
     (option: AutocompleteOption) => {
@@ -688,6 +702,14 @@ export const useAutocomplete = (props: AutocompleteProps): UseAutocompleteReturn
     },
     [classNames?.item, resolvedSize, selectedValue]
   );
+
+  const handlePopoverMouseDown: NonNullable<ComponentProps<'div'>['onMouseDown']> = useCallback((event) => {
+    const target = event.target as HTMLElement;
+
+    if (!target.closest('input, textarea, [contenteditable]')) {
+      event.preventDefault();
+    }
+  }, []);
 
   const triggerProps: ComponentProps<'button'> = {
     ...rest,
@@ -719,7 +741,7 @@ export const useAutocomplete = (props: AutocompleteProps): UseAutocompleteReturn
     placeholder: searchPlaceholder,
     'aria-label': searchAriaLabel,
     'aria-expanded': true,
-    'aria-controls': `${id}-listbox`,
+    'aria-controls': listboxId,
     'aria-activedescendant': activeDescendantId,
     'aria-autocomplete': 'list',
     onChange: handleSearchChange,
@@ -803,6 +825,13 @@ export const useAutocomplete = (props: AutocompleteProps): UseAutocompleteReturn
     searchInputClassName,
     emptyMessageClassName,
     filterContainerClassName,
+    descriptionClassName,
+    placeholderClassName,
+    loadingClassName,
+    portalScopeClassName,
+    shouldShowEmptyState,
+    shouldShowList,
+    listboxId,
     getOptionClassName,
     popoverStyle,
     triggerProps,
@@ -813,6 +842,7 @@ export const useAutocomplete = (props: AutocompleteProps): UseAutocompleteReturn
     hiddenInputProps,
     containerProps,
     handleClear,
+    handlePopoverMouseDown,
     hasHint,
     hintIconProps,
     hintMessage,

--- a/src/components/atoms/autocomplete/useAutocomplete.ts
+++ b/src/components/atoms/autocomplete/useAutocomplete.ts
@@ -1,0 +1,779 @@
+import type { ComponentProps, CSSProperties, MouseEvent, RefObject } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
+import type { DynamicIconName } from '@/types';
+import type { IconTone } from '../icon';
+import type { AutocompleteHint, AutocompleteOption, AutocompleteProps } from './types';
+import {
+  autocompleteEmptyMessage,
+  autocompleteFilterContainer,
+  autocompleteSearchInput,
+  hintMessageVariants,
+  selectActionGroup,
+  selectBase,
+  selectClearButton,
+  selectContent,
+  selectIndicator,
+  selectItem,
+  selectLabel,
+  selectNativeTrigger,
+  selectPopover,
+  selectTrigger,
+  selectValue
+} from './types';
+
+type HintIconProps = {
+  name: DynamicIconName;
+  tone: IconTone;
+  size: 16;
+};
+
+type CloseReason = 'escape' | 'selection' | 'outside' | 'tab' | 'toggle';
+
+type AutocompleteOptionProps = ComponentProps<'div'> & Record<`data-${string}`, string | undefined>;
+
+type UseAutocompleteReturn = {
+  isOpen: boolean;
+  activeOptionKey: string | null;
+  filteredOptions: AutocompleteOption[];
+  selectedOption: AutocompleteOption | undefined;
+  hasValue: boolean;
+  showClearButton: boolean;
+  isLoading: boolean;
+  isRequired: boolean;
+  clearAriaLabel: string;
+  loadingLabel: string;
+  emptyMessage: string;
+  label: string | undefined;
+  description: string | undefined;
+  placeholder: string | undefined;
+  searchPlaceholder: string;
+  triggerRef: RefObject<HTMLButtonElement | null>;
+  searchInputRef: RefObject<HTMLInputElement | null>;
+  popoverRef: RefObject<HTMLDivElement | null>;
+  searchQuery: string;
+  triggerClassName: string;
+  popoverClassName: string;
+  contentClassName: string;
+  nativeTriggerClassName: string;
+  valueClassName: string;
+  actionGroupClassName: string;
+  indicatorClassName: string;
+  clearButtonClassName: string;
+  labelClassName: string;
+  baseClassName: string;
+  searchInputClassName: string;
+  emptyMessageClassName: string;
+  filterContainerClassName: string;
+  getOptionClassName: (option: AutocompleteOption) => string;
+  popoverStyle: CSSProperties;
+  triggerProps: ComponentProps<'button'>;
+  searchInputProps: ComponentProps<'input'>;
+  getOptionProps: (option: AutocompleteOption) => AutocompleteOptionProps;
+  labelProps: ComponentProps<'label'>;
+  descriptionProps: ComponentProps<'div'>;
+  hiddenInputProps: ComponentProps<'input'>;
+  containerProps: ComponentProps<'div'>;
+  handleClear: (e: MouseEvent<HTMLElement>) => void;
+  hasHint: boolean;
+  hintIconProps?: HintIconProps;
+  hintMessage?: string;
+  hintMessageClassName: string;
+  needsScopedDarkPortal: boolean;
+  portalContainer: HTMLElement | null;
+  listboxAriaLabel: string;
+};
+
+const getHintIconProps = (type?: AutocompleteHint['type']): HintIconProps | undefined => {
+  switch (type) {
+    case 'error': {
+      return { name: 'circle-alert', tone: 'danger', size: 16 };
+    }
+    case 'warning': {
+      return { name: 'triangle-alert', tone: 'warning', size: 16 };
+    }
+    case 'success': {
+      return { name: 'circle-check', tone: 'success', size: 16 };
+    }
+    case 'info': {
+      return { name: 'info', tone: 'muted', size: 16 };
+    }
+    default: {
+      return undefined;
+    }
+  }
+};
+
+const getFloatingLabelState = ({
+  hasFloatingLabel,
+  size
+}: {
+  hasFloatingLabel: boolean;
+  size: NonNullable<AutocompleteProps['size']>;
+}) => {
+  if (!hasFloatingLabel) {
+    return 'resting';
+  }
+
+  if (size === 'sm') {
+    return 'floatingSm';
+  }
+
+  if (size === 'lg') {
+    return 'floatingLg';
+  }
+
+  return 'floatingMd';
+};
+
+const defaultFilterFn = (option: AutocompleteOption, query: string) => {
+  return option.label.toLowerCase().includes(query.toLowerCase());
+};
+
+export const useAutocomplete = (props: AutocompleteProps): UseAutocompleteReturn => {
+  const {
+    options,
+    value: valueProp,
+    defaultValue = null,
+    onChange,
+    onClear,
+    onOpenChange,
+    filterFn = defaultFilterFn,
+    placeholder,
+    searchPlaceholder = 'Search...',
+    searchAriaLabel = 'Search options',
+    listboxAriaLabel = 'Options',
+    emptyMessage = 'No results found.',
+    label,
+    description,
+    errorMessage,
+    isInvalid = false,
+    isDisabled = false,
+    isRequired = false,
+    isLoading = false,
+    isClearable = false,
+    isFullWidth = false,
+    ariaLabel,
+    clearAriaLabel = 'Clear selection',
+    loadingLabel = 'Loading options...',
+    name,
+    id: idProp,
+    className,
+    classNames,
+    variant = 'regular',
+    size = 'md',
+    hint,
+    onClick: onClickProp,
+    onMouseDown: onMouseDownProp,
+    'aria-describedby': ariaDescribedByProp,
+    'aria-label': nativeAriaLabel,
+    ...rest
+  } = props;
+
+  const resolvedSize = (size ?? 'md') as NonNullable<typeof size>;
+  const deprecationWarningsRef = useRef({ errorMessage: false, isInvalid: false, faded: false });
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      return;
+    }
+
+    const warned = deprecationWarningsRef.current;
+
+    if (errorMessage !== undefined && !warned.errorMessage) {
+      console.warn(
+        '[Autocomplete] `errorMessage` is deprecated. Use `hint={{ message: errorMessage, type: "error" }}` instead.'
+      );
+      warned.errorMessage = true;
+    }
+
+    if (isInvalid && !warned.isInvalid) {
+      console.warn('[Autocomplete] `isInvalid` is deprecated. Use `hint={{ type: "error" }}` instead.');
+      warned.isInvalid = true;
+    }
+
+    if (variant === 'faded' && !warned.faded) {
+      console.warn('[Autocomplete] `variant="faded"` is deprecated. Use `variant="line"` instead.');
+      warned.faded = true;
+    }
+  }, [errorMessage, isInvalid, variant]);
+
+  const effectiveHint = hint ?? (errorMessage ? { message: errorMessage, type: 'error' as const } : undefined);
+  const status = effectiveHint?.type ?? (isInvalid ? 'error' : 'default');
+  const generatedId = useId().replaceAll(':', '');
+  const id = idProp ?? `autocomplete-${generatedId}`;
+
+  const triggerContainerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [internalValue, setInternalValue] = useState<string | null>(defaultValue);
+  const [activeOptionKey, setActiveOptionKey] = useState<string | null>(null);
+  const [popoverStyle, setPopoverStyle] = useState<CSSProperties>({});
+  const [needsScopedDarkPortal, setNeedsScopedDarkPortal] = useState(false);
+
+  const isControlled = valueProp !== undefined;
+  const selectedValue = isControlled ? valueProp : internalValue;
+  const selectedOption = options.find((option) => option.key === selectedValue);
+  const hasValue = selectedValue != null;
+  const showClearButton = isClearable && hasValue && !isDisabled && !isLoading;
+  const effectiveDisabled = isDisabled;
+  const resolvedVariant = variant;
+  const explicitAriaLabel = ariaLabel ?? nativeAriaLabel;
+
+  const filteredOptions = useMemo(() => {
+    return options.filter((option) => filterFn(option, searchQuery));
+  }, [filterFn, options, searchQuery]);
+
+  const enabledFilteredOptions = useMemo(() => {
+    return filteredOptions.filter((option) => !option.disabled);
+  }, [filteredOptions]);
+
+  const activeOption = useMemo(() => {
+    if (!activeOptionKey) {
+      return undefined;
+    }
+
+    return filteredOptions.find((option) => option.key === activeOptionKey);
+  }, [activeOptionKey, filteredOptions]);
+
+  const activeDescendantId = activeOption ? `${id}-option-${activeOption.key}` : undefined;
+
+  const closePopover = useCallback(
+    (reason: CloseReason) => {
+      setSearchQuery('');
+      setActiveOptionKey(null);
+      onOpenChange?.(false);
+      setIsOpen(false);
+
+      if (reason === 'outside') {
+        setTimeout(() => {
+          triggerRef.current?.focus();
+        }, 0);
+      } else if (reason !== 'tab') {
+        triggerRef.current?.focus();
+      }
+    },
+    [onOpenChange]
+  );
+
+  const openPopover = useCallback(() => {
+    if (effectiveDisabled) {
+      return;
+    }
+
+    setIsOpen(true);
+    setSearchQuery('');
+    setActiveOptionKey(null);
+    onOpenChange?.(true);
+  }, [effectiveDisabled, onOpenChange]);
+
+  useEffect(() => {
+    if (!isOpen || isLoading) {
+      return;
+    }
+
+    window.requestAnimationFrame(() => {
+      searchInputRef.current?.focus();
+    });
+  }, [isLoading, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const maintainFocus = () => {
+      if (document.activeElement !== searchInputRef.current && popoverRef.current?.contains(document.activeElement)) {
+        searchInputRef.current?.focus();
+      }
+    };
+
+    document.addEventListener('focusin', maintainFocus);
+    return () => document.removeEventListener('focusin', maintainFocus);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const updatePosition = () => {
+      const container = triggerContainerRef.current;
+      if (!container) {
+        return;
+      }
+
+      const rect = container.getBoundingClientRect();
+      setPopoverStyle({
+        position: 'fixed',
+        left: rect.left,
+        top: rect.bottom + 4,
+        width: rect.width
+      });
+    };
+
+    updatePosition();
+
+    window.addEventListener('scroll', updatePosition, true);
+    window.addEventListener('resize', updatePosition);
+
+    return () => {
+      window.removeEventListener('scroll', updatePosition, true);
+      window.removeEventListener('resize', updatePosition);
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleMouseDown = (event: globalThis.MouseEvent) => {
+      const target = event.target as Node;
+
+      if (popoverRef.current?.contains(target) || triggerContainerRef.current?.contains(target)) {
+        return;
+      }
+
+      closePopover('outside');
+    };
+
+    document.addEventListener('mousedown', handleMouseDown);
+
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown);
+    };
+  }, [closePopover, isOpen]);
+
+  useEffect(() => {
+    if (!activeDescendantId) {
+      return;
+    }
+
+    const element = document.getElementById(activeDescendantId);
+    if (typeof element?.scrollIntoView === 'function') {
+      element.scrollIntoView({ block: 'nearest' });
+    }
+  }, [activeDescendantId]);
+
+  useEffect(() => {
+    if (!activeOptionKey) {
+      return;
+    }
+
+    const stillEnabledAndVisible = enabledFilteredOptions.some((option) => option.key === activeOptionKey);
+    if (!stillEnabledAndVisible) {
+      setActiveOptionKey(null);
+    }
+  }, [activeOptionKey, enabledFilteredOptions]);
+
+  // Compute dark portal scope after mount (ref is null on first render)
+  useEffect(() => {
+    const el = triggerContainerRef.current?.closest('.dark');
+    setNeedsScopedDarkPortal(Boolean(el && el.tagName !== 'HTML' && el.tagName !== 'BODY'));
+  }, []);
+
+  // Dev warning: trigger must have an accessible name
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      return;
+    }
+    if (!label && !explicitAriaLabel) {
+      console.warn(
+        '[Autocomplete] Provide either `label`, `ariaLabel`, or `aria-label` so the trigger button has an accessible name.'
+      );
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const selectOption = useCallback(
+    (option: AutocompleteOption) => {
+      if (option.disabled || isLoading || effectiveDisabled) {
+        return;
+      }
+
+      if (!isControlled) {
+        setInternalValue(option.key);
+      }
+
+      onChange?.(option.key);
+      closePopover('selection');
+    },
+    [closePopover, effectiveDisabled, isControlled, isLoading, onChange]
+  );
+
+  const handleClear = useCallback(
+    (event: MouseEvent<HTMLElement>) => {
+      event.stopPropagation();
+
+      if (isLoading || effectiveDisabled) {
+        return;
+      }
+
+      if (!isControlled) {
+        setInternalValue(null);
+      }
+
+      onClear?.();
+      triggerRef.current?.focus();
+    },
+    [effectiveDisabled, isControlled, isLoading, onClear]
+  );
+
+  const moveToBoundaryOption = useCallback(
+    (boundary: 'first' | 'last') => {
+      const option =
+        boundary === 'first' ? enabledFilteredOptions[0] : enabledFilteredOptions[enabledFilteredOptions.length - 1];
+
+      if (!option) {
+        return;
+      }
+
+      setActiveOptionKey(option.key);
+    },
+    [enabledFilteredOptions]
+  );
+
+  const moveActiveOption = useCallback(
+    (direction: 'next' | 'previous') => {
+      if (enabledFilteredOptions.length === 0) {
+        return;
+      }
+
+      if (!activeOptionKey) {
+        const fallbackOption =
+          direction === 'next' ? enabledFilteredOptions[0] : enabledFilteredOptions[enabledFilteredOptions.length - 1];
+        setActiveOptionKey(fallbackOption?.key ?? null);
+        return;
+      }
+
+      const currentIndex = enabledFilteredOptions.findIndex((option) => option.key === activeOptionKey);
+      if (currentIndex < 0) {
+        const fallbackOption =
+          direction === 'next' ? enabledFilteredOptions[0] : enabledFilteredOptions[enabledFilteredOptions.length - 1];
+        setActiveOptionKey(fallbackOption?.key ?? null);
+        return;
+      }
+
+      const nextIndex =
+        direction === 'next'
+          ? (currentIndex + 1) % enabledFilteredOptions.length
+          : (currentIndex - 1 + enabledFilteredOptions.length) % enabledFilteredOptions.length;
+
+      setActiveOptionKey(enabledFilteredOptions[nextIndex]?.key ?? null);
+    },
+    [activeOptionKey, enabledFilteredOptions]
+  );
+
+  const handleTriggerMouseDown = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      onMouseDownProp?.(event);
+
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      triggerRef.current?.focus();
+      event.preventDefault();
+    },
+    [onMouseDownProp]
+  );
+
+  const handleTriggerClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      onClickProp?.(event);
+    },
+    [onClickProp]
+  );
+
+  const handleContainerClick = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (effectiveDisabled || event.defaultPrevented) {
+        return;
+      }
+
+      if (isOpen) {
+        closePopover('toggle');
+      } else {
+        openPopover();
+      }
+    },
+    [closePopover, effectiveDisabled, isOpen, openPopover]
+  );
+
+  const handleSearchChange: NonNullable<ComponentProps<'input'>['onChange']> = useCallback((event) => {
+    setSearchQuery(event.target.value);
+    setActiveOptionKey(null);
+  }, []);
+
+  const handleSearchKeyDown: NonNullable<ComponentProps<'input'>['onKeyDown']> = useCallback(
+    (event) => {
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      switch (event.key) {
+        case 'ArrowDown': {
+          event.preventDefault();
+          moveActiveOption('next');
+          break;
+        }
+        case 'ArrowUp': {
+          if (!activeOptionKey) {
+            return;
+          }
+
+          event.preventDefault();
+
+          const currentIndex = enabledFilteredOptions.findIndex((option) => option.key === activeOptionKey);
+          if (currentIndex === 0) {
+            setActiveOptionKey(null);
+            return;
+          }
+
+          moveActiveOption('previous');
+          break;
+        }
+        case 'Enter': {
+          if (activeOptionKey) {
+            event.preventDefault();
+            const option = enabledFilteredOptions.find((item) => item.key === activeOptionKey);
+            if (option) {
+              selectOption(option);
+            }
+            return;
+          }
+
+          if (enabledFilteredOptions.length === 1) {
+            event.preventDefault();
+            const [onlyOption] = enabledFilteredOptions;
+            if (onlyOption) {
+              selectOption(onlyOption);
+            }
+          }
+          break;
+        }
+        case 'Escape': {
+          event.preventDefault();
+          closePopover('escape');
+          break;
+        }
+        case 'Tab': {
+          event.preventDefault();
+          // Use document-level focusable query instead of fragile sibling traversal
+          const triggerEl = triggerRef.current;
+          if (triggerEl) {
+            const allFocusable = Array.from(
+              document.querySelectorAll<HTMLElement>(
+                'button:not([disabled]), [href], input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+              )
+            );
+            const triggerIndex = allFocusable.indexOf(triggerEl);
+            if (triggerIndex !== -1) {
+              const nextIndex = event.shiftKey ? triggerIndex - 1 : triggerIndex + 1;
+              allFocusable[nextIndex]?.focus();
+            }
+          }
+          closePopover('tab');
+          break;
+        }
+        case 'Home': {
+          event.preventDefault();
+          moveToBoundaryOption('first');
+          break;
+        }
+        case 'End': {
+          event.preventDefault();
+          moveToBoundaryOption('last');
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+    },
+    [activeOptionKey, closePopover, enabledFilteredOptions, moveActiveOption, moveToBoundaryOption, selectOption]
+  );
+
+  const hasFloatingLabel = Boolean(label) && (isOpen || hasValue || Boolean(placeholder));
+  const portalContainer = typeof document === 'undefined' ? null : document.body;
+
+  const baseClassName = cn(selectBase({ fullWidth: isFullWidth }), className, classNames?.base);
+  const triggerClassName = cn(
+    selectTrigger({ variant: resolvedVariant, size: resolvedSize, status }),
+    label ? 'items-end' : 'items-center',
+    effectiveDisabled && 'pointer-events-none cursor-not-allowed opacity-40',
+    classNames?.container,
+    classNames?.trigger
+  );
+  const contentClassName = selectContent({ hasLabel: Boolean(label) });
+  const nativeTriggerClassName = selectNativeTrigger();
+  const valueClassName = cn(selectValue(), classNames?.value);
+  const actionGroupClassName = selectActionGroup({ size: resolvedSize });
+  const indicatorClassName = cn(selectIndicator({ isOpen }), classNames?.indicator);
+  const popoverClassName = cn(selectPopover(), 'overflow-hidden flex flex-col', classNames?.popover);
+  const labelClassName = cn(
+    selectLabel({
+      size: resolvedSize,
+      state: getFloatingLabelState({ hasFloatingLabel, size: resolvedSize })
+    }),
+    classNames?.label
+  );
+  const clearButtonClassName = cn(selectClearButton(), classNames?.clearButton);
+  const searchInputClassName = cn(
+    autocompleteSearchInput({ size: resolvedSize }),
+    'placeholder:text-text-muted-light dark:placeholder:text-text-muted-dark',
+    classNames?.searchInput
+  );
+  const emptyMessageClassName = cn(autocompleteEmptyMessage(), classNames?.emptyMessage);
+  const filterContainerClassName = autocompleteFilterContainer();
+
+  const getOptionClassName = useCallback(
+    (option: AutocompleteOption) => {
+      return cn(
+        selectItem({
+          size: resolvedSize,
+          isSelected: option.key === selectedValue,
+          isDisabled: Boolean(option.disabled)
+        }),
+        classNames?.item
+      );
+    },
+    [classNames?.item, resolvedSize, selectedValue]
+  );
+
+  const triggerProps: ComponentProps<'button'> = {
+    ...rest,
+    ref: triggerRef,
+    type: 'button',
+    id,
+    'aria-haspopup': 'listbox',
+    'aria-expanded': isOpen,
+    'aria-invalid': effectiveHint?.type === 'error' || isInvalid || undefined,
+    'aria-required': isRequired || undefined,
+    'aria-describedby':
+      [ariaDescribedByProp, description ? `${id}-description` : null, effectiveHint?.message ? `${id}-hint` : null]
+        .filter(Boolean)
+        .join(' ') || undefined,
+    'aria-label': label ? undefined : explicitAriaLabel,
+    'aria-labelledby': label ? `${id}-label` : undefined,
+    disabled: effectiveDisabled,
+    'aria-disabled': effectiveDisabled || undefined,
+    onMouseDown: handleTriggerMouseDown,
+    onClick: handleTriggerClick
+  };
+
+  const searchInputProps: ComponentProps<'input'> = {
+    ref: searchInputRef,
+    type: 'text',
+    role: 'combobox',
+    value: searchQuery,
+    placeholder: searchPlaceholder,
+    'aria-label': searchAriaLabel,
+    'aria-expanded': true,
+    'aria-controls': `${id}-listbox`,
+    'aria-activedescendant': activeDescendantId,
+    'aria-autocomplete': 'list',
+    onChange: handleSearchChange,
+    onKeyDown: handleSearchKeyDown
+  };
+
+  const getOptionProps = useCallback(
+    (option: AutocompleteOption): AutocompleteOptionProps => {
+      return {
+        role: 'option',
+        id: `${id}-option-${option.key}`,
+        'aria-selected': option.key === selectedValue,
+        'aria-disabled': option.disabled ? 'true' : undefined,
+        'data-disabled': option.disabled ? 'true' : undefined,
+        'data-focused': option.key === activeOptionKey ? 'true' : undefined,
+        onClick: () => selectOption(option)
+      };
+    },
+    [activeOptionKey, id, selectOption, selectedValue]
+  );
+
+  const labelProps: ComponentProps<'label'> = {
+    htmlFor: id,
+    id: `${id}-label`
+  };
+
+  const descriptionProps: ComponentProps<'div'> = {
+    id: `${id}-description`
+  };
+
+  const hiddenInputProps: ComponentProps<'input'> = {
+    type: 'hidden',
+    name,
+    value: selectedValue ?? ''
+  };
+
+  const containerProps: ComponentProps<'div'> = {
+    ref: triggerContainerRef,
+    onClick: handleContainerClick
+  };
+
+  const hintIconProps = useMemo(() => getHintIconProps(effectiveHint?.type), [effectiveHint?.type]);
+  const hasHint = Boolean(effectiveHint?.message);
+  const hintMessage = effectiveHint?.message;
+  const hintMessageClassName = cn(
+    hintMessageVariants({ tone: effectiveHint?.type ?? 'info' }),
+    classNames?.hint,
+    effectiveHint?.type === 'error' && classNames?.errorMessage
+  );
+
+  return {
+    isOpen,
+    activeOptionKey,
+    filteredOptions,
+    selectedOption,
+    hasValue,
+    showClearButton,
+    isLoading,
+    isRequired,
+    clearAriaLabel,
+    loadingLabel,
+    emptyMessage,
+    label,
+    description,
+    placeholder,
+    searchPlaceholder,
+    triggerRef,
+    searchInputRef,
+    popoverRef,
+    searchQuery,
+    triggerClassName,
+    popoverClassName,
+    contentClassName,
+    nativeTriggerClassName,
+    valueClassName,
+    actionGroupClassName,
+    indicatorClassName,
+    clearButtonClassName,
+    labelClassName,
+    baseClassName,
+    searchInputClassName,
+    emptyMessageClassName,
+    filterContainerClassName,
+    getOptionClassName,
+    popoverStyle,
+    triggerProps,
+    searchInputProps,
+    getOptionProps,
+    labelProps,
+    descriptionProps,
+    hiddenInputProps,
+    containerProps,
+    handleClear,
+    hasHint,
+    hintIconProps,
+    hintMessage,
+    hintMessageClassName,
+    needsScopedDarkPortal,
+    portalContainer,
+    listboxAriaLabel
+  };
+};

--- a/src/components/atoms/autocomplete/useAutocomplete.ts
+++ b/src/components/atoms/autocomplete/useAutocomplete.ts
@@ -96,7 +96,7 @@ const getHintIconProps = (type?: AutocompleteHint['type']): HintIconProps | unde
       return { name: 'circle-check', tone: 'success', size: 16 };
     }
     case 'info': {
-      return { name: 'info', tone: 'muted', size: 16 };
+      return { name: 'info', tone: 'info', size: 16 };
     }
     default: {
       return undefined;
@@ -538,8 +538,9 @@ export const useAutocomplete = (props: AutocompleteProps): UseAutocompleteReturn
           break;
         }
         case 'Enter': {
+          event.preventDefault();
+
           if (activeOptionKey) {
-            event.preventDefault();
             const option = enabledFilteredOptions.find((item) => item.key === activeOptionKey);
             if (option) {
               selectOption(option);
@@ -548,7 +549,6 @@ export const useAutocomplete = (props: AutocompleteProps): UseAutocompleteReturn
           }
 
           if (enabledFilteredOptions.length === 1) {
-            event.preventDefault();
             const [onlyOption] = enabledFilteredOptions;
             if (onlyOption) {
               selectOption(onlyOption);
@@ -563,21 +563,35 @@ export const useAutocomplete = (props: AutocompleteProps): UseAutocompleteReturn
         }
         case 'Tab': {
           event.preventDefault();
-          // Use document-level focusable query instead of fragile sibling traversal
-          const triggerEl = triggerRef.current;
-          if (triggerEl) {
-            const allFocusable = Array.from(
-              document.querySelectorAll<HTMLElement>(
-                'button:not([disabled]), [href], input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-              )
-            );
-            const triggerIndex = allFocusable.indexOf(triggerEl);
-            if (triggerIndex !== -1) {
-              const nextIndex = event.shiftKey ? triggerIndex - 1 : triggerIndex + 1;
-              allFocusable[nextIndex]?.focus();
-            }
-          }
           closePopover('tab');
+
+          const container = triggerContainerRef.current;
+          if (!container) {
+            break;
+          }
+
+          const allFocusable = Array.from(
+            document.querySelectorAll<HTMLElement>(
+              'button:not([disabled]), [href], input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+            )
+          );
+
+          const internalIndices = allFocusable
+            .map((el, i) => (container.contains(el) ? i : -1))
+            .filter((i) => i !== -1);
+
+          if (internalIndices.length === 0) {
+            break;
+          }
+
+          const firstInternal = Math.min(...internalIndices);
+          const lastInternal = Math.max(...internalIndices);
+
+          if (event.shiftKey) {
+            allFocusable[firstInternal - 1]?.focus();
+          } else {
+            allFocusable[lastInternal + 1]?.focus();
+          }
           break;
         }
         case 'Home': {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import './styles/global.css';
 
 // ─── Atoms ───────────────────────────────────────────────────────────────────
 export { Alert } from './components/atoms/alert';
+export { Autocomplete } from './components/atoms/autocomplete';
 export { Avatar } from './components/atoms/avatar';
 export { Badge } from './components/atoms/badge';
 export { Button } from './components/atoms/button';

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -418,6 +418,9 @@
   --spacing-form-field-sm: 3rem; /* 48px */
   --spacing-form-field-md: 3.5rem; /* 56px */
   --spacing-form-field-lg: 4rem; /* 64px */
+  --spacing-search-input-sm: 2rem; /* 32px */
+  --spacing-search-input-md: 2.25rem; /* 36px */
+  --spacing-search-input-lg: 2.5rem; /* 40px */
   --spacing-touch-target-min: 2.75rem; /* 44px */
   --spacing-16: 4rem; /* 64px */
   --spacing-20: 5rem; /* 80px */


### PR DESCRIPTION
Closes #12

---

## Summary

Implementa el componente **Autocomplete** como átomo del design system.
Permite buscar y seleccionar una opción de una lista con popover,
search input y navegación por teclado completa.

---

## Tabla de cambios

| Archivo | Tipo | Descripción |
|---------|------|-------------|
| `src/components/atoms/autocomplete/Autocomplete.tsx` | New | Componente presentacional con portal |
| `src/components/atoms/autocomplete/useAutocomplete.ts` | New | Hook con lógica de estado, búsqueda, navegación y ARIA |
| `src/components/atoms/autocomplete/types.ts` | New | Tipos TypeScript y CVAs propios del componente |
| `src/components/atoms/autocomplete/Autocomplete.test.tsx` | New | Suite completa de 24 tests |
| `src/components/atoms/autocomplete/Autocomplete.stories.tsx` | New | 10 stories documentando todos los estados |
| `src/components/atoms/autocomplete/index.ts` | New | Public API exports |
| `src/index.ts` | Modified | Export del nuevo componente |
| `src/styles/theme.css` | Modified | Tokens `--spacing-search-input-*` |

---

## Evidencia de tests/build

```
Test Files  36 passed (36)
Tests       769 passed (769)
```

**Pre-commit hooks pasan:**
- ✅ biome (lint + format)
- ✅ harness-skills (skill boundaries verified)
- ✅ prop-docs (prop default docs verified)
- ✅ typecheck (TypeScript compilation)
- ✅ commitlint (conventional commit format)
- ✅ test (full suite en pre-push)

---

## Resultado de pre-PR component review

### Component Audit → **PASS**
- 6-file pattern correcto ✅
- TypeScript estricto, sin `any` ✅
- JSDoc en props públicas con `@default` ✅
- Tokens del design system, sin valores raw ✅
- Storybook convenciones seguidas ✅

### Visual Review → **PASS**
- Estados: base, hover, focus, active, disabled ✅
- Focus-ring nativo con `focus-visible:focus-ring` ✅
- Transiciones con `motion-safe:` prefix ✅
- Contraste WCAG AA ✅

### Judgment Day (accesibilidad) → **APPROVED**

**Issues CRITICAL encontrados y resueltos:**
1. Empty state sin `role="status" aria-live="polite"` → fixed
2. Home/End keys rotas sin opción activa → fixed

**Issues WARNING encontrados y resueltos:**
3. Tab handler con DOM traversal frágil → robusto con `querySelectorAll`
4. `needsScopedDarkPortal` lee ref durante render → movido a `useEffect`
5. Clases `data-[focused=true]` duplicadas → eliminadas
6. `popoverProps` retornado pero nunca usado → eliminado
7. Trigger sin nombre accesible sin label → dev warning agregado

**Mejoras menores adicionales:**
- ARIA structure: empty state fuera del listbox
- Warning message: menciona `aria-label` además de `label`/`ariaLabel`
- Tests: 4 tests nuevos para Home/End, empty state ARIA, dev warning, dark portal

---

## Notas de accesibilidad

### ARIA pattern
- **Trigger**: `button` con `aria-haspopup="listbox"` + `aria-expanded`
- **Search input**: `role="combobox"` con `aria-controls`, `aria-activedescendant`, `aria-autocomplete="list"`
- **Listbox**: `role="listbox"` con `aria-label`
- **Options**: `role="option"` con `aria-selected`, `aria-disabled`, `data-focused`
- **Empty state**: `role="status"` + `aria-live="polite"`
- **Loading**: `role="status"` + `aria-live="polite"`

### Keyboard navigation
| Tecla | Comportamiento |
|-------|----------------|
| ArrowDown | Siguiente opción habilitada |
| ArrowUp | Opción anterior / cierra si estamos al inicio |
| Home | Primera opción (funciona sin flecha previa) |
| End | Última opción (funciona sin flecha previa) |
| Enter | Selecciona opción activa o única filtrada |
| Escape | Cierra popover, foco al trigger |
| Tab | Cierra popover, foco al siguiente elemento |

### Separación de Select
Autocomplete tiene CVAs propios (copiados de Select) para ser
independiente según roadmap v1. Ambos componentes podrán evolucionar
por separado. Select queda pendiente de sus propios fixes de
`motion-safe:` y dev warning en issue separada.