### PR TITLE
feat(date-picker): add DatePicker molecule

### DIFF
--- a/src/components/atoms/calendar/Calendar.test.tsx
+++ b/src/components/atoms/calendar/Calendar.test.tsx
@@ -200,6 +200,42 @@ describe('Calendar — component behavior', () => {
     expect(screen.getByRole('button', { name: getDateMatcher(firstEnabledDate) })).toHaveAttribute('tabindex', '0');
   });
 
+  it('does not focus a day on mount by default', () => {
+    render(<Calendar selectedDate={baseDate} />);
+
+    expect(screen.getByRole('button', { name: getDateMatcher(baseDate) })).not.toHaveFocus();
+    expect(document.body).toHaveFocus();
+  });
+
+  it('focuses the selected enabled date on mount when autoFocusOnMount is true', () => {
+    render(<Calendar selectedDate={baseDate} autoFocusOnMount={true} />);
+
+    expect(screen.getByRole('button', { name: getDateMatcher(baseDate) })).toHaveFocus();
+  });
+
+  it('focuses the first enabled fallback on mount when the selected date is unavailable', () => {
+    const fallbackDate = new Date(2025, 7, 15);
+
+    render(<Calendar selectedDate={baseDate} disabledDates={[baseDate]} autoFocusOnMount={true} />);
+
+    expect(screen.getByRole('button', { name: getDateMatcher(baseDate) })).toBeDisabled();
+    expect(screen.getByRole('button', { name: getDateMatcher(fallbackDate) })).toHaveFocus();
+  });
+
+  it('does not focus a day on mount when disabled', () => {
+    render(<Calendar selectedDate={baseDate} disabled={true} autoFocusOnMount={true} />);
+
+    expect(screen.getByRole('button', { name: getDateMatcher(baseDate) })).not.toHaveFocus();
+    expect(document.body).toHaveFocus();
+  });
+
+  it('does not focus a day on mount when read-only', () => {
+    render(<Calendar selectedDate={baseDate} readOnly={true} autoFocusOnMount={true} />);
+
+    expect(screen.getByRole('button', { name: getDateMatcher(baseDate) })).not.toHaveFocus();
+    expect(document.body).toHaveFocus();
+  });
+
   it('skips disabled dates during keyboard navigation', async () => {
     const user = userEvent.setup();
 

--- a/src/components/atoms/calendar/Calendar.test.tsx
+++ b/src/components/atoms/calendar/Calendar.test.tsx
@@ -70,11 +70,29 @@ describe('useCalendar — logic', () => {
 });
 
 describe('Calendar — component behavior', () => {
-  it('renders a labeled calendar grid and month heading', () => {
+  it('keeps a single-month heading accessible while visually hidden', () => {
     render(<Calendar selectedDate={baseDate} />);
 
-    expect(screen.getByRole('grid', { name: /august 2025/i })).toBeInTheDocument();
+    const grid = screen.getByRole('grid', { name: /august 2025/i });
+    const heading = screen.getByRole('heading', { name: /august 2025/i });
+
+    expect(heading).toHaveClass('sr-only');
+    expect(grid).toHaveAttribute('aria-labelledby', heading.id);
     expect(screen.getByRole('button', { name: /choose month and year/i })).toBeInTheDocument();
+  });
+
+  it('keeps month headings visible in multi-month layouts', () => {
+    render(<Calendar selectedDate={baseDate} visibleMonths={2} />);
+
+    const augustGrid = screen.getByRole('grid', { name: /august 2025/i });
+    const septemberGrid = screen.getByRole('grid', { name: /september 2025/i });
+    const augustHeading = screen.getByRole('heading', { name: /august 2025/i });
+    const septemberHeading = screen.getByRole('heading', { name: /september 2025/i });
+
+    expect(augustHeading).not.toHaveClass('sr-only');
+    expect(septemberHeading).not.toHaveClass('sr-only');
+    expect(augustGrid).toHaveAttribute('aria-labelledby', augustHeading.id);
+    expect(septemberGrid).toHaveAttribute('aria-labelledby', septemberHeading.id);
   });
 
   it('selects a single date when an enabled day button is clicked', async () => {
@@ -209,6 +227,17 @@ describe('Calendar — component behavior', () => {
 
   it('focuses the selected enabled date on mount when autoFocusOnMount is true', () => {
     render(<Calendar selectedDate={baseDate} autoFocusOnMount={true} />);
+
+    expect(screen.getByRole('button', { name: getDateMatcher(baseDate) })).toHaveFocus();
+  });
+
+  it('focuses the selected enabled date when shown after hidden mount with autoFocusOnMount', () => {
+    const { rerender } = render(<Calendar selectedDate={baseDate} autoFocusOnMount={true} show={false} />);
+
+    expect(screen.queryByRole('grid')).not.toBeInTheDocument();
+    expect(document.body).toHaveFocus();
+
+    rerender(<Calendar selectedDate={baseDate} autoFocusOnMount={true} show={true} />);
 
     expect(screen.getByRole('button', { name: getDateMatcher(baseDate) })).toHaveFocus();
   });

--- a/src/components/atoms/calendar/types.ts
+++ b/src/components/atoms/calendar/types.ts
@@ -856,6 +856,11 @@ export type CalendarProps = {
   selectedDate?: CalendarSelection;
   onDateChange?: (date: CalendarSelection) => void;
   /**
+   * @control boolean
+   * @default false
+   */
+  autoFocusOnMount?: boolean;
+  /**
    * @control object
    * @default []
    */

--- a/src/components/atoms/calendar/useCalendar.ts
+++ b/src/components/atoms/calendar/useCalendar.ts
@@ -405,6 +405,7 @@ export const useCalendar = ({
   color = 'default',
   selectedDate,
   onDateChange,
+  autoFocusOnMount = false,
   disabledDates = EMPTY_DISABLED_DATES,
   variant = 'filled',
   size = 'md',
@@ -520,6 +521,7 @@ export const useCalendar = ({
   const [isPickerOpen, setIsPickerOpen] = useState(false);
   const dayButtonRefs = useRef(new Map<string, HTMLButtonElement>());
   const pendingFocusKeyRef = useRef<string | null>(null);
+  const hasAutoFocusAttemptedOnMountRef = useRef(false);
   const pickerCloseButtonRef = useRef<HTMLButtonElement | null>(null);
   const togglePickerButtonRef = useRef<HTMLButtonElement | null>(null);
 
@@ -865,6 +867,26 @@ export const useCalendar = ({
     nextFocusedElement?.focus();
     pendingFocusKeyRef.current = null;
   }, [months]);
+
+  useEffect(() => {
+    if (hasAutoFocusAttemptedOnMountRef.current) {
+      return;
+    }
+
+    hasAutoFocusAttemptedOnMountRef.current = true;
+
+    if (!autoFocusOnMount || !show || disabled || readOnly || isPickerOpen) {
+      return;
+    }
+
+    const focusedElement = dayButtonRefs.current.get(toDateKey(effectiveFocusedDate));
+
+    if (!focusedElement || focusedElement.disabled) {
+      return;
+    }
+
+    focusedElement.focus();
+  }, [autoFocusOnMount, disabled, effectiveFocusedDate, isPickerOpen, readOnly, show]);
 
   const headerLabel = useMemo(() => buildHeaderLabel(locale, monthDates), [locale, monthDates]);
   const calendarLabel = `${localizedText.calendarGrid}: ${headerLabel}`;

--- a/src/components/atoms/calendar/useCalendar.ts
+++ b/src/components/atoms/calendar/useCalendar.ts
@@ -869,13 +869,13 @@ export const useCalendar = ({
   }, [months]);
 
   useEffect(() => {
-    if (hasAutoFocusAttemptedOnMountRef.current) {
+    if (hasAutoFocusAttemptedOnMountRef.current || !show) {
       return;
     }
 
     hasAutoFocusAttemptedOnMountRef.current = true;
 
-    if (!autoFocusOnMount || !show || disabled || readOnly || isPickerOpen) {
+    if (!autoFocusOnMount || disabled || readOnly || isPickerOpen) {
       return;
     }
 
@@ -1001,7 +1001,7 @@ export const useCalendar = ({
     headerClassName: calendarHeaderVariants({ size }),
     headerLabel,
     liveRegionLabel: headerLabel,
-    monthHeadingClassName: calendarMonthHeadingVariants({ size }),
+    monthHeadingClassName: cn(calendarMonthHeadingVariants({ size }), months.length === 1 && 'sr-only'),
     monthPickerLabel,
     monthSectionClassName: calendarMonthSectionVariants({ size }),
     monthsLayoutClassName: calendarMonthsLayoutVariants({ size }),

--- a/src/components/atoms/popover/Popover.test.tsx
+++ b/src/components/atoms/popover/Popover.test.tsx
@@ -266,6 +266,24 @@ describe('Popover — component behavior', () => {
     expect(screen.queryByRole('dialog', { name: 'Disabled content' })).not.toBeInTheDocument();
   });
 
+  it('preserves an as-child trigger aria-disabled state without disabling focusable buttons', () => {
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <button type='button' aria-disabled={true}>
+            Read-only trigger
+          </button>
+        </Popover.Trigger>
+        <Popover.Content ariaLabel='Read-only content'>Read-only body</Popover.Content>
+      </Popover>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Read-only trigger' });
+
+    expect(trigger).not.toBeDisabled();
+    expect(trigger).toHaveAttribute('aria-disabled', 'true');
+  });
+
   it('supports a non-button custom trigger with keyboard activation', async () => {
     const user = userEvent.setup();
 

--- a/src/components/atoms/popover/Popover.test.tsx
+++ b/src/components/atoms/popover/Popover.test.tsx
@@ -284,6 +284,52 @@ describe('Popover — component behavior', () => {
     expect(trigger).toHaveAttribute('aria-disabled', 'true');
   });
 
+  it('does not open from click when an as-child trigger is aria-disabled', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <Popover onOpenChange={onOpenChange}>
+        <Popover.Trigger>
+          <button type='button' aria-disabled={true}>
+            Read-only click trigger
+          </button>
+        </Popover.Trigger>
+        <Popover.Content ariaLabel='Read-only click content'>Read-only click body</Popover.Content>
+      </Popover>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Read-only click trigger' }));
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole('dialog', { name: 'Read-only click content' })).not.toBeInTheDocument();
+  });
+
+  it('does not open from keyboard activation when an as-child trigger is aria-disabled', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <Popover onOpenChange={onOpenChange}>
+        <Popover.Trigger>
+          <button type='button' aria-disabled={true}>
+            Read-only keyboard trigger
+          </button>
+        </Popover.Trigger>
+        <Popover.Content ariaLabel='Read-only keyboard content'>Read-only keyboard body</Popover.Content>
+      </Popover>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Read-only keyboard trigger' });
+    trigger.focus();
+
+    await user.keyboard('{Enter}');
+    await user.keyboard(' ');
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole('dialog', { name: 'Read-only keyboard content' })).not.toBeInTheDocument();
+  });
+
   it('supports a non-button custom trigger with keyboard activation', async () => {
     const user = userEvent.setup();
 

--- a/src/components/atoms/popover/Popover.test.tsx
+++ b/src/components/atoms/popover/Popover.test.tsx
@@ -284,14 +284,15 @@ describe('Popover — component behavior', () => {
     expect(trigger).toHaveAttribute('aria-disabled', 'true');
   });
 
-  it('does not open from click when an as-child trigger is aria-disabled', async () => {
+  it('does not call child onClick or open from click when an as-child trigger is aria-disabled', async () => {
     const user = userEvent.setup();
+    const onClick = vi.fn();
     const onOpenChange = vi.fn();
 
     render(
       <Popover onOpenChange={onOpenChange}>
         <Popover.Trigger>
-          <button type='button' aria-disabled={true}>
+          <button type='button' aria-disabled={true} onClick={onClick}>
             Read-only click trigger
           </button>
         </Popover.Trigger>
@@ -301,18 +302,46 @@ describe('Popover — component behavior', () => {
 
     await user.click(screen.getByRole('button', { name: 'Read-only click trigger' }));
 
+    expect(onClick).not.toHaveBeenCalled();
     expect(onOpenChange).not.toHaveBeenCalled();
     expect(screen.queryByRole('dialog', { name: 'Read-only click content' })).not.toBeInTheDocument();
   });
 
-  it('does not open from keyboard activation when an as-child trigger is aria-disabled', async () => {
-    const user = userEvent.setup();
+  it('prevents default, skips child onClick, and does not open for aria-disabled anchor triggers', () => {
+    const onClick = vi.fn();
     const onOpenChange = vi.fn();
 
     render(
       <Popover onOpenChange={onOpenChange}>
         <Popover.Trigger>
-          <button type='button' aria-disabled={true}>
+          <a href='/disabled-popover-target' aria-disabled={true} onClick={onClick}>
+            Read-only anchor trigger
+          </a>
+        </Popover.Trigger>
+        <Popover.Content ariaLabel='Read-only anchor content'>Read-only anchor body</Popover.Content>
+      </Popover>
+    );
+
+    const trigger = screen.getByRole('link', { name: 'Read-only anchor trigger' });
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const wasNotCanceled = trigger.dispatchEvent(clickEvent);
+
+    expect(wasNotCanceled).toBe(false);
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(onClick).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole('dialog', { name: 'Read-only anchor content' })).not.toBeInTheDocument();
+  });
+
+  it('does not call child onKeyDown or open from keyboard activation when an as-child trigger is aria-disabled', async () => {
+    const user = userEvent.setup();
+    const onKeyDown = vi.fn();
+    const onOpenChange = vi.fn();
+
+    render(
+      <Popover onOpenChange={onOpenChange}>
+        <Popover.Trigger>
+          <button type='button' aria-disabled={true} onKeyDown={onKeyDown}>
             Read-only keyboard trigger
           </button>
         </Popover.Trigger>
@@ -326,8 +355,35 @@ describe('Popover — component behavior', () => {
     await user.keyboard('{Enter}');
     await user.keyboard(' ');
 
+    expect(onKeyDown).not.toHaveBeenCalled();
     expect(onOpenChange).not.toHaveBeenCalled();
     expect(screen.queryByRole('dialog', { name: 'Read-only keyboard content' })).not.toBeInTheDocument();
+  });
+
+  it('preserves child onKeyDown for aria-disabled non-activation keys', async () => {
+    const user = userEvent.setup();
+    const onKeyDown = vi.fn();
+    const onOpenChange = vi.fn();
+
+    render(
+      <Popover onOpenChange={onOpenChange}>
+        <Popover.Trigger>
+          <button type='button' aria-disabled={true} onKeyDown={onKeyDown}>
+            Read-only non-activation trigger
+          </button>
+        </Popover.Trigger>
+        <Popover.Content ariaLabel='Read-only non-activation content'>Read-only non-activation body</Popover.Content>
+      </Popover>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Read-only non-activation trigger' });
+    trigger.focus();
+
+    await user.keyboard('{ArrowDown}');
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole('dialog', { name: 'Read-only non-activation content' })).not.toBeInTheDocument();
   });
 
   it('supports a non-button custom trigger with keyboard activation', async () => {

--- a/src/components/atoms/popover/usePopover.ts
+++ b/src/components/atoms/popover/usePopover.ts
@@ -419,7 +419,7 @@ export const usePopoverTrigger = ({
       'aria-controls': contentId,
       'aria-expanded': open,
       'aria-haspopup': 'dialog',
-      'aria-disabled': disabled || undefined,
+      'aria-disabled': disabled ? true : triggerChild.props['aria-disabled'],
       onClick: withComposedHandler(triggerChild.props.onClick, handleIntrinsicClick),
       onFocus: withComposedHandler(triggerChild.props.onFocus, handleIntrinsicFocus),
       onKeyDown: withComposedHandler(triggerChild.props.onKeyDown, handleIntrinsicKeyDown)

--- a/src/components/atoms/popover/usePopover.ts
+++ b/src/components/atoms/popover/usePopover.ts
@@ -251,15 +251,39 @@ const getTriggerElementFromAnchor = (anchorElement: HTMLSpanElement | null): HTM
 
 const withComposedHandler = <TEvent>(
   originalHandler: ((event: TEvent) => void) | undefined,
-  nextHandler: (event: TEvent) => void
+  nextHandler: (event: TEvent) => void,
+  shouldBlock?: (event: TEvent) => boolean
 ) => {
   return (event: TEvent) => {
+    if (shouldBlock?.(event)) {
+      return;
+    }
+
     originalHandler?.(event);
     nextHandler(event);
   };
 };
 
 const isAriaDisabledTrigger = (element: HTMLElement) => element.getAttribute('aria-disabled') === 'true';
+const isKeyboardActivationKey = (key: string) => key === 'Enter' || key === ' ';
+
+const shouldBlockAriaDisabledClick = (event: MouseEvent<HTMLElement>): boolean => {
+  if (!isAriaDisabledTrigger(event.currentTarget)) {
+    return false;
+  }
+
+  event.preventDefault();
+  return true;
+};
+
+const shouldBlockAriaDisabledKeyboardActivation = (event: KeyboardEvent<HTMLElement>): boolean => {
+  if (!isAriaDisabledTrigger(event.currentTarget) || !isKeyboardActivationKey(event.key)) {
+    return false;
+  }
+
+  event.preventDefault();
+  return true;
+};
 
 export const PopoverRootProvider = ({ children, value }: PopoverRootProviderProps) => {
   return createElement(PopoverRootContext.Provider, { value }, children);
@@ -422,9 +446,13 @@ export const usePopoverTrigger = ({
       'aria-expanded': open,
       'aria-haspopup': 'dialog',
       'aria-disabled': disabled ? true : triggerChild.props['aria-disabled'],
-      onClick: withComposedHandler(triggerChild.props.onClick, handleIntrinsicClick),
+      onClick: withComposedHandler(triggerChild.props.onClick, handleIntrinsicClick, shouldBlockAriaDisabledClick),
       onFocus: withComposedHandler(triggerChild.props.onFocus, handleIntrinsicFocus),
-      onKeyDown: withComposedHandler(triggerChild.props.onKeyDown, handleIntrinsicKeyDown)
+      onKeyDown: withComposedHandler(
+        triggerChild.props.onKeyDown,
+        handleIntrinsicKeyDown,
+        shouldBlockAriaDisabledKeyboardActivation
+      )
     };
 
     if (!isIntrinsicInteractiveTrigger(triggerChild)) {

--- a/src/components/atoms/popover/usePopover.ts
+++ b/src/components/atoms/popover/usePopover.ts
@@ -259,6 +259,8 @@ const withComposedHandler = <TEvent>(
   };
 };
 
+const isAriaDisabledTrigger = (element: HTMLElement) => element.getAttribute('aria-disabled') === 'true';
+
 export const PopoverRootProvider = ({ children, value }: PopoverRootProviderProps) => {
   return createElement(PopoverRootContext.Provider, { value }, children);
 };
@@ -362,7 +364,7 @@ export const usePopoverTrigger = ({
 
   const handleIntrinsicClick = useCallback(
     (event: MouseEvent<HTMLElement>) => {
-      if (event.defaultPrevented || disabled) {
+      if (event.defaultPrevented || disabled || isAriaDisabledTrigger(event.currentTarget)) {
         return;
       }
 
@@ -388,7 +390,7 @@ export const usePopoverTrigger = ({
 
   const handleIntrinsicKeyDown = useCallback(
     (event: KeyboardEvent<HTMLElement>) => {
-      if (event.defaultPrevented || disabled) {
+      if (event.defaultPrevented || disabled || isAriaDisabledTrigger(event.currentTarget)) {
         return;
       }
 

--- a/src/components/molecules/date-picker/DatePicker.stories.tsx
+++ b/src/components/molecules/date-picker/DatePicker.stories.tsx
@@ -1,0 +1,171 @@
+import { action } from '@storybook/addon-actions';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { DatePicker } from './DatePicker';
+
+/**
+ * ## Description
+ * DatePicker lets users choose one local calendar date from an accessible popover field.
+ * It is intended for forms that need a `Date | null` value, optional hidden input serialization, and Calendar-powered date constraints.
+ *
+ * ## Dependencies
+ * - `Popover` anchors the calendar surface and manages dialog semantics.
+ * - `Calendar` renders the date grid and owns calendar keyboard behavior.
+ *
+ * ## Usage Guide
+ * Provide either a visible `label` or an `ariaLabel` so the trigger has an accessible name.
+ * Use `name` when the selected date should serialize as a local `YYYY-MM-DD` hidden input value.
+ */
+const meta: Meta<typeof DatePicker> = {
+  title: 'Molecules/DatePicker',
+  component: DatePicker,
+  parameters: {
+    docs: {
+      autodocs: true
+    }
+  },
+  tags: ['autodocs']
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DatePicker>;
+
+/**
+ * Default field with a visible label and no selected date.
+ */
+export const Default: Story = {
+  args: {
+    id: 'storybook-date-picker-default',
+    label: 'Event date',
+    name: 'eventDate',
+    onDateChange: action('date change'),
+    onOpenChange: action('open change')
+  }
+};
+
+/**
+ * Initial values display with the configured formatter and serialize through the hidden input when a name is provided.
+ */
+export const WithInitialValue: Story = {
+  args: {
+    id: 'storybook-date-picker-initial',
+    label: 'Start date',
+    name: 'startDate',
+    defaultValue: new Date(2024, 4, 15),
+    isClearable: true,
+    onDateChange: action('date change'),
+    onOpenChange: action('open change')
+  }
+};
+
+/**
+ * Controlled usage keeps the selected date in parent state while still reporting Storybook actions.
+ */
+export const Controlled: Story = {
+  render: () => {
+    const [value, setValue] = useState<Date | null>(new Date(2024, 5, 20));
+
+    return (
+      <DatePicker
+        id='storybook-date-picker-controlled'
+        label='Controlled date'
+        name='controlledDate'
+        value={value}
+        isClearable={true}
+        onDateChange={(date) => {
+          action('date change')(date);
+          setValue(date);
+        }}
+        onOpenChange={action('open change')}
+      />
+    );
+  }
+};
+
+/**
+ * Validation copy is announced through the trigger description and uses the error visual state.
+ */
+export const ValidationError: Story = {
+  args: {
+    id: 'storybook-date-picker-error',
+    label: 'Required date',
+    description: 'Choose the date that should appear on the booking.',
+    isRequired: true,
+    validationState: 'error',
+    validationMessage: 'Choose an available date.',
+    onDateChange: action('date change'),
+    onOpenChange: action('open change')
+  }
+};
+
+/**
+ * Disabled fields do not open and do not render a hidden input value.
+ */
+export const Disabled: Story = {
+  args: {
+    id: 'storybook-date-picker-disabled',
+    label: 'Disabled date',
+    name: 'disabledDate',
+    defaultValue: new Date(2024, 7, 10),
+    disabled: true,
+    onDateChange: action('date change'),
+    onOpenChange: action('open change')
+  }
+};
+
+/**
+ * Read-only fields remain readable and keep their hidden input value while preventing user-driven changes.
+ */
+export const ReadOnly: Story = {
+  args: {
+    id: 'storybook-date-picker-readonly',
+    label: 'Read-only date',
+    name: 'readonlyDate',
+    defaultValue: new Date(2024, 7, 10),
+    readOnly: true,
+    isClearable: true,
+    onDateChange: action('date change'),
+    onOpenChange: action('open change')
+  }
+};
+
+/**
+ * Clearable fields render the clear action as a sibling button when a date is selected.
+ */
+export const Clearable: Story = {
+  args: {
+    id: 'storybook-date-picker-clearable',
+    label: 'Clearable date',
+    name: 'clearableDate',
+    defaultValue: new Date(2024, 8, 3),
+    isClearable: true,
+    onDateChange: action('date change'),
+    onOpenChange: action('open change')
+  }
+};
+
+/**
+ * Calendar constraints, multiple visible months, and Gregorian locale formatting can be configured together.
+ */
+export const WithConstraints: Story = {
+  args: {
+    id: 'storybook-date-picker-constraints',
+    label: 'Booking date',
+    description: 'Only the visible booking window is selectable.',
+    minDate: new Date(2024, 4, 1),
+    maxDate: new Date(2024, 5, 30),
+    disabledDates: [new Date(2024, 4, 12), new Date(2024, 4, 19)],
+    firstDayOfWeek: 1,
+    visibleMonths: 2,
+    locale: 'en-GB',
+    formatOptions: {
+      day: '2-digit',
+      month: 'long',
+      year: 'numeric'
+    },
+    defaultValue: new Date(2024, 4, 15),
+    onDateChange: action('date change'),
+    onOpenChange: action('open change')
+  }
+};

--- a/src/components/molecules/date-picker/DatePicker.stories.tsx
+++ b/src/components/molecules/date-picker/DatePicker.stories.tsx
@@ -60,6 +60,46 @@ export const WithInitialValue: Story = {
 };
 
 /**
+ * Shows the supported size options side by side for visual comparison.
+ */
+export const Sizes: Story = {
+  render: () => (
+    <div className='flex items-end gap-4'>
+      <div className='w-56'>
+        <DatePicker
+          id='storybook-date-picker-size-sm'
+          label='Small'
+          size='sm'
+          placeholder='Select date'
+          onDateChange={action('sm-date-change')}
+          onOpenChange={action('sm-open-change')}
+        />
+      </div>
+      <div className='w-56'>
+        <DatePicker
+          id='storybook-date-picker-size-md'
+          label='Medium'
+          size='md'
+          placeholder='Select date'
+          onDateChange={action('md-date-change')}
+          onOpenChange={action('md-open-change')}
+        />
+      </div>
+      <div className='w-56'>
+        <DatePicker
+          id='storybook-date-picker-size-lg'
+          label='Large'
+          size='lg'
+          placeholder='Select date'
+          onDateChange={action('lg-date-change')}
+          onOpenChange={action('lg-open-change')}
+        />
+      </div>
+    </div>
+  )
+};
+
+/**
  * Controlled usage keeps the selected date in parent state while still reporting Storybook actions.
  */
 export const Controlled: Story = {

--- a/src/components/molecules/date-picker/DatePicker.test.tsx
+++ b/src/components/molecules/date-picker/DatePicker.test.tsx
@@ -111,6 +111,16 @@ describe('useDatePicker — logic', () => {
     });
   });
 
+  it('fits the popover to the calendar while allowing consumer width overrides', () => {
+    const defaultWidth = renderHook(() => useDatePicker({ id: 'fit-popover' }));
+    const consumerWidth = renderHook(() =>
+      useDatePicker({ id: 'custom-popover-width', popoverClassName: 'w-full custom-popover-class' })
+    );
+
+    expect(defaultWidth.result.current.popoverClassName).toBe('w-fit');
+    expect(consumerWidth.result.current.popoverClassName).toBe('w-full custom-popover-class');
+  });
+
   it('serializes hidden input dates with local date getters instead of ISO UTC slicing', () => {
     const boundaryDate = new Date('2024-01-01T00:00:00.000Z');
     vi.spyOn(boundaryDate, 'getFullYear').mockReturnValue(2023);
@@ -236,6 +246,63 @@ describe('useDatePicker — logic', () => {
 
     act(() => {
       result.current.selectDate(unavailableDate);
+    });
+
+    expect(result.current.effectiveOpen).toBe(true);
+    expect(handleDateChange).not.toHaveBeenCalled();
+    expect(handleOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('accepts min and max boundary dates while rejecting dates outside the range', () => {
+    const handleDateChange = vi.fn();
+    const handleOpenChange = vi.fn();
+    const minDate = new Date(2024, 4, 10);
+    const maxDate = new Date(2024, 4, 20);
+    const beforeMin = new Date(2024, 4, 9);
+    const atMin = new Date(2024, 4, 10);
+    const atMax = new Date(2024, 4, 20);
+    const afterMax = new Date(2024, 4, 21);
+    const { result } = renderHook(() =>
+      useDatePicker({
+        id: 'bounded-direct-selection',
+        open: true,
+        minDate,
+        maxDate,
+        onDateChange: handleDateChange,
+        onOpenChange: handleOpenChange
+      })
+    );
+
+    act(() => {
+      result.current.selectDate(beforeMin);
+    });
+
+    expect(result.current.effectiveOpen).toBe(true);
+    expect(handleDateChange).not.toHaveBeenCalled();
+    expect(handleOpenChange).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.selectDate(atMin);
+    });
+
+    expect(handleDateChange).toHaveBeenCalledWith(atMin);
+    expect(handleOpenChange).toHaveBeenCalledWith(false);
+
+    handleDateChange.mockClear();
+    handleOpenChange.mockClear();
+
+    act(() => {
+      result.current.selectDate(atMax);
+    });
+
+    expect(handleDateChange).toHaveBeenCalledWith(atMax);
+    expect(handleOpenChange).toHaveBeenCalledWith(false);
+
+    handleDateChange.mockClear();
+    handleOpenChange.mockClear();
+
+    act(() => {
+      result.current.selectDate(afterMax);
     });
 
     expect(result.current.effectiveOpen).toBe(true);
@@ -371,6 +438,29 @@ describe('DatePicker — component behavior', () => {
     expect(screen.getByRole('button', { name: 'Choose deadline Select date' })).toHaveTextContent('Select date');
   });
 
+  it('forwards native root props to the DatePicker wrapper', () => {
+    render(
+      <DatePicker
+        id='native-root-date'
+        aria-label='Native root label'
+        data-integration='booking-form'
+        data-testid='date-picker-root'
+        dir='rtl'
+        style={{ display: 'block' }}
+        title='Native root title'
+      />
+    );
+
+    const root = screen.getByTestId('date-picker-root');
+
+    expect(root).toHaveAttribute('data-slot', 'date-picker');
+    expect(root).toHaveAttribute('aria-label', 'Native root label');
+    expect(root).toHaveAttribute('data-integration', 'booking-form');
+    expect(root).toHaveAttribute('dir', 'rtl');
+    expect(root).toHaveAttribute('title', 'Native root title');
+    expect(root).toHaveStyle({ display: 'block' });
+  });
+
   it('includes the selected display value in trigger accessible names', () => {
     const selectedDate = new Date(2024, 4, 15);
     const { rerender } = render(<DatePicker id='start-date' label='Start date' value={selectedDate} locale='en-US' />);
@@ -443,7 +533,10 @@ describe('DatePicker — component behavior', () => {
 
     await user.click(screen.getByRole('button', { name: /Booking date/ }));
 
-    expect(await screen.findByRole('dialog', { name: 'Booking date calendar' })).toHaveClass('custom-popover-class');
+    expect(await screen.findByRole('dialog', { name: 'Booking date calendar' })).toHaveClass(
+      'w-fit',
+      'custom-popover-class'
+    );
     expect(screen.getByRole('application', { name: 'Mock calendar' })).toHaveAttribute('data-autofocus', 'true');
 
     const calendarProps = getLastCalendarProps();
@@ -525,8 +618,11 @@ describe('DatePicker — component behavior', () => {
     );
 
     const readOnlyTrigger = screen.getByRole('button', { name: 'Blocked date Jul 4, 2024' });
+    const readOnlyField = container.querySelector('[data-slot="date-picker-field"]');
     expect(readOnlyTrigger).not.toBeDisabled();
     expect(readOnlyTrigger).toHaveAttribute('aria-disabled', 'true');
+    expect(readOnlyField).not.toHaveClass('opacity-40');
+    expect(readOnlyField).not.toHaveClass('cursor-not-allowed');
     expect(getHiddenInput(container, 'blocked')).toHaveValue('2024-07-04');
     expect(screen.queryByRole('button', { name: 'Clear selected date' })).not.toBeInTheDocument();
 

--- a/src/components/molecules/date-picker/DatePicker.test.tsx
+++ b/src/components/molecules/date-picker/DatePicker.test.tsx
@@ -1,0 +1,600 @@
+/** @vitest-environment jsdom */
+
+import '@testing-library/jest-dom/vitest';
+import { act, render, renderHook, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { FormEvent } from 'react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+type MockCalendarSelection = Date | null | [Date | null, Date | null];
+
+type MockCalendarProps = {
+  autoFocusOnMount?: boolean;
+  disabled?: boolean;
+  disabledDates?: Date[];
+  firstDayOfWeek?: number;
+  locale?: string;
+  maxDate?: Date;
+  minDate?: Date;
+  onDateChange?: (selection: MockCalendarSelection) => void;
+  readOnly?: boolean;
+  selectedDate?: MockCalendarSelection;
+  visibleMonths?: number;
+};
+
+const calendarMockState = vi.hoisted(() => ({
+  props: [] as MockCalendarProps[]
+}));
+
+vi.mock('../../atoms/calendar', () => ({
+  // biome-ignore lint/style/useNamingConvention: must match component export name
+  Calendar: (props: MockCalendarProps) => {
+    calendarMockState.props.push(props);
+
+    return (
+      <div aria-label='Mock calendar' data-autofocus={String(props.autoFocusOnMount)} role='application'>
+        <button type='button' onClick={() => props.onDateChange?.(new Date(2024, 4, 15))}>
+          Select May 15, 2024
+        </button>
+        <button type='button' onClick={() => props.onDateChange?.([new Date(2024, 4, 1), new Date(2024, 4, 15)])}>
+          Select range
+        </button>
+      </div>
+    );
+  }
+}));
+
+import { DatePicker as RootDatePicker } from '../../../index';
+import { DatePicker } from './DatePicker';
+import { DatePicker as BarrelDatePicker } from './index';
+import { useDatePicker } from './useDatePicker';
+
+const getLastCalendarProps = () => {
+  const props = calendarMockState.props.at(-1);
+
+  if (!props) {
+    throw new Error('Expected DatePicker to render Calendar.');
+  }
+
+  return props;
+};
+
+const getHiddenInput = (container: HTMLElement, name: string) => {
+  const input = container.querySelector(`input[name="${name}"]`);
+
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error(`Expected hidden input named ${name}.`);
+  }
+
+  return input;
+};
+
+beforeAll(() => {
+  if (typeof window.ResizeObserver === 'undefined') {
+    class ResizeObserver {
+      observe() {
+        // no-op for jsdom positioning tests
+      }
+
+      unobserve() {
+        // no-op for jsdom positioning tests
+      }
+
+      disconnect() {
+        // no-op for jsdom positioning tests
+      }
+    }
+
+    window.ResizeObserver = ResizeObserver;
+  }
+});
+
+afterEach(() => {
+  calendarMockState.props = [];
+  vi.restoreAllMocks();
+});
+
+describe('useDatePicker — logic', () => {
+  it('returns the default empty state and hidden value for named fields', () => {
+    const { result } = renderHook(() => useDatePicker({ id: 'birthday', name: 'birthday' }));
+
+    expect(result.current.selectedDate).toBeNull();
+    expect(result.current.displayValue).toBe('Select date');
+    expect(result.current.effectiveOpen).toBe(false);
+    expect(result.current.firstDayOfWeek).toBe(1);
+    expect(result.current.visibleMonths).toBe(1);
+    expect(result.current.hiddenInputProps).toMatchObject({
+      type: 'hidden',
+      name: 'birthday',
+      value: '',
+      disabled: false
+    });
+  });
+
+  it('serializes hidden input dates with local date getters instead of ISO UTC slicing', () => {
+    const boundaryDate = new Date('2024-01-01T00:00:00.000Z');
+    vi.spyOn(boundaryDate, 'getFullYear').mockReturnValue(2023);
+    vi.spyOn(boundaryDate, 'getMonth').mockReturnValue(11);
+    vi.spyOn(boundaryDate, 'getDate').mockReturnValue(31);
+
+    const { result } = renderHook(() =>
+      useDatePicker({ id: 'boundary', name: 'boundary', defaultValue: boundaryDate })
+    );
+
+    expect(result.current.hiddenInputProps?.value).toBe('2023-12-31');
+    expect(result.current.hiddenInputProps?.value).not.toBe(boundaryDate.toISOString().slice(0, 10));
+  });
+
+  it('sanitizes date-only format options and lets dateStyle win over granular fields', () => {
+    const { result } = renderHook(() =>
+      useDatePicker({
+        id: 'formatted',
+        defaultValue: new Date(2024, 0, 15),
+        locale: 'en-US',
+        formatOptions: {
+          calendar: 'islamic',
+          dateStyle: 'medium',
+          day: '2-digit',
+          hour: '2-digit',
+          month: '2-digit',
+          timeStyle: 'short',
+          timeZone: 'UTC',
+          year: 'numeric'
+        }
+      })
+    );
+
+    expect(result.current.sanitizedFormatOptions).toEqual({ dateStyle: 'medium' });
+    expect(result.current.displayValue.length).toBeGreaterThan(0);
+  });
+
+  it('resolves invalid and non-Gregorian locale candidates to one Gregorian locale for display and Calendar', () => {
+    const invalidLocale = renderHook(() => useDatePicker({ id: 'invalid-locale', locale: 'not-a-locale' }));
+    const nonGregorianLocale = renderHook(() =>
+      useDatePicker({ id: 'non-gregorian-locale', locale: 'ar-SA-u-ca-islamic' })
+    );
+
+    for (const hook of [invalidLocale, nonGregorianLocale]) {
+      expect(hook.result.current.calendarProps.locale).toBe(hook.result.current.effectiveLocale);
+      expect(new Intl.DateTimeFormat(hook.result.current.effectiveLocale).resolvedOptions().calendar).toBe('gregory');
+    }
+  });
+
+  it('falls back gracefully for invalid display dates and runtime-invalid format options', () => {
+    const invalidDate = renderHook(() =>
+      useDatePicker({ id: 'invalid-date', name: 'invalid-date', value: new Date(Number.NaN) })
+    );
+    const invalidOptions = renderHook(() =>
+      useDatePicker({
+        id: 'invalid-options',
+        defaultValue: new Date(2024, 0, 15),
+        locale: 'en-US',
+        formatOptions: { dateStyle: 'not-a-date-style' } as unknown as Intl.DateTimeFormatOptions
+      })
+    );
+
+    expect(invalidDate.result.current.displayValue).toBe('Select date');
+    expect(invalidDate.result.current.hiddenInputProps?.value).toBe('');
+    expect(invalidDate.result.current.calendarProps.selectedDate).toBeNull();
+    expect(invalidOptions.result.current.displayValue).toBe('Jan 15, 2024');
+  });
+
+  it('lets controlled value win over defaultValue while emitting selected dates and clear events', () => {
+    const controlledDate = new Date(2024, 3, 10);
+    const defaultDate = new Date(2024, 4, 11);
+    const nextDate = new Date(2024, 5, 12);
+    const handleDateChange = vi.fn();
+
+    const controlled = renderHook(() =>
+      useDatePicker({
+        id: 'controlled',
+        value: controlledDate,
+        defaultValue: defaultDate,
+        onDateChange: handleDateChange
+      })
+    );
+
+    expect(controlled.result.current.selectedDate).toBe(controlledDate);
+
+    act(() => {
+      controlled.result.current.selectDate(nextDate);
+    });
+
+    expect(controlled.result.current.selectedDate).toBe(controlledDate);
+    expect(handleDateChange).toHaveBeenLastCalledWith(nextDate);
+
+    const uncontrolled = renderHook(() =>
+      useDatePicker({ id: 'uncontrolled', defaultValue: defaultDate, onDateChange: handleDateChange })
+    );
+
+    act(() => {
+      uncontrolled.result.current.selectDate(nextDate);
+    });
+    act(() => {
+      uncontrolled.result.current.clearDate();
+    });
+
+    expect(uncontrolled.result.current.selectedDate).toBeNull();
+    expect(handleDateChange).toHaveBeenCalledWith(nextDate);
+    expect(handleDateChange).toHaveBeenCalledWith(null);
+    expect(uncontrolled.result.current.shouldRestoreFocusAfterClear).toBe(true);
+  });
+
+  it('does not close the popover when direct hook selection rejects an unavailable date', () => {
+    const handleDateChange = vi.fn();
+    const handleOpenChange = vi.fn();
+    const unavailableDate = new Date(2024, 0, 1);
+    const { result } = renderHook(() =>
+      useDatePicker({
+        id: 'unavailable-direct-selection',
+        defaultOpen: true,
+        disabledDates: [unavailableDate],
+        onDateChange: handleDateChange,
+        onOpenChange: handleOpenChange
+      })
+    );
+
+    act(() => {
+      result.current.selectDate(unavailableDate);
+    });
+
+    expect(result.current.effectiveOpen).toBe(true);
+    expect(handleDateChange).not.toHaveBeenCalled();
+    expect(handleOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('supports uncontrolled and controlled open state precedence', () => {
+    const uncontrolledOpenChange = vi.fn();
+    const controlledOpenChange = vi.fn();
+
+    const uncontrolled = renderHook(() =>
+      useDatePicker({ id: 'uncontrolled-open', defaultOpen: true, onOpenChange: uncontrolledOpenChange })
+    );
+    const controlled = renderHook(() =>
+      useDatePicker({ id: 'controlled-open', open: false, defaultOpen: true, onOpenChange: controlledOpenChange })
+    );
+
+    expect(uncontrolled.result.current.effectiveOpen).toBe(true);
+    expect(controlled.result.current.effectiveOpen).toBe(false);
+
+    act(() => {
+      uncontrolled.result.current.requestOpenChange(false);
+      controlled.result.current.requestOpenChange(true);
+    });
+
+    expect(uncontrolled.result.current.effectiveOpen).toBe(false);
+    expect(uncontrolledOpenChange).toHaveBeenLastCalledWith(false);
+    expect(controlled.result.current.effectiveOpen).toBe(false);
+    expect(controlledOpenChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it('forces controlled open state closed for disabled and read-only fields without emitting user open changes', () => {
+    const disabledOpenChange = vi.fn();
+    const readOnlyOpenChange = vi.fn();
+
+    const disabled = renderHook(() =>
+      useDatePicker({ id: 'disabled', open: true, disabled: true, onOpenChange: disabledOpenChange })
+    );
+    const readOnly = renderHook(() =>
+      useDatePicker({ id: 'readonly', open: true, readOnly: true, onOpenChange: readOnlyOpenChange })
+    );
+
+    expect(disabled.result.current.effectiveOpen).toBe(false);
+    expect(readOnly.result.current.effectiveOpen).toBe(false);
+
+    act(() => {
+      disabled.result.current.requestOpenChange(true);
+      readOnly.result.current.requestOpenChange(true);
+    });
+
+    expect(disabledOpenChange).not.toHaveBeenCalled();
+    expect(readOnlyOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('returns hidden input props only when named and not disabled, while read-only stays enabled', () => {
+    const enabled = renderHook(() => useDatePicker({ id: 'enabled', name: 'enabled' }));
+    const disabled = renderHook(() => useDatePicker({ id: 'disabled', name: 'disabled', disabled: true }));
+    const readOnly = renderHook(() => useDatePicker({ id: 'readonly', name: 'readonly', readOnly: true }));
+
+    expect(enabled.result.current.hiddenInputProps?.disabled).toBe(false);
+    expect(disabled.result.current.hiddenInputProps).toBeUndefined();
+    expect(readOnly.result.current.hiddenInputProps).toMatchObject({
+      name: 'readonly',
+      disabled: false
+    });
+  });
+
+  it('sanitizes firstDayOfWeek and visibleMonths into Calendar-safe values', () => {
+    const defaults = renderHook(() => useDatePicker({ id: 'defaults', firstDayOfWeek: Number.NaN, visibleMonths: 0 }));
+    const floored = renderHook(() => useDatePicker({ id: 'floored', firstDayOfWeek: 6.9, visibleMonths: 2.8 }));
+    const outOfRange = renderHook(() =>
+      useDatePicker({ id: 'out-of-range', firstDayOfWeek: 9, visibleMonths: Number.POSITIVE_INFINITY })
+    );
+    const capped = renderHook(() => useDatePicker({ id: 'capped', visibleMonths: 10_000 }));
+
+    expect(defaults.result.current.firstDayOfWeek).toBe(1);
+    expect(defaults.result.current.visibleMonths).toBe(1);
+    expect(floored.result.current.firstDayOfWeek).toBe(6);
+    expect(floored.result.current.visibleMonths).toBe(2);
+    expect(outOfRange.result.current.firstDayOfWeek).toBe(1);
+    expect(outOfRange.result.current.visibleMonths).toBe(1);
+    expect(capped.result.current.visibleMonths).toBe(12);
+  });
+
+  it('keeps clear behavior inert while disabled or read-only', () => {
+    const disabledChange = vi.fn();
+    const readOnlyChange = vi.fn();
+    const disabled = renderHook(() =>
+      useDatePicker({
+        id: 'disabled-clear',
+        defaultValue: new Date(2024, 0, 1),
+        disabled: true,
+        onDateChange: disabledChange
+      })
+    );
+    const readOnly = renderHook(() =>
+      useDatePicker({
+        id: 'readonly-clear',
+        defaultValue: new Date(2024, 0, 1),
+        readOnly: true,
+        onDateChange: readOnlyChange
+      })
+    );
+
+    act(() => {
+      disabled.result.current.clearDate();
+      readOnly.result.current.clearDate();
+    });
+
+    expect(disabled.result.current.selectedDate).toEqual(new Date(2024, 0, 1));
+    expect(readOnly.result.current.selectedDate).toEqual(new Date(2024, 0, 1));
+    expect(disabled.result.current.shouldRestoreFocusAfterClear).toBe(false);
+    expect(readOnly.result.current.shouldRestoreFocusAfterClear).toBe(false);
+    expect(disabledChange).not.toHaveBeenCalled();
+    expect(readOnlyChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('DatePicker — component behavior', () => {
+  it('is exported from the molecule barrel and package root', () => {
+    expect(BarrelDatePicker).toBe(DatePicker);
+    expect(RootDatePicker).toBe(DatePicker);
+  });
+
+  it('renders accessible triggers from a visible label or ariaLabel fallback', () => {
+    const { rerender } = render(<DatePicker id='start-date' label='Start date' />);
+
+    expect(screen.getByRole('button', { name: 'Start date Select date' })).toHaveTextContent('Select date');
+
+    rerender(<DatePicker id='deadline' ariaLabel='Choose deadline' />);
+
+    expect(screen.getByRole('button', { name: 'Choose deadline Select date' })).toHaveTextContent('Select date');
+  });
+
+  it('includes the selected display value in trigger accessible names', () => {
+    const selectedDate = new Date(2024, 4, 15);
+    const { rerender } = render(<DatePicker id='start-date' label='Start date' value={selectedDate} locale='en-US' />);
+
+    expect(screen.getByRole('button', { name: 'Start date May 15, 2024' })).toHaveTextContent('May 15, 2024');
+
+    rerender(<DatePicker id='deadline' ariaLabel='Choose deadline' value={selectedDate} locale='en-US' />);
+
+    expect(screen.getByRole('button', { name: 'Choose deadline May 15, 2024' })).toHaveTextContent('May 15, 2024');
+  });
+
+  it('renders and wires descriptions, validation, required, and read-only copy without aria-required', () => {
+    render(
+      <DatePicker
+        id='readonly-date'
+        label='Review date'
+        description='Pick the date that reviewers should see.'
+        isRequired={true}
+        readOnly={true}
+        validationState='error'
+        validationMessage='Choose an available date.'
+      />
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Review date Select date' });
+    const describedBy = trigger.getAttribute('aria-describedby') ?? '';
+
+    expect(screen.getByText('Pick the date that reviewers should see.')).toHaveAttribute(
+      'id',
+      'readonly-date-description'
+    );
+    expect(screen.getByText('Required field.')).toHaveAttribute('id', 'readonly-date-required');
+    expect(screen.getByText('Read-only field.')).toHaveAttribute('id', 'readonly-date-readonly');
+    expect(screen.getByText('Choose an available date.')).toHaveAttribute('id', 'readonly-date-validation');
+    expect(describedBy.split(' ')).toEqual(
+      expect.arrayContaining([
+        'readonly-date-description',
+        'readonly-date-required',
+        'readonly-date-readonly',
+        'readonly-date-validation'
+      ])
+    );
+    expect(trigger).not.toHaveAttribute('aria-required');
+    expect(trigger).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('opens an accessible Popover and passes sanitized Calendar props only while open', async () => {
+    const user = userEvent.setup();
+    const selectedDate = new Date(2024, 4, 10);
+    const minDate = new Date(2024, 4, 1);
+    const maxDate = new Date(2024, 4, 31);
+    const disabledDates = [new Date(2024, 4, 12)];
+
+    render(
+      <DatePicker
+        id='booking-date'
+        label='Booking date'
+        defaultValue={selectedDate}
+        minDate={minDate}
+        maxDate={maxDate}
+        disabledDates={disabledDates}
+        firstDayOfWeek={6.9}
+        visibleMonths={2.8}
+        locale='ar-SA-u-ca-islamic'
+        popoverClassName='custom-popover-class'
+      />
+    );
+
+    expect(screen.queryByRole('application', { name: 'Mock calendar' })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Booking date/ }));
+
+    expect(await screen.findByRole('dialog', { name: 'Booking date calendar' })).toHaveClass('custom-popover-class');
+    expect(screen.getByRole('application', { name: 'Mock calendar' })).toHaveAttribute('data-autofocus', 'true');
+
+    const calendarProps = getLastCalendarProps();
+    expect(calendarProps.selectedDate).toBe(selectedDate);
+    expect(calendarProps.minDate).toBe(minDate);
+    expect(calendarProps.maxDate).toBe(maxDate);
+    expect(calendarProps.disabledDates).toBe(disabledDates);
+    expect(calendarProps.firstDayOfWeek).toBe(6);
+    expect(calendarProps.visibleMonths).toBe(2);
+    expect(calendarProps.autoFocusOnMount).toBe(true);
+    expect(calendarProps.locale).toBeDefined();
+    expect(new Intl.DateTimeFormat(calendarProps.locale).resolvedOptions().calendar).toBe('gregory');
+  });
+
+  it('selects a single Calendar date, updates display and hidden input, emits once, and closes', async () => {
+    const user = userEvent.setup();
+    const handleDateChange = vi.fn();
+    const { container } = render(
+      <DatePicker
+        id='appointment-date'
+        name='appointment'
+        label='Appointment date'
+        locale='en-US'
+        onDateChange={handleDateChange}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Appointment date Select date' }));
+    await user.click(await screen.findByRole('button', { name: 'Select May 15, 2024' }));
+
+    expect(handleDateChange).toHaveBeenCalledTimes(1);
+    expect(handleDateChange).toHaveBeenCalledWith(new Date(2024, 4, 15));
+    expect(getHiddenInput(container, 'appointment')).toHaveValue('2024-05-15');
+    expect(screen.getByRole('button', { name: 'Appointment date May 15, 2024' })).toHaveTextContent('May 15, 2024');
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: 'Appointment date calendar' })).not.toBeInTheDocument()
+    );
+  });
+
+  it('ignores Calendar range selections in single-date mode', async () => {
+    const user = userEvent.setup();
+    const handleDateChange = vi.fn();
+
+    render(<DatePicker id='single-date' label='Single date' onDateChange={handleDateChange} />);
+
+    await user.click(screen.getByRole('button', { name: 'Single date Select date' }));
+    await user.click(await screen.findByRole('button', { name: 'Select range' }));
+
+    expect(handleDateChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog', { name: 'Single date calendar' })).toBeInTheDocument();
+  });
+
+  it('keeps disabled and read-only fields closed while preserving read-only hidden values', async () => {
+    const user = userEvent.setup();
+    const handleReadOnlyChange = vi.fn();
+    const readOnlyDate = new Date(2024, 6, 4);
+    const { container, rerender } = render(
+      <DatePicker id='blocked-date' name='blocked' label='Blocked date' disabled={true} />
+    );
+
+    const disabledTrigger = screen.getByRole('button', { name: 'Blocked date Select date' });
+    expect(disabledTrigger).toBeDisabled();
+    expect(container.querySelector('input[name="blocked"]')).toBeNull();
+
+    await user.click(disabledTrigger);
+    expect(screen.queryByRole('dialog', { name: 'Blocked date calendar' })).not.toBeInTheDocument();
+
+    rerender(
+      <DatePicker
+        id='blocked-date'
+        name='blocked'
+        label='Blocked date'
+        value={readOnlyDate}
+        readOnly={true}
+        isClearable={true}
+        locale='en-US'
+        onDateChange={handleReadOnlyChange}
+      />
+    );
+
+    const readOnlyTrigger = screen.getByRole('button', { name: 'Blocked date Jul 4, 2024' });
+    expect(readOnlyTrigger).not.toBeDisabled();
+    expect(readOnlyTrigger).toHaveAttribute('aria-disabled', 'true');
+    expect(getHiddenInput(container, 'blocked')).toHaveValue('2024-07-04');
+    expect(screen.queryByRole('button', { name: 'Clear selected date' })).not.toBeInTheDocument();
+
+    await user.click(readOnlyTrigger);
+    expect(screen.queryByRole('dialog', { name: 'Blocked date calendar' })).not.toBeInTheDocument();
+    expect(handleReadOnlyChange).not.toHaveBeenCalled();
+  });
+
+  it('renders clear as a sibling button, clears the value, and restores focus to the trigger', async () => {
+    const user = userEvent.setup();
+    const handleDateChange = vi.fn();
+    const { container } = render(
+      <DatePicker
+        id='clearable-date'
+        name='clearable'
+        label='Clearable date'
+        defaultValue={new Date(2024, 4, 15)}
+        isClearable={true}
+        locale='en-US'
+        onDateChange={handleDateChange}
+      />
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Clearable date May 15, 2024' });
+    const clearButton = screen.getByRole('button', { name: 'Clear selected date' });
+
+    expect(clearButton).toHaveAttribute('type', 'button');
+    expect(trigger).toHaveAttribute('type', 'button');
+    expect(trigger).not.toContainElement(clearButton);
+    expect(trigger.parentElement?.parentElement).toBe(clearButton.parentElement);
+
+    await user.click(clearButton);
+
+    expect(handleDateChange).toHaveBeenCalledWith(null);
+    expect(getHiddenInput(container, 'clearable')).toHaveValue('');
+    expect(trigger).toHaveTextContent('Select date');
+    expect(screen.queryByRole('button', { name: 'Clear selected date' })).not.toBeInTheDocument();
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+
+  it('keeps the calendar indicator decorative and all DatePicker buttons non-submitting', async () => {
+    const user = userEvent.setup();
+    const handleSubmit = vi.fn((event: FormEvent<HTMLFormElement>) => event.preventDefault());
+    const { container } = render(
+      <form onSubmit={handleSubmit}>
+        <DatePicker
+          id='form-date'
+          label='Form date'
+          defaultValue={new Date(2024, 4, 15)}
+          isClearable={true}
+          locale='en-US'
+        />
+      </form>
+    );
+
+    const indicator = container.querySelector('[data-slot="date-picker-indicator"]');
+
+    expect(indicator).toHaveAttribute('aria-hidden', 'true');
+    expect(indicator).toHaveAttribute('focusable', 'false');
+
+    await user.click(screen.getByRole('button', { name: 'Form date May 15, 2024' }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'Form date calendar' });
+    const calendarButton = within(dialog).getByRole('button', { name: 'Select May 15, 2024' });
+    expect(calendarButton).toHaveAttribute('type', 'button');
+
+    await user.click(screen.getByRole('button', { name: 'Clear selected date' }));
+
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/molecules/date-picker/DatePicker.tsx
+++ b/src/components/molecules/date-picker/DatePicker.tsx
@@ -8,7 +8,7 @@ export const DatePicker: FC<DatePickerProps> = (props) => {
   const datePicker = useDatePicker(props);
 
   return (
-    <div className={datePicker.wrapperClassName} data-slot='date-picker'>
+    <div {...datePicker.rootProps} className={datePicker.wrapperClassName} data-slot='date-picker'>
       {datePicker.hiddenInputProps && <input {...datePicker.hiddenInputProps} />}
 
       {datePicker.label && (

--- a/src/components/molecules/date-picker/DatePicker.tsx
+++ b/src/components/molecules/date-picker/DatePicker.tsx
@@ -1,0 +1,117 @@
+import type { FC } from 'react';
+import { Calendar } from '../../atoms/calendar';
+import { Popover } from '../../atoms/popover';
+import type { DatePickerProps } from './types';
+import { useDatePicker } from './useDatePicker';
+
+export const DatePicker: FC<DatePickerProps> = (props) => {
+  const datePicker = useDatePicker(props);
+
+  return (
+    <div className={datePicker.wrapperClassName} data-slot='date-picker'>
+      {datePicker.hiddenInputProps && <input {...datePicker.hiddenInputProps} />}
+
+      {datePicker.label && (
+        <label
+          className='fs-small font-semibold text-text-light dark:text-text-dark'
+          htmlFor={props.id}
+          id={datePicker.labelId}
+        >
+          {datePicker.label}{' '}
+          {datePicker.isRequired && (
+            <span className='text-brand-light dark:text-brand-dark' aria-hidden={true}>
+              *
+            </span>
+          )}
+        </label>
+      )}
+
+      <div className={datePicker.fieldClassName} data-slot='date-picker-field'>
+        <Popover open={datePicker.effectiveOpen} onOpenChange={(open) => datePicker.requestOpenChange(open, 'trigger')}>
+          <Popover.Trigger disabled={props.disabled ?? false}>
+            <button
+              {...datePicker.triggerButtonProps}
+              className={datePicker.triggerClassName}
+              data-slot='date-picker-trigger'
+            >
+              <span className={datePicker.valueClassName} id={datePicker.triggerValueId}>
+                {datePicker.displayValue}
+              </span>
+              <svg
+                aria-hidden={true}
+                className={datePicker.indicatorClassName}
+                data-slot='date-picker-indicator'
+                fill='none'
+                focusable='false'
+                height='20'
+                stroke='currentColor'
+                viewBox='0 0 24 24'
+                width='20'
+                xmlns='http://www.w3.org/2000/svg'
+              >
+                <path
+                  d='M8 2v4M16 2v4M3.5 9.5h17M5 5h14a1.5 1.5 0 0 1 1.5 1.5v12A1.5 1.5 0 0 1 19 20H5a1.5 1.5 0 0 1-1.5-1.5v-12A1.5 1.5 0 0 1 5 5Z'
+                  strokeLinecap='round'
+                  strokeLinejoin='round'
+                  strokeWidth='2'
+                />
+              </svg>
+            </button>
+          </Popover.Trigger>
+
+          <Popover.Content
+            ariaLabel={datePicker.popoverAriaLabel}
+            className={datePicker.popoverClassName}
+            placement='bottom-start'
+            size='lg'
+          >
+            <Popover.Body>
+              <Calendar {...datePicker.calendarProps} />
+            </Popover.Body>
+          </Popover.Content>
+        </Popover>
+
+        {datePicker.shouldRenderClearButton && (
+          <button {...datePicker.clearButtonProps} data-slot='date-picker-clear'>
+            <svg
+              aria-hidden={true}
+              fill='none'
+              focusable='false'
+              height='18'
+              stroke='currentColor'
+              viewBox='0 0 24 24'
+              width='18'
+              xmlns='http://www.w3.org/2000/svg'
+            >
+              <path d='M6 6l12 12M18 6 6 18' strokeLinecap='round' strokeLinejoin='round' strokeWidth='2' />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      {datePicker.description && (
+        <p className='fs-small text-text-secondary-light dark:text-text-secondary-dark' id={datePicker.descriptionId}>
+          {datePicker.description}
+        </p>
+      )}
+
+      {datePicker.requiredDescriptionId && (
+        <p className='sr-only' id={datePicker.requiredDescriptionId}>
+          Required field.
+        </p>
+      )}
+
+      {datePicker.readOnlyDescriptionId && (
+        <p className='sr-only' id={datePicker.readOnlyDescriptionId}>
+          Read-only field.
+        </p>
+      )}
+
+      {datePicker.validationMessage && (
+        <p className={datePicker.messageClassName} id={datePicker.validationMessageId}>
+          {datePicker.validationMessage}
+        </p>
+      )}
+    </div>
+  );
+};

--- a/src/components/molecules/date-picker/index.ts
+++ b/src/components/molecules/date-picker/index.ts
@@ -1,0 +1,2 @@
+export { DatePicker } from './DatePicker';
+export type * from './types';

--- a/src/components/molecules/date-picker/types.ts
+++ b/src/components/molecules/date-picker/types.ts
@@ -1,0 +1,325 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { ComponentProps, RefObject } from 'react';
+import type { CalendarProps, CalendarSelection } from '../../atoms/calendar';
+
+export const datePickerVariants = cva(
+  [
+    'relative flex max-w-full justify-between overflow-hidden border py-2',
+    'cursor-pointer transition-[background,border-color,box-shadow] duration-200 ease-[ease]',
+    '[&:has(:focus-visible)]:focus-ring'
+  ],
+  {
+    variants: {
+      variant: {
+        regular: [
+          'bg-surface-light border-border-light hover:bg-surface-raised-light hover:border-border-strong-light',
+          'dark:bg-surface-dark dark:border-border-dark dark:hover:bg-surface-raised-dark dark:hover:border-border-strong-dark'
+        ],
+        underlined: [
+          'bg-transparent border-border-light hover:border-border-strong-light',
+          'dark:border-border-dark dark:hover:border-border-strong-dark'
+        ],
+        line: [
+          'bg-transparent border-t-transparent border-l-transparent border-r-transparent rounded-none!',
+          'border-b-border-light hover:border-b-border-strong-light',
+          'dark:border-b-border-dark dark:hover:border-b-border-strong-dark'
+        ],
+        bordered: [
+          'bg-surface-light border-border-strong-light hover:bg-surface-raised-light',
+          'dark:bg-surface-dark dark:border-border-strong-dark dark:hover:bg-surface-raised-dark'
+        ]
+      },
+      rounded: {
+        true: 'rounded-full',
+        false: 'rounded-md'
+      },
+      size: {
+        sm: 'h-form-field-sm px-3 fs-small',
+        md: 'h-form-field-md px-4 fs-base',
+        lg: 'h-form-field-lg px-4 fs-h6'
+      },
+      status: {
+        default: '',
+        error:
+          'border-error-light shadow-glow-input-error-light hover:!border-error-light dark:border-error dark:shadow-glow-input-error dark:hover:!border-error',
+        warning:
+          'border-warning-light shadow-glow-input-warning-light hover:!border-warning-light dark:border-warning dark:shadow-glow-input-warning dark:hover:!border-warning',
+        success:
+          'border-success-light shadow-glow-input-success-light hover:!border-success-light dark:border-success dark:shadow-glow-input-success dark:hover:!border-success',
+        info: 'border-info-light shadow-glow-input-info-light hover:!border-info-light dark:border-info dark:shadow-glow-input-info dark:hover:!border-info'
+      },
+      focused: {
+        true: '!border-brand-light/50 dark:!border-brand-dark/50',
+        false: ''
+      },
+      fullWidth: {
+        true: 'w-full',
+        false: 'w-auto'
+      }
+    },
+    compoundVariants: [
+      {
+        focused: true,
+        status: 'error',
+        class: '!border-error-light dark:!border-error'
+      },
+      {
+        focused: true,
+        status: 'warning',
+        class: '!border-warning-light dark:!border-warning'
+      },
+      {
+        focused: true,
+        status: 'success',
+        class: '!border-success-light dark:!border-success'
+      },
+      {
+        focused: true,
+        status: 'info',
+        class: '!border-info-light dark:!border-info'
+      }
+    ],
+    defaultVariants: {
+      variant: 'regular',
+      rounded: false,
+      size: 'md',
+      status: 'default',
+      focused: false,
+      fullWidth: false
+    }
+  }
+);
+
+export const datePickerValueVariants = cva(
+  'flex-1 truncate border-none bg-transparent text-left font-medium outline-none',
+  {
+    variants: {
+      hasValue: {
+        true: 'text-text-light dark:text-text-dark',
+        false: 'text-text-muted-light dark:text-text-muted-dark'
+      }
+    },
+    defaultVariants: {
+      hasValue: false
+    }
+  }
+);
+
+export const datePickerInlineButtonVariants = cva(
+  [
+    'cursor-pointer rounded-full bg-surface-light p-0.5 text-text-light hover:bg-surface-raised-light',
+    'dark:bg-surface-dark dark:text-text-dark dark:hover:bg-surface-raised-dark',
+    'focus-visible:focus-ring',
+    'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-40'
+  ],
+  {
+    variants: {
+      visibility: {
+        visible: '',
+        hidden: 'hidden'
+      }
+    },
+    defaultVariants: {
+      visibility: 'visible'
+    }
+  }
+);
+
+export const datePickerMessageVariants = cva('fs-small', {
+  variants: {
+    tone: {
+      info: 'text-info-light dark:text-info',
+      warning: 'text-warning-text-light dark:text-warning',
+      error: 'text-error-light dark:text-error',
+      success: 'text-success-text-light dark:text-success'
+    }
+  },
+  defaultVariants: {
+    tone: 'info'
+  }
+});
+
+type DatePickerVariantProps = VariantProps<typeof datePickerVariants>;
+
+type DatePickerCalendarProps = Pick<
+  CalendarProps,
+  | 'autoFocusOnMount'
+  | 'disabled'
+  | 'disabledDates'
+  | 'firstDayOfWeek'
+  | 'locale'
+  | 'maxDate'
+  | 'minDate'
+  | 'onDateChange'
+  | 'readOnly'
+  | 'selectedDate'
+  | 'visibleMonths'
+>;
+
+export type DatePickerValidationState = 'default' | 'error' | 'warning' | 'success' | 'info';
+export type DatePickerVariant = NonNullable<DatePickerVariantProps['variant']>;
+export type DatePickerSize = NonNullable<DatePickerVariantProps['size']>;
+export type DatePickerFirstDayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+export type DatePickerFormatOptions = Intl.DateTimeFormatOptions;
+export type DatePickerOpenChangeSource = 'trigger' | 'calendar' | 'clear' | 'programmatic';
+
+export type DatePickerProps = {
+  /** @control text */
+  id: string;
+  /** @control text */
+  name?: string;
+  /** @control text */
+  label?: string;
+  /** @control text */
+  ariaLabel?: string;
+  /**
+   * @control text
+   * @default Select date
+   */
+  placeholder?: string;
+  /** @control date */
+  value?: Date | null;
+  /**
+   * @control date
+   * @default null
+   */
+  defaultValue?: Date | null;
+  onDateChange?: (date: Date | null) => void;
+  /** @control boolean */
+  open?: boolean;
+  /**
+   * @control boolean
+   * @default false
+   */
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /** @control date */
+  minDate?: Date;
+  /** @control date */
+  maxDate?: Date;
+  /**
+   * @control object
+   * @default []
+   */
+  disabledDates?: Date[];
+  /**
+   * @control text
+   * @default browser Gregorian locale
+   */
+  locale?: string;
+  /**
+   * @control object
+   * @default { dateStyle: 'medium' }
+   */
+  formatOptions?: DatePickerFormatOptions;
+  /** @control text */
+  description?: string;
+  /**
+   * @control number
+   * @default 1
+   */
+  firstDayOfWeek?: number;
+  /**
+   * @control number
+   * @default 1
+   */
+  visibleMonths?: number;
+  /**
+   * @control select
+   * @default regular
+   */
+  variant?: DatePickerVariant;
+  /**
+   * @control select
+   * @default md
+   */
+  size?: DatePickerSize;
+  /**
+   * @control boolean
+   * @default false
+   */
+  rounded?: boolean;
+  /**
+   * @control boolean
+   * @default false
+   */
+  isFullWidth?: boolean;
+  /**
+   * @control boolean
+   * @default false
+   */
+  isRequired?: boolean;
+  /**
+   * @control boolean
+   * @default false
+   */
+  disabled?: boolean;
+  /**
+   * @control boolean
+   * @default false
+   */
+  readOnly?: boolean;
+  /**
+   * @control boolean
+   * @default false
+   */
+  isClearable?: boolean;
+  /**
+   * @control select
+   * @default default
+   */
+  validationState?: DatePickerValidationState;
+  /** @control text */
+  validationMessage?: string;
+  /** @control text */
+  className?: string;
+  /** @control text */
+  fieldClassName?: string;
+  /** @control text */
+  popoverClassName?: string;
+  /** @control text */
+  ariaDescribedBy?: string | string[];
+  /** @control text */
+  ariaLabelledBy?: string | string[];
+};
+
+export type UseDatePickerReturn = {
+  calendarProps: DatePickerCalendarProps;
+  clearButtonProps: ComponentProps<'button'>;
+  clearDate: () => void;
+  description?: string;
+  descriptionId?: string;
+  displayValue: string;
+  effectiveLocale: string;
+  effectiveOpen: boolean;
+  fieldClassName: string;
+  firstDayOfWeek: DatePickerFirstDayOfWeek;
+  focusTrigger: () => void;
+  hiddenInputProps?: ComponentProps<'input'>;
+  indicatorClassName: string;
+  isRequired: boolean;
+  label?: string;
+  labelId?: string;
+  messageClassName: string;
+  popoverAriaLabel: string;
+  popoverClassName?: string;
+  readOnlyDescriptionId?: string;
+  requestOpenChange: (open: boolean, source?: DatePickerOpenChangeSource) => void;
+  requiredDescriptionId?: string;
+  sanitizedFormatOptions: Intl.DateTimeFormatOptions;
+  selectDate: (date: Date | null) => void;
+  selectedDate: Date | null;
+  shouldRenderClearButton: boolean;
+  shouldRestoreFocusAfterClear: boolean;
+  triggerButtonProps: ComponentProps<'button'>;
+  triggerClassName: string;
+  triggerRef: RefObject<HTMLButtonElement | null>;
+  triggerValueId: string;
+  validationMessage?: string;
+  validationMessageId?: string;
+  valueClassName: string;
+  visibleMonths: number;
+  wrapperClassName: string;
+};
+
+export type DatePickerCalendarSelectionHandler = (selection: CalendarSelection) => void;

--- a/src/components/molecules/date-picker/types.ts
+++ b/src/components/molecules/date-picker/types.ts
@@ -163,7 +163,9 @@ export type DatePickerFirstDayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 export type DatePickerFormatOptions = Intl.DateTimeFormatOptions;
 export type DatePickerOpenChangeSource = 'trigger' | 'calendar' | 'clear' | 'programmatic';
 
-export type DatePickerProps = {
+type DatePickerRootProps = Omit<ComponentProps<'div'>, 'defaultValue' | 'id'>;
+
+type DatePickerOwnProps = {
   /** @control text */
   id: string;
   /** @control text */
@@ -283,6 +285,8 @@ export type DatePickerProps = {
   ariaLabelledBy?: string | string[];
 };
 
+export type DatePickerProps = DatePickerOwnProps & DatePickerRootProps;
+
 export type UseDatePickerReturn = {
   calendarProps: DatePickerCalendarProps;
   clearButtonProps: ComponentProps<'button'>;
@@ -305,6 +309,7 @@ export type UseDatePickerReturn = {
   popoverClassName?: string;
   readOnlyDescriptionId?: string;
   requestOpenChange: (open: boolean, source?: DatePickerOpenChangeSource) => void;
+  rootProps: DatePickerRootProps;
   requiredDescriptionId?: string;
   sanitizedFormatOptions: Intl.DateTimeFormatOptions;
   selectDate: (date: Date | null) => void;

--- a/src/components/molecules/date-picker/types.ts
+++ b/src/components/molecules/date-picker/types.ts
@@ -95,7 +95,9 @@ export const datePickerValueVariants = cva(
   {
     variants: {
       hasValue: {
-        false: 'text-text-secondary-light dark:text-text-secondary-dark'
+        true: 'text-text-light dark:text-text-dark',
+        false: 'text-text-secondary-light dark:text-text-muted-dark'
+      }
     },
     defaultVariants: {
       hasValue: false

--- a/src/components/molecules/date-picker/types.ts
+++ b/src/components/molecules/date-picker/types.ts
@@ -96,7 +96,7 @@ export const datePickerValueVariants = cva(
     variants: {
       hasValue: {
         true: 'text-text-light dark:text-text-dark',
-        false: 'text-text-muted-light dark:text-text-muted-dark'
+        false: 'text-text-secondary-light dark:text-text-muted-dark'
       }
     },
     defaultVariants: {

--- a/src/components/molecules/date-picker/types.ts
+++ b/src/components/molecules/date-picker/types.ts
@@ -95,9 +95,7 @@ export const datePickerValueVariants = cva(
   {
     variants: {
       hasValue: {
-        true: 'text-text-light dark:text-text-dark',
-        false: 'text-text-secondary-light dark:text-text-muted-dark'
-      }
+        false: 'text-text-secondary-light dark:text-text-secondary-dark'
     },
     defaultVariants: {
       hasValue: false

--- a/src/components/molecules/date-picker/useDatePicker.ts
+++ b/src/components/molecules/date-picker/useDatePicker.ts
@@ -1,0 +1,463 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
+import type { CalendarSelection } from '../../atoms/calendar';
+import {
+  type DatePickerCalendarSelectionHandler,
+  type DatePickerFirstDayOfWeek,
+  type DatePickerOpenChangeSource,
+  type DatePickerProps,
+  datePickerInlineButtonVariants,
+  datePickerMessageVariants,
+  datePickerValueVariants,
+  datePickerVariants,
+  type UseDatePickerReturn
+} from './types';
+
+const DEFAULT_PLACEHOLDER = 'Select date';
+const DEFAULT_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = { dateStyle: 'medium' };
+const GREGORIAN_LOCALE_FALLBACK = 'en-u-ca-gregory';
+const MAX_VISIBLE_MONTHS = 12;
+
+const formatAriaIds = (ids?: string | (string | undefined)[]) => {
+  if (!Array.isArray(ids)) {
+    return ids;
+  }
+
+  return (
+    ids
+      .map((id) => id?.trim())
+      .filter((id): id is string => Boolean(id))
+      .join(' ') || undefined
+  );
+};
+
+const startOfLocalDay = (date: Date) => new Date(date.getFullYear(), date.getMonth(), date.getDate());
+
+const isValidDate = (date: Date) => Number.isFinite(date.getTime());
+
+const serializeLocalDate = (date: Date) => {
+  const year = String(date.getFullYear()).padStart(4, '0');
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+};
+
+const serializeLocalDateOrEmpty = (date: Date) => (isValidDate(date) ? serializeLocalDate(date) : '');
+
+const isSameLocalDate = (left: Date, right: Date) => serializeLocalDate(left) === serializeLocalDate(right);
+
+const isBeforeLocalDay = (left: Date, right: Date) =>
+  startOfLocalDay(left).getTime() < startOfLocalDay(right).getTime();
+
+const isAfterLocalDay = (left: Date, right: Date) => startOfLocalDay(left).getTime() > startOfLocalDay(right).getTime();
+
+const sanitizeFirstDayOfWeek = (candidate?: number): DatePickerFirstDayOfWeek => {
+  if (typeof candidate !== 'number' || !Number.isFinite(candidate)) {
+    return 1;
+  }
+
+  const normalized = Math.floor(candidate);
+
+  if (normalized < 0 || normalized > 6) {
+    return 1;
+  }
+
+  return normalized as DatePickerFirstDayOfWeek;
+};
+
+const sanitizeVisibleMonths = (candidate?: number) => {
+  if (typeof candidate !== 'number' || !Number.isFinite(candidate)) {
+    return 1;
+  }
+
+  return Math.min(MAX_VISIBLE_MONTHS, Math.max(1, Math.floor(candidate)));
+};
+
+const normalizeGregorianLocaleCandidate = (candidate?: string) => {
+  if (!candidate) {
+    return undefined;
+  }
+
+  try {
+    return new Intl.Locale(candidate, { calendar: 'gregory' }).toString();
+  } catch {
+    return undefined;
+  }
+};
+
+const getBrowserLocaleCandidate = () => {
+  if (typeof navigator === 'undefined') {
+    return undefined;
+  }
+
+  return navigator.language;
+};
+
+const resolveGregorianLocale = (locale?: string) => {
+  const candidates = [
+    locale,
+    getBrowserLocaleCandidate(),
+    Intl.DateTimeFormat().resolvedOptions().locale,
+    GREGORIAN_LOCALE_FALLBACK,
+    'en'
+  ];
+
+  for (const candidate of candidates) {
+    const normalized = normalizeGregorianLocaleCandidate(candidate);
+
+    if (!normalized) {
+      continue;
+    }
+
+    try {
+      const resolved = new Intl.DateTimeFormat(normalized, { calendar: 'gregory' }).resolvedOptions();
+
+      if (resolved.calendar === 'gregory') {
+        return resolved.locale;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return GREGORIAN_LOCALE_FALLBACK;
+};
+
+const sanitizeDateOnlyFormatOptions = (options?: Intl.DateTimeFormatOptions): Intl.DateTimeFormatOptions => {
+  if (!options) {
+    return DEFAULT_FORMAT_OPTIONS;
+  }
+
+  const { calendar, dateStyle, day, era, month, weekday, year } = options;
+  const sanitized: Intl.DateTimeFormatOptions = {};
+
+  if (calendar === 'gregory') {
+    sanitized.calendar = calendar;
+  }
+
+  if (dateStyle) {
+    sanitized.dateStyle = dateStyle;
+    return sanitized;
+  }
+
+  if (weekday) {
+    sanitized.weekday = weekday;
+  }
+
+  if (era) {
+    sanitized.era = era;
+  }
+
+  if (year) {
+    sanitized.year = year;
+  }
+
+  if (month) {
+    sanitized.month = month;
+  }
+
+  if (day) {
+    sanitized.day = day;
+  }
+
+  return Object.keys(sanitized).length > 0 ? sanitized : DEFAULT_FORMAT_OPTIONS;
+};
+
+const formatDisplayDate = ({
+  date,
+  locale,
+  options,
+  placeholder
+}: {
+  date: Date;
+  locale: string;
+  options: Intl.DateTimeFormatOptions;
+  placeholder: string;
+}) => {
+  if (!isValidDate(date)) {
+    return placeholder;
+  }
+
+  try {
+    return new Intl.DateTimeFormat(locale, options).format(date);
+  } catch {
+    try {
+      return new Intl.DateTimeFormat(locale, DEFAULT_FORMAT_OPTIONS).format(date);
+    } catch {
+      return serializeLocalDateOrEmpty(date) || placeholder;
+    }
+  }
+};
+
+const isDateUnavailable = ({
+  date,
+  disabledDates,
+  maxDate,
+  minDate
+}: {
+  date: Date;
+  disabledDates: Date[];
+  maxDate?: Date;
+  minDate?: Date;
+}) => {
+  if (minDate && isBeforeLocalDay(date, minDate)) {
+    return true;
+  }
+
+  if (maxDate && isAfterLocalDay(date, maxDate)) {
+    return true;
+  }
+
+  return disabledDates.some((disabledDate) => isSameLocalDate(disabledDate, date));
+};
+
+const isSingleDateSelection = (selection: CalendarSelection): selection is Date | null =>
+  selection === null || selection instanceof Date;
+
+export const useDatePicker = ({
+  id,
+  name,
+  label,
+  ariaLabel,
+  placeholder = DEFAULT_PLACEHOLDER,
+  value,
+  defaultValue = null,
+  onDateChange,
+  open,
+  defaultOpen = false,
+  onOpenChange,
+  minDate,
+  maxDate,
+  disabledDates = [],
+  locale,
+  formatOptions,
+  description,
+  firstDayOfWeek,
+  visibleMonths,
+  variant = 'regular',
+  size = 'md',
+  rounded = false,
+  isFullWidth = false,
+  isRequired = false,
+  disabled = false,
+  readOnly = false,
+  isClearable = false,
+  validationState = 'default',
+  validationMessage,
+  className,
+  fieldClassName,
+  popoverClassName,
+  ariaDescribedBy,
+  ariaLabelledBy
+}: DatePickerProps): UseDatePickerReturn => {
+  const [internalSelectedDate, setInternalSelectedDate] = useState<Date | null>(defaultValue);
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const [shouldRestoreFocusAfterClear, setShouldRestoreFocusAfterClear] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+
+  const selectedDate = value !== undefined ? value : internalSelectedDate;
+  const requestedOpen = open !== undefined ? open : internalOpen;
+  const effectiveOpen = disabled || readOnly ? false : requestedOpen;
+  const sanitizedFirstDayOfWeek = sanitizeFirstDayOfWeek(firstDayOfWeek);
+  const sanitizedVisibleMonths = sanitizeVisibleMonths(visibleMonths);
+  const effectiveLocale = useMemo(() => resolveGregorianLocale(locale), [locale]);
+  const sanitizedFormatOptions = useMemo(() => sanitizeDateOnlyFormatOptions(formatOptions), [formatOptions]);
+  const externalDescribedBy = formatAriaIds(ariaDescribedBy);
+  const labelId = label ? `${id}-label` : undefined;
+  const baseLabelledBy = formatAriaIds(ariaLabelledBy ?? labelId);
+  const triggerValueId = `${id}-value`;
+  const shouldUseAriaLabel = !baseLabelledBy && Boolean(ariaLabel);
+  const labelledBy = shouldUseAriaLabel ? undefined : formatAriaIds([baseLabelledBy, triggerValueId]);
+  const descriptionId = description ? `${id}-description` : undefined;
+  const requiredDescriptionId = isRequired ? `${id}-required` : undefined;
+  const readOnlyDescriptionId = readOnly ? `${id}-readonly` : undefined;
+  const validationMessageId = validationMessage ? `${id}-validation` : undefined;
+  const describedBy =
+    [externalDescribedBy, descriptionId, requiredDescriptionId, readOnlyDescriptionId, validationMessageId]
+      .filter(Boolean)
+      .join(' ') || undefined;
+
+  const displayValue = useMemo(() => {
+    if (!selectedDate) {
+      return placeholder;
+    }
+
+    return formatDisplayDate({
+      date: selectedDate,
+      locale: effectiveLocale,
+      options: sanitizedFormatOptions,
+      placeholder
+    });
+  }, [effectiveLocale, placeholder, sanitizedFormatOptions, selectedDate]);
+
+  const focusTrigger = useCallback(() => {
+    triggerRef.current?.focus();
+    setShouldRestoreFocusAfterClear(false);
+  }, []);
+
+  const requestOpenChange = useCallback(
+    (nextOpen: boolean, _source: DatePickerOpenChangeSource = 'programmatic') => {
+      if (disabled || readOnly) {
+        return;
+      }
+
+      if (open === undefined) {
+        setInternalOpen(nextOpen);
+      }
+
+      onOpenChange?.(nextOpen);
+    },
+    [disabled, onOpenChange, open, readOnly]
+  );
+
+  const commitDateChange = useCallback(
+    (nextDate: Date | null) => {
+      if (disabled || readOnly) {
+        return false;
+      }
+
+      if (nextDate && isDateUnavailable({ date: nextDate, disabledDates, maxDate, minDate })) {
+        return false;
+      }
+
+      if (value === undefined) {
+        setInternalSelectedDate(nextDate);
+      }
+
+      onDateChange?.(nextDate);
+      return true;
+    },
+    [disabled, disabledDates, maxDate, minDate, onDateChange, readOnly, value]
+  );
+
+  const selectDate = useCallback(
+    (nextDate: Date | null) => {
+      const didCommit = commitDateChange(nextDate);
+
+      if (didCommit) {
+        requestOpenChange(false, 'calendar');
+      }
+    },
+    [commitDateChange, requestOpenChange]
+  );
+
+  const clearDate = useCallback(() => {
+    if (disabled || readOnly) {
+      return;
+    }
+
+    const didCommit = commitDateChange(null);
+
+    if (didCommit) {
+      setShouldRestoreFocusAfterClear(true);
+      queueMicrotask(() => triggerRef.current?.focus());
+    }
+  }, [commitDateChange, disabled, readOnly]);
+
+  const handleCalendarDateChange: DatePickerCalendarSelectionHandler = useCallback(
+    (selection) => {
+      if (!isSingleDateSelection(selection)) {
+        return;
+      }
+
+      selectDate(selection);
+    },
+    [selectDate]
+  );
+
+  const safeSelectedDate = selectedDate && isValidDate(selectedDate) ? selectedDate : null;
+  const hasSelectedDate = safeSelectedDate !== null;
+  const shouldRenderClearButton = isClearable && hasSelectedDate && !disabled && !readOnly;
+  const status = validationState;
+  const triggerAriaLabel = shouldUseAriaLabel ? `${ariaLabel} ${displayValue}` : undefined;
+  const popoverLabel = label ?? ariaLabel;
+  const popoverAriaLabel = popoverLabel ? `${popoverLabel} calendar` : 'Date picker calendar';
+
+  return {
+    calendarProps: {
+      autoFocusOnMount: effectiveOpen,
+      disabled,
+      disabledDates,
+      firstDayOfWeek: sanitizedFirstDayOfWeek,
+      locale: effectiveLocale,
+      maxDate,
+      minDate,
+      onDateChange: handleCalendarDateChange,
+      readOnly,
+      selectedDate: safeSelectedDate,
+      visibleMonths: sanitizedVisibleMonths
+    },
+    clearButtonProps: {
+      type: 'button',
+      'aria-label': 'Clear selected date',
+      'aria-controls': id,
+      className: datePickerInlineButtonVariants({ visibility: shouldRenderClearButton ? 'visible' : 'hidden' }),
+      disabled: disabled || readOnly,
+      onClick: clearDate
+    },
+    clearDate,
+    description,
+    descriptionId,
+    displayValue,
+    effectiveLocale,
+    effectiveOpen,
+    fieldClassName: cn(
+      datePickerVariants({
+        focused: effectiveOpen,
+        fullWidth: isFullWidth,
+        rounded,
+        size,
+        status,
+        variant
+      }),
+      (disabled || readOnly) && 'cursor-not-allowed opacity-40',
+      fieldClassName
+    ),
+    firstDayOfWeek: sanitizedFirstDayOfWeek,
+    focusTrigger,
+    hiddenInputProps:
+      name && !disabled
+        ? { type: 'hidden', name, value: safeSelectedDate ? serializeLocalDate(safeSelectedDate) : '', disabled: false }
+        : undefined,
+    indicatorClassName: 'shrink-0 text-text-muted-light dark:text-text-muted-dark',
+    isRequired,
+    label,
+    labelId,
+    messageClassName: datePickerMessageVariants({ tone: status === 'default' ? 'info' : status }),
+    popoverAriaLabel,
+    popoverClassName,
+    readOnlyDescriptionId,
+    requestOpenChange,
+    requiredDescriptionId,
+    sanitizedFormatOptions,
+    selectDate,
+    selectedDate: safeSelectedDate,
+    shouldRenderClearButton,
+    shouldRestoreFocusAfterClear,
+    triggerButtonProps: {
+      ref: triggerRef,
+      id,
+      type: 'button',
+      'aria-label': triggerAriaLabel,
+      'aria-labelledby': labelledBy,
+      'aria-describedby': describedBy,
+      'aria-expanded': effectiveOpen,
+      'aria-haspopup': 'dialog',
+      'aria-invalid': status === 'error' ? true : undefined,
+      'aria-disabled': disabled || readOnly ? true : undefined,
+      disabled
+    },
+    triggerClassName: cn(
+      'flex min-w-0 flex-1 items-center justify-between gap-2 border-none bg-transparent text-left outline-none',
+      'disabled:cursor-not-allowed'
+    ),
+    triggerRef,
+    triggerValueId,
+    validationMessage,
+    validationMessageId,
+    valueClassName: datePickerValueVariants({ hasValue: hasSelectedDate }),
+    visibleMonths: sanitizedVisibleMonths,
+    wrapperClassName: cn('flex flex-col gap-2', isFullWidth && 'w-full', className)
+  };
+};

--- a/src/components/molecules/date-picker/useDatePicker.ts
+++ b/src/components/molecules/date-picker/useDatePicker.ts
@@ -249,7 +249,8 @@ export const useDatePicker = ({
   fieldClassName,
   popoverClassName,
   ariaDescribedBy,
-  ariaLabelledBy
+  ariaLabelledBy,
+  ...rootProps
 }: DatePickerProps): UseDatePickerReturn => {
   const [internalSelectedDate, setInternalSelectedDate] = useState<Date | null>(defaultValue);
   const [internalOpen, setInternalOpen] = useState(defaultOpen);
@@ -411,7 +412,7 @@ export const useDatePicker = ({
         status,
         variant
       }),
-      (disabled || readOnly) && 'cursor-not-allowed opacity-40',
+      disabled && 'cursor-not-allowed opacity-40',
       fieldClassName
     ),
     firstDayOfWeek: sanitizedFirstDayOfWeek,
@@ -426,9 +427,10 @@ export const useDatePicker = ({
     labelId,
     messageClassName: datePickerMessageVariants({ tone: status === 'default' ? 'info' : status }),
     popoverAriaLabel,
-    popoverClassName,
+    popoverClassName: cn('w-fit', popoverClassName),
     readOnlyDescriptionId,
     requestOpenChange,
+    rootProps,
     requiredDescriptionId,
     sanitizedFormatOptions,
     selectDate,

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export { Tooltip } from './components/atoms/tooltip';
 // ─── Molecules ───────────────────────────────────────────────────────────────
 export { Accordion } from './components/molecules/accordion';
 export { Breadcrumb } from './components/molecules/breadcrumb';
+export { DatePicker } from './components/molecules/date-picker';
 export {
   Pagination,
   PaginationContent,


### PR DESCRIPTION
## Summary

- Adds the `DatePicker` molecule with controlled/uncontrolled value and open state, Calendar-powered selection, hidden input serialization, validation states, disabled/read-only behavior, and clear support.
- Adds Calendar autofocus opt-in support for popover usage and fixes Popover as-child `aria-disabled` preservation for read-only trigger semantics.
- Adds tests, stories, root export, and package verification evidence for React 18 and React 19 consumers.

Closes #20

## Review scope

- Primary files/areas:
  - `src/components/molecules/date-picker/*`
  - `src/components/atoms/calendar/*`
  - `src/components/atoms/popover/*`
  - `src/index.ts`
- Out of scope:
  - Token/theme changes
  - New dependencies
  - Live Storybook screenshot capture
- Review workload: large — 12 files / ~1.7k inserted lines. Most of the diff is the new component, tests, and stories; final review and fallback 4R review were run before PR creation.

## Type of change

- [x] New component
- [x] Existing component update/refactor
- [ ] Bug fix
- [x] Accessibility
- [ ] Design tokens
- [x] Storybook/docs
- [ ] Infrastructure/tooling
- [ ] NPM/dependencies

## Workflow gates

- [x] Linked issue is present with `Closes #NNN` or maintainer approved an exception.
- [x] Linked issue has label `status:approved` before implementation starts.
- [x] Linked issue assignee was checked before work started; if it was assigned to someone else, explicit reassignment permission is documented.
- [x] Work was started through the Project flow: assignee set, Project status `In progress`, branch/worktree recorded.
- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`.
- [x] Commits follow the same commitlint-enforced format.
- [x] Diff is focused; unrelated work is called out in Review scope.
- [x] MCP/runtime artifacts are absent: `.playwright-mcp`, `page-*.png`, `page-*.jpeg`, `*.md.playwright-output`.

## Component evidence (required for component changes)

- [x] Validated component spec is linked or quoted in the issue.
- [x] Accessibility contract from the spec was implemented or deviations are explained below.
- [x] Follows the 6-file pattern: `types.ts`, `use*.ts`, `Component.tsx`, `Component.test.tsx`, `Component.stories.tsx`, `index.ts`.
- [x] CVA variants live in `types.ts`; JSX component has no state, CVA calls, or business logic.
- [x] Public props with runtime defaults have matching `@default` JSDoc in `types.ts` (`node scripts/verify-prop-default-docs.mjs`).
- [x] Uses design tokens from `theme.css`; no hardcoded colors or arbitrary color utilities.
- [x] Storybook covers default, variants, documented states, edge cases, and dark mode when visually different.
- [x] Component audit result is PASS or accepted PASS WITH WARNINGS.
- [x] Visual review result is included when visuals changed.

## Accessibility evidence

- [x] Role/name semantics verified with Testing Library queries or equivalent.
- [x] Keyboard-only behavior verified: Tab / Shift+Tab, Enter / Space, Arrow keys, Escape, Home / End / typeahead where applicable.
- [x] Focus lifecycle verified: initial focus, roving/active descendant, focus restore, trap/portal behavior where applicable.
- [x] Disabled, required, invalid/error, loading, and empty states expose the expected semantics where applicable.
- [x] Reduced motion behavior is respected where motion changed.
- [x] Screen reader or axe/manual evidence is included below when applicable.

## Validation evidence

- TypeScript:
  - [x] `pnpm exec tsc --noEmit` — passed before commit retry.
  - [x] Lefthook pre-commit `typecheck` — passed.
- Unit tests:
  - [x] `pnpm vitest run src/components/atoms/calendar/Calendar.test.tsx src/components/atoms/popover/Popover.test.tsx src/components/molecules/date-picker/DatePicker.test.tsx` — passed.
  - [x] Pre-push `pnpm run test` — 37 files passed, 797 tests passed.
- Build/package:
  - [x] `pnpm run verify:package` — passed; verified React 18.3.1 and React 19.2.7 consumers.
  - Note: Vite emitted the existing `lottie-web` eval warning only.
- Storybook or visual check:
  - [x] Storybook stories added for default, initial value, controlled, validation error, disabled, read-only, clearable, and constrained scenarios.
  - [x] Static visual/component review passed; no live screenshot capture was run.
- Accessibility check:
  - [x] Trigger accessible names include label/ARIA label plus current display value.
  - [x] Popover content has an accessible name.
  - [x] Read-only trigger remains focusable with `aria-disabled` and does not open/mutate.
  - [x] Calendar autofocus is opt-in and covered for popover usage.
- Security/dependency check:
  - [x] No new dependencies.
  - [x] Fallback R1 risk review reported no findings.

## Screenshots or recordings

No screenshots attached. The PR adds Storybook examples for visual inspection; static visual review passed.

## Notes for reviewer

- `DatePicker` accepts `Date | null` and serializes the optional hidden input as local `YYYY-MM-DD`, avoiding UTC ISO slicing.
- Invalid `Date` values are treated as empty for display, hidden input, and Calendar handoff so they do not crash rendering.
- Runtime-invalid date format options fall back to default date formatting.
- `visibleMonths` is capped to avoid consumer-controlled large synchronous renders.
- Specialized 4R agents timed out in this local run, so equivalent fresh-context fallback reviewers were used; resulting resilience findings were fixed before PR creation.
