### PR TITLE
docs(cataloging): add v1 recatalogation handoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ Keep it minimal — detailed workflows live in skills (`skills/`).
 | Key           | Value                                             |
 | ------------- | ------------------------------------------------- |
 | Package       | `@stack-and-flow/design-system`                   |
-| Repo          | https://github.com/Stack-and-Flow/design-system   |
-| Storybook     | https://sf-design-system.netlify.app/             |
+| Repo          | <https://github.com/Stack-and-Flow/design-system>   |
+| Storybook     | <https://sf-design-system.netlify.app/>             |
 | Guidelines    | [`docs/GUIDELINES.md`](docs/GUIDELINES.md)       |
 | Contributing  | [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md)   |
 | Visual Design | [`docs/DESIGN.md`](docs/DESIGN.md)               |
@@ -32,7 +32,7 @@ Keep it minimal — detailed workflows live in skills (`skills/`).
 
 ## Structure
 
-Components live in `src/components/{atoms|molecules|organisms}/{kebab-name}/` with exactly 6 files:
+Implemented components live in `src/components/{atoms|molecules|organisms}/{kebab-name}/` with exactly 6 files by default. `primitive` remains a catalog tier, but `src/components/primitives/...` is only valid when a validated cataloging decision explicitly approves primitive implementation support and path:
 
 | File                        | Role                                              |
 | --------------------------- | ------------------------------------------------- |
@@ -74,7 +74,9 @@ Load the relevant skill for detailed workflows:
 | Trigger                                                                                                                | Skill                                                                |
 | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
 | Contributor shares a GitHub issue URL or component spec and asks to implement it                                       | [`component-contributor`](skills/component-contributor/SKILL.md)     |
-| User provides a HeroUI/reference component and wants an implementation-ready spec before coding                        | [`component-spec-proposer`](skills/component-spec-proposer/SKILL.md) |
+| User provides a capture-first component idea or reference-component-first URL and wants a validated issue spec before coding | [`component-spec-proposer`](skills/component-spec-proposer/SKILL.md) |
+| Validating a proposed component spec against catalog tiers, existing components, and reuse/extraction opportunities before approval | [`component-spec-cataloging-validator`](skills/component-spec-cataloging-validator/SKILL.md) |
+| Creating or reusing child issues from a validated component cataloging decision for independently reviewable primitives/atoms/molecules/organisms | [`component-child-issues`](skills/component-child-issues/SKILL.md)   |
 | Reviewing an existing component — code quality, visual states, tokens, accessibility                                   | [`components-auditor`](skills/components-auditor/SKILL.md)           |
 | Auditing the design system package — token architecture, folder structure, npm distributable standards                 | [`system-auditor`](skills/system-auditor/SKILL.md)                   |
 | External project wants to use Stack-and-Flow as a base and customize its tokens                                        | [`bootstrapping`](skills/bootstrapping/SKILL.md)                     |

--- a/docs/COMPONENT-CATALOGING.en.md
+++ b/docs/COMPONENT-CATALOGING.en.md
@@ -1,0 +1,190 @@
+# Component cataloging and V1 recatalogation handoff
+
+This guide defines how to classify components during MVP and how to hand recatalogation to V1. Short answer: **MVP PRs may merge in their current location when they meet the quality bar; full recatalogation belongs to V1**.
+
+---
+
+## Quick path
+
+1. Validate the MVP quality bar first: TypeScript, tests or justification, reasonable Storybook coverage, accessibility basics, token usage without major drift, and no known functional blocker.
+2. Classify the component with the `primitives`, `atoms`, `molecules`, and `organisms` contracts in this guide.
+3. If the current location does not match the classification, document it as a V1 follow-up; do not mix it into the MVP PR unless required for MVP quality.
+4. Create child issues only from validated cataloging decisions with enough evidence.
+5. After MVP, follow the V1 sequence: #223 → #224 → #225 → #226 → #227.
+
+---
+
+## MVP merge rule vs V1 boundary
+
+| Topic | Decision |
+| --- | --- |
+| MVP merge | An MVP component may merge where it is if it meets the current quality bar. |
+| MVP quality bar | TypeScript passes; tests exist or their absence is justified; Storybook covers meaningful states/variants; accessibility basics are covered; token usage has no major drift; no known functional blocker remains. |
+| Catalog mismatch | The difference between the current location and target tier is documented as V1 follow-up work. |
+| V1 work | Do not mix it into MVP PRs unless the change is required to meet MVP quality. |
+| Handoff | This guide is the final criteria and contract handoff before #223; no “issue 0” is needed. |
+
+> If recatalogation changes imports, exports, stories, or structure without unlocking MVP quality, it is V1.
+
+---
+
+## Operational workflow
+
+### During MVP
+
+- Validate the MVP quality bar before recataloging.
+- Classify the component with this guide and leave any current-location mismatch as a V1 follow-up.
+- Do not move or split components unless required to meet MVP quality.
+
+### Handoff after MVP / before #223
+
+- Use this guide as the criteria source for V1 recatalogation.
+- Do not create an “issue 0”: #223 starts directly from these contracts and checklist.
+
+### #223 inventory
+
+Inspect every MVP component and record:
+
+- current path/tier;
+- proposed V1 tier;
+- decision: `reuse existing`, `keep in parent`, `split/extract`, `needs child issue`, or `defer to V1 inventory`;
+- evidence against the MVP bar and tier contract;
+- migration impact: imports, exports, stories, docs, and tests;
+- whether a validated child issue is needed.
+
+### Child issues
+
+- For proposed specs, use `skills/component-spec-cataloging-validator/SKILL.md` before approving `## Validated component spec`; before approval it must produce `## Draft cataloging decision` or `## Cataloging blockers/questions`.
+- Create or reuse child issues only after a final validated `## Cataloging decision`, placed immediately after `## Validated component spec` in the same comment/update and without unresolved blockers/questions.
+- Use them for `primitive`, `atom`, `molecule`, or `organism` candidates that can be reviewed independently.
+- Extracted lower-tier pieces are usually `primitive`, `atom`, or `molecule`; an `organism` may also have a child issue when the validated decision marks it as independently reviewable scope.
+- If `Child issue candidates` is `yes`, the `### Child issue candidates` block is the handoff consumed by `component-child-issues`.
+- Link parent/child and update the cataloging checklist.
+- `skills/component-child-issues/SKILL.md` can help execute this part without skipping the gate.
+
+### Recatalogation PRs
+
+- Keep each PR reviewable: prefer one independent piece or a small, closely related set.
+- Keep docs, stories, tests, and exports with the unit that changes.
+- Use #224/#225 for moves/splits, #226 for public surface and docs migration, and #227 for final verification.
+
+### Blocking rule
+
+If the decision is not validated or evidence is missing, do not create child issues. Record the finding in #223 first.
+
+---
+
+## Tier contracts
+
+| Tier | Contract | May depend on | Must not do |
+| --- | --- | --- | --- |
+| `primitives` | Native design-system unit at the HTML/ARIA level: base element, slot, wrapper, or minimal behavior that preserves native semantics. | Tokens, shared utilities, HTML/ARIA attributes, and minimal accessibility hooks. | Compose product concepts, impose copy, coordinate several controls, or represent a business pattern. |
+| `atoms` | One semantic UI concept. It may use up to two supporting sub-`primitives` when that keeps the API simple. | `primitives`, tokens, simple CVA/variants, limited local state. | Orchestrate several peer concepts, expose complex layout, contain flows, coordinate lists, or create contextual composition. |
+| `molecules` | Small composition of several UI concepts that work together as a reusable unit. | `atoms`, `primitives`, interaction hooks, and local layout. | Represent a full page section, own high-level navigation, or absorb extensive domain logic. |
+| `organisms` | Large composed block: section, region, or interface pattern with several molecules/atoms and a clear structural responsibility. | `molecules`, `atoms`, `primitives`, and sample data for stories. | Become a full page, mix non-reusable application rules, or hide smaller components that should be extracted. |
+
+### Operational definitions
+
+- `Primitive` means native HTML/ARIA-level design-system unit.
+- `Atom` means one semantic UI concept; it may rely on at most two supporting sub-`primitives`.
+- `split/extract` means the proposal must be conceptually divided or extracted before final implementation is decided.
+- `needs child issue` means at least one extracted or reused unit is independently reviewable and should be tracked separately.
+- Candidate tier groupings are examples, not automatic targets. V1 recatalogation must dissect complex current molecules/organisms into smaller reusable `primitives`, `atoms`, and `molecules` when appropriate.
+
+---
+
+## Split and recatalogation criteria
+
+Use this table to decide whether to keep, move, or split.
+
+| Signal | Suggested decision |
+| --- | --- |
+| One UI concept, small API, simple local state | Candidate `atom`. |
+| Reusable native wrapper without its own visual concept | Candidate `primitive`. |
+| Two or more coordinated UI concepts | Candidate `molecule`. |
+| Full region with hierarchy, composition, and structural responsibility | Candidate `organism`. |
+| Variants change component semantics, not only styling | Evaluate a split before classifying. |
+| Props enable mutually exclusive behaviors | Evaluate separate components. |
+| Storybook needs many stories to explain unrelated uses | Likely split. |
+| Tests cover independent flows inside the same component | Likely split. |
+| Current component only exists for one page layout | Keep outside the catalog or treat as a specific `organism` if reusable. |
+
+---
+
+## Automatic disqualifiers for `atom`
+
+A component **must not** be classified as an `atom` if any of these conditions apply:
+
+- It coordinates three or more semantic subparts.
+- It exposes multiple slots or regions with independent responsibilities.
+- It contains a list, collection, menu, table, wizard, field group, or composite navigation.
+- It requires shared state across subcomponents to work.
+- It has variants that change the full interaction pattern.
+- It needs more than two sub-`primitives` to support its contract.
+- Its documentation must explain several unrelated use cases.
+- Its API mixes layout, content, interaction, and presentation in one component.
+
+If a disqualifier appears, classify it as `molecule`/`organism` or split before deciding.
+
+---
+
+## Classification checklist for reviewers
+
+Copy this template into the issue, PR, or review comment only for a final/approved catalog decision. Before approval, use `## Draft cataloging decision` or `## Cataloging blockers/questions` instead.
+
+```md
+## Cataloging decision
+
+- Component:
+- Proposed tier: primitive | atom | molecule | organism
+- Current/proposed path:
+- Decision: reuse existing | keep in parent | split/extract | needs child issue | defer to V1 inventory
+- Existing pieces to reuse:
+- Pieces to extract/create:
+- Child issue candidates: yes | no
+- Target issue: parent | #223 | #224 | #225 | #226 | #227
+- Blockers/questions: none
+
+### Child issue candidates
+
+If `Child issue candidates` is `yes`, this section is the deterministic handoff consumed later by `component-child-issues`. Include one row per candidate with blockers/questions resolved as `none`; use `none` across the row only when candidates are `no`. Any unresolved blocker or question belongs in `## Cataloging blockers/questions` or the draft state, not in the final decision.
+
+| Candidate name | Proposed tier | Source/parent component | Action | Reuse target or extraction reason | Scope summary | Target issue | Blockers/questions |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| {name or none} | primitive/atom/molecule/organism | {source component} | reuse existing/create new/skip/defer | {existing component or why this must be extracted} | {independently reviewable scope} | parent/#223/#224/#225/#226/#227 | none |
+
+### Evidence
+
+- Tier contract check:
+- Existing catalog check:
+- Reuse/extraction rationale:
+```
+
+---
+
+## Child issues: only from validated decisions
+
+Do not create child issues from intuition or shallow inventory. A recatalogation child issue must come from a validated `## Cataloging decision`, adjacent to `## Validated component spec` in the same comment/update, that includes:
+
+- affected component or group;
+- current tier and target tier;
+- evidence of the unmet contract or required split;
+- expected impact on imports, exports, Storybook, docs, or tests;
+- target V1 issue;
+- per candidate: name, proposed tier, source/parent component, action, reuse target or extraction reason, scope summary, target issue, and blockers/questions.
+
+If that evidence is missing, record the observation in #223 first.
+
+---
+
+## V1 sequence
+
+| Order | Issue | Expected outcome |
+| --- | --- | --- |
+| 1 | [#223](https://github.com/Stack-and-Flow/design-system/issues/223) | Complete inventory and validated target taxonomy. |
+| 2 | [#224](https://github.com/Stack-and-Flow/design-system/issues/224) | `primitives` and `atoms` recatalogation. |
+| 3 | [#225](https://github.com/Stack-and-Flow/design-system/issues/225) | `molecules` and `organisms` recatalogation. |
+| 4 | [#226](https://github.com/Stack-and-Flow/design-system/issues/226) | Exports, Storybook, and docs migration. |
+| 5 | [#227](https://github.com/Stack-and-Flow/design-system/issues/227) | Final verification of catalog, imports, docs, and coverage. |
+
+Keep the sequence: validate the map first, then move/split, then migrate public surfaces, and finally verify.

--- a/docs/COMPONENT-CATALOGING.md
+++ b/docs/COMPONENT-CATALOGING.md
@@ -1,0 +1,190 @@
+# Catalogación de componentes y handoff de recatalogación V1
+
+Esta guía define cómo clasificar componentes durante el MVP y cómo entregar la recatalogación a V1. La respuesta corta: **los PRs MVP pueden mergearse en su ubicación actual si cumplen la barra de calidad; la recatalogación completa pertenece a V1**.
+
+---
+
+## Ruta rápida
+
+1. Validá primero la barra MVP: TypeScript, tests o justificación, Storybook razonable, accesibilidad básica, tokens sin drift mayor y sin blocker funcional conocido.
+2. Clasificá el componente con los contratos de `primitives`, `atoms`, `molecules` y `organisms` de esta guía.
+3. Si la ubicación actual no coincide con la clasificación, documentalo como follow-up V1; no lo mezcles en el PR MVP salvo que sea necesario para cumplir la calidad MVP.
+4. Creá child issues solo cuando la decisión de catalogación esté validada y tenga evidencia suficiente.
+5. Después del MVP, seguí la secuencia V1: #223 → #224 → #225 → #226 → #227.
+
+---
+
+## Regla de merge MVP vs límite V1
+
+| Tema | Decisión |
+| --- | --- |
+| Merge MVP | Un componente MVP puede mergearse donde está si cumple la barra de calidad actual. |
+| Barra MVP | TypeScript pasa; hay tests o ausencia justificada; Storybook cubre estados/variantes razonables; accesibilidad básica está cubierta; uso de tokens sin drift mayor; no hay blocker funcional conocido. |
+| Mismatch de catálogo | La diferencia entre ubicación actual y tier objetivo se documenta como follow-up V1. |
+| Trabajo V1 | No se mezcla en PRs MVP salvo que el cambio sea necesario para alcanzar la barra MVP. |
+| Handoff | Esta guía es el handoff final de criterios y contratos antes de #223; no hace falta una “issue 0”. |
+
+> Si una recatalogación cambia imports, exports, stories o estructura sin desbloquear calidad MVP, es V1.
+
+---
+
+## Flujo operativo
+
+### Durante el MVP
+
+- Validá la barra de calidad MVP antes de recatalogar.
+- Clasificá el componente con esta guía y dejá el mismatch como follow-up V1 cuando la ubicación actual no coincida.
+- No muevas ni dividas componentes salvo que sea necesario para cumplir la calidad MVP.
+
+### Handoff después del MVP / antes de #223
+
+- Usá esta guía como fuente de criterios para la recatalogación V1.
+- No crees una “issue 0”: #223 arranca directamente con estos contratos y checklist.
+
+### Inventario de #223
+
+Inspeccioná cada componente MVP y registrá:
+
+- ruta/tier actual;
+- tier V1 propuesto;
+- decisión: `reuse existing`, `keep in parent`, `split/extract`, `needs child issue` o `defer to V1 inventory`;
+- evidencia contra la barra MVP y el contrato de tier;
+- impacto de migración: imports, exports, stories, docs y tests;
+- si necesita child issue validada.
+
+### Child issues
+
+- Para specs propuestas, usá `skills/component-spec-cataloging-validator/SKILL.md` antes de aprobar `## Validated component spec`; antes de aprobación debe producir `## Draft cataloging decision` o `## Cataloging blockers/questions`.
+- Creá o reutilizá child issues solo después de un `## Cataloging decision` final validado, ubicado inmediatamente después de `## Validated component spec` en el mismo comentario/actualización y sin blockers/questions sin resolver.
+- Usalas para candidatos `primitive`, `atom`, `molecule` u `organism` que puedan revisarse de forma independiente.
+- Las piezas extraídas de tier inferior suelen ser `primitive`, `atom` o `molecule`; un `organism` también puede tener child issue cuando la decisión validada lo marca como alcance independiente.
+- Si `Child issue candidates` es `yes`, el bloque `### Child issue candidates` es el handoff que consume `component-child-issues`.
+- Linkeá parent/child y actualizá el checklist de catalogación.
+- `skills/component-child-issues/SKILL.md` puede ayudar a ejecutar esta parte sin saltar el gate.
+
+### PRs de recatalogación
+
+- Mantené cada PR revisable: preferí una pieza independiente o un set pequeño y estrechamente relacionado.
+- Llevá docs, stories, tests y exports junto con la unidad que cambia.
+- Usá #224/#225 para moves/splits, #226 para migración de superficies públicas y docs, y #227 para verificación final.
+
+### Regla de bloqueo
+
+Si la decisión no está validada o falta evidencia, no crees child issues. Registrá el hallazgo en #223 primero.
+
+---
+
+## Contratos por tier
+
+| Tier | Contrato | Puede depender de | No debe hacer |
+| --- | --- | --- | --- |
+| `primitives` | Unidad nativa del design system a nivel HTML/ARIA: elemento base, slot, wrapper o comportamiento mínimo que preserva semántica nativa. | Tokens, utilidades compartidas, atributos HTML/ARIA y hooks mínimos de accesibilidad. | Componer conceptos de producto, imponer copy, coordinar varios controles o representar un patrón de negocio. |
+| `atoms` | Un concepto UI semántico único. Puede usar hasta dos sub-`primitives` de apoyo cuando eso mantiene una API simple. | `primitives`, tokens, CVA/variantes simples, estado local acotado. | Orquestar varios conceptos pares, exponer layout complejo, contener flujos, coordinar listas o crear composición contextual. |
+| `molecules` | Composición pequeña de varios conceptos UI que funcionan juntos como una unidad reusable. | `atoms`, `primitives`, hooks de interacción y layout local. | Representar una sección completa de página, poseer navegación de alto nivel o absorber lógica de dominio extensa. |
+| `organisms` | Bloque compuesto grande: sección, región o patrón de interfaz con varias moléculas/átomos y responsabilidad estructural clara. | `molecules`, `atoms`, `primitives`, datos de ejemplo para stories. | Convertirse en página completa, mezclar reglas de aplicación no reutilizables o esconder componentes menores que deberían extraerse. |
+
+### Definiciones operativas
+
+- `Primitive` significa unidad nativa HTML/ARIA del design system.
+- `Atom` significa un solo concepto UI semántico; como máximo puede apoyarse en dos sub-`primitives`.
+- `split/extract` significa que la propuesta debe dividirse o extraerse conceptualmente antes de decidir implementación final.
+- `needs child issue` significa que al menos una unidad extraída o reutilizada es revisable de forma independiente y debe trackearse por separado.
+- Las agrupaciones candidatas son ejemplos, no destino automático. La recatalogación V1 debe diseccionar moléculas/organismos complejos en `primitives`, `atoms` y `molecules` más reutilizables cuando corresponda.
+
+---
+
+## Criterios de split y recatalogación
+
+Usá esta tabla para decidir si se mantiene, se mueve o se divide.
+
+| Señal | Decisión sugerida |
+| --- | --- |
+| Un solo concepto UI, API pequeña, estado local simple | Candidato a `atom`. |
+| Wrapper nativo reutilizable sin concepto visual propio | Candidato a `primitive`. |
+| Dos o más conceptos UI coordinados | Candidato a `molecule`. |
+| Región completa con jerarquía, composición y responsabilidad estructural | Candidato a `organism`. |
+| Variantes que cambian la semántica del componente, no solo su estilo | Evaluar split antes de clasificar. |
+| Props que activan comportamientos mutuamente excluyentes | Evaluar componentes separados. |
+| Storybook necesita muchas stories para explicar usos no relacionados | Probable split. |
+| Tests cubren flujos independientes dentro del mismo componente | Probable split. |
+| El componente actual solo existe para layout de una página | Mantener fuera del catálogo o tratar como `organism` específico si es reusable. |
+
+---
+
+## Descalificadores automáticos para `atom`
+
+Un componente **no** debe clasificarse como `atom` si cumple cualquiera de estas condiciones:
+
+- Coordina tres o más subpiezas semánticas.
+- Expone slots o regiones múltiples con responsabilidades independientes.
+- Contiene una lista, colección, menú, tabla, wizard, grupo de campos o navegación compuesta.
+- Requiere estado compartido entre subcomponentes para funcionar.
+- Tiene variantes que cambian el patrón de interacción completo.
+- Necesita más de dos sub-`primitives` para sostener su contrato.
+- Su documentación necesita explicar varios casos de uso no relacionados.
+- Su API mezcla layout, contenido, interacción y presentación en un solo componente.
+
+Si aparece un descalificador, clasificá como `molecule`/`organism` o dividí antes de decidir.
+
+---
+
+## Checklist de clasificación para reviewers
+
+Copiá esta plantilla en la issue, PR o comentario de revisión solo para una decisión de catálogo final/aprobada. Antes de aprobación, usá `## Draft cataloging decision` o `## Cataloging blockers/questions`.
+
+```md
+## Cataloging decision
+
+- Component:
+- Proposed tier: primitive | atom | molecule | organism
+- Current/proposed path:
+- Decision: reuse existing | keep in parent | split/extract | needs child issue | defer to V1 inventory
+- Existing pieces to reuse:
+- Pieces to extract/create:
+- Child issue candidates: yes | no
+- Target issue: parent | #223 | #224 | #225 | #226 | #227
+- Blockers/questions: none
+
+### Child issue candidates
+
+Si `Child issue candidates` es `yes`, esta sección es el handoff determinístico que consume después `component-child-issues`. Incluí una fila por candidato con blockers/questions resueltos como `none`; usá `none` en toda la fila solo cuando candidates es `no`. Cualquier blocker o pregunta pendiente pertenece a `## Cataloging blockers/questions` o al draft, no a la decisión final.
+
+| Candidate name | Proposed tier | Source/parent component | Action | Reuse target or extraction reason | Scope summary | Target issue | Blockers/questions |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| {name or none} | primitive/atom/molecule/organism | {source component} | reuse existing/create new/skip/defer | {existing component or why this must be extracted} | {independently reviewable scope} | parent/#223/#224/#225/#226/#227 | none |
+
+### Evidence
+
+- Tier contract check:
+- Existing catalog check:
+- Reuse/extraction rationale:
+```
+
+---
+
+## Child issues: solo desde decisiones validadas
+
+No crees child issues por intuición ni por inventario superficial. Una child issue de recatalogación debe nacer de un `## Cataloging decision` validado, adyacente a `## Validated component spec` en el mismo comentario/actualización, que incluya:
+
+- componente o grupo afectado;
+- tier actual y tier objetivo;
+- evidencia del contrato incumplido o del split necesario;
+- impacto esperado en imports, exports, Storybook, docs o tests;
+- issue V1 destino;
+- por cada candidato: nombre, tier propuesto, source/parent component, acción, reuse target o razón de extracción, resumen de scope, target issue y blockers/questions.
+
+Si falta esa evidencia, registrá la observación en #223 primero.
+
+---
+
+## Secuencia V1
+
+| Orden | Issue | Resultado esperado |
+| --- | --- | --- |
+| 1 | [#223](https://github.com/Stack-and-Flow/design-system/issues/223) | Inventario completo y taxonomía objetivo validada. |
+| 2 | [#224](https://github.com/Stack-and-Flow/design-system/issues/224) | Recatalogación de `primitives` y `atoms`. |
+| 3 | [#225](https://github.com/Stack-and-Flow/design-system/issues/225) | Recatalogación de `molecules` y `organisms`. |
+| 4 | [#226](https://github.com/Stack-and-Flow/design-system/issues/226) | Migración de exports, Storybook y documentación. |
+| 5 | [#227](https://github.com/Stack-and-Flow/design-system/issues/227) | Verificación final de catálogo, imports, docs y cobertura. |
+
+Mantené la secuencia: primero se valida el mapa, después se mueve/divide, después se migran superficies públicas y finalmente se verifica.

--- a/docs/COMPONENTS.en.md
+++ b/docs/COMPONENTS.en.md
@@ -2,6 +2,8 @@
 
 > Reference for AI agents writing or reviewing component code. Covers every interactive state, glow system, transition rules, gradient border technique, and accessibility requirements. Derived from Stack-and-Flow tokens and the current project visual contract.
 
+For tier, split, or V1 recatalogation follow-up decisions, use [`COMPONENT-CATALOGING.en.md`](./COMPONENT-CATALOGING.en.md).
+
 ---
 
 ## 1. Compositional Principles

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -2,6 +2,8 @@
 
 > Referencia para agentes de IA que escriben o revisan código de componentes. Cubre todos los estados interactivos, el sistema de glow, las reglas de transición, la técnica de bordes con degradado y los requisitos de accesibilidad. Se basa en los tokens de Stack-and-Flow y en el contrato visual actual del proyecto.
 
+Para decidir tier, split o follow-up de recatalogación V1, usá [`COMPONENT-CATALOGING.md`](./COMPONENT-CATALOGING.md).
+
 ---
 
 ## 1. Principios de composición

--- a/docs/CONTRIBUTING.en.md
+++ b/docs/CONTRIBUTING.en.md
@@ -13,19 +13,26 @@ You MUST have the following installed:
 ## Local Setup
 
 1. **Clone the repository**:
+
    ```bash
    git clone https://github.com/Stack-and-Flow/design-system.git
    cd design-system
    ```
+
 2. **Set the correct Node version**:
+
    ```bash
    nvm use
    ```
+
 3. **Install dependencies**:
+
    ```bash
    pnpm install
    ```
+
 4. **Start Storybook**:
+
    ```bash
    pnpm run storybook
    ```
@@ -55,6 +62,7 @@ Every component MUST strictly follow the Atomic Design + Container/Presentationa
 
 1. **Locate the right tier**: Decide if it's an `atom`, `molecule`, or `organism`.
 2. **Create the structure**: If you create a `Button` atom, the structure MUST be exactly:
+
    ```text
    src/components/atoms/button/
    ├── types.ts             # Types, public props, JSDoc controls, CVA variants
@@ -64,6 +72,7 @@ Every component MUST strictly follow the Atomic Design + Container/Presentationa
    ├── Button.stories.tsx   # Storybook documentation
    └── index.ts             # Re-exports
    ```
+
 3. **Implement in order**: `types.ts` → hook → component → tests → stories → `index.ts`.
 4. **Design visual semantics deliberately**: decorative glow/elevation belongs to the component contract. When consumers may need a quieter version of a glow-bearing control, prefer `emphasis="default" | "flat"` over a raw `glow?: boolean` prop. Never let decorative emphasis disable the shared `focus-ring` focus-visible indicator.
 5. **Review before PR**: run the pre-PR component review defined in `CONTRIBUTOR-FLOW.en.md`.
@@ -220,7 +229,7 @@ Phase summary:
 3. **Approval gate** — once the spec is written, wait for the `status:approved` label on the issue; without that label there is no START WORK or implementation under any circumstance.
 4. **Assignee gate** — before any action on a linked issue, verify assignees; if it is assigned to someone else, explicit permission is required before reassigning it.
 5. **START WORK** — after the `status:approved` label and assignee gate, assign the issue, move it to `In progress`, and record branch/worktree.
-6. **Spec intake** — with START WORK already completed, `component-contributor` reads the `## Validated component spec` section without inventing behavior.
+6. **Spec intake** — with START WORK already completed, `component-contributor` reads `## Validated component spec` and the immediately following `## Cataloging decision` without inventing behavior.
 7. **Spec review** — the agent critiques gaps, risks, and inconsistencies before planning.
 8. **Visual preflight** — tokens, surfaces, states, focus, transitions, and dark mode are aligned before the plan.
 9. **Plan** — review and approve files, variants, tests, stories, and accessibility.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -13,19 +13,26 @@ Es **obligatorio** tener instalado:
 ## Configuración local
 
 1. **Clona el repositorio**:
+
    ```bash
    git clone https://github.com/Stack-and-Flow/design-system.git
    cd design-system
    ```
+
 2. **Establece la versión correcta de Node**:
+
    ```bash
    nvm use
    ```
+
 3. **Instala las dependencias**:
+
    ```bash
    pnpm install
    ```
+
 4. **Inicia Storybook**:
+
    ```bash
    pnpm run storybook
    ```
@@ -55,6 +62,7 @@ Todo componente DEBE seguir estrictamente la arquitectura Atomic Design + Contai
 
 1. **Determina el nivel correcto**: Decide si es un `atom`, `molecule` u `organism`.
 2. **Crea la estructura**: Si creas un átomo `Button`, la estructura DEBE ser exactamente:
+
    ```text
    src/components/atoms/button/
    ├── types.ts             # Tipos, props públicas, JSDoc controls y variantes CVA
@@ -64,6 +72,7 @@ Todo componente DEBE seguir estrictamente la arquitectura Atomic Design + Contai
    ├── Button.stories.tsx   # Documentación Storybook
    └── index.ts             # Re-exportaciones
    ```
+
 3. **Implementa en orden**: `types.ts` → hook → componente → tests → stories → `index.ts`.
 4. **Revisa antes del PR**: ejecuta la review pre-PR del componente definida en `CONTRIBUTOR-FLOW.md`.
 
@@ -223,7 +232,7 @@ Resumen de fases:
 3. **Approval gate** — una vez escrita la spec, esperas el label `status:approved` en la issue; sin ese label no hay START WORK ni implementación bajo ningún concepto.
 4. **Assignee gate** — antes de cualquier acción sobre una issue linkeada, verificas assignees; si está asignada a otra persona, hace falta permiso explícito antes de reasignarla.
 5. **START WORK** — después del label `status:approved` y el assignee gate, asignas la issue, la mueves a `In progress` y registras branch/worktree.
-6. **Spec intake** — con START WORK ya completado, `component-contributor` lee la sección `## Validated component spec` sin inventar comportamiento.
+6. **Spec intake** — con START WORK ya completado, `component-contributor` lee `## Validated component spec` y el `## Cataloging decision` inmediatamente siguiente sin inventar comportamiento.
 7. **Review de spec** — el agente critica gaps, riesgos e inconsistencias antes de planificar.
 8. **Prefase visual** — el agente alinea tokens, superficie, estados, focus, transición y dark mode antes del plan.
 9. **Plan** — revisas y apruebas archivos, variantes, tests, stories y accesibilidad.

--- a/docs/CONTRIBUTOR-FLOW.en.md
+++ b/docs/CONTRIBUTOR-FLOW.en.md
@@ -7,7 +7,7 @@ This is the canonical document for contributing components to the design system.
 ## Quick summary
 
 ```text
-Project task → Research → Spec proposal skill → Validated issue spec → wait for `status:approved` → verify assignee → START WORK → Spec review → Visual preflight → Plan → Implementation → Visual review → Pre-PR component review → PR → Review → Merge → END WORK
+Project task → Research → Spec proposal skill → Cataloging validator → Validated issue spec → wait for `status:approved` → verify assignee → START WORK → Spec review → Visual preflight → Plan → Implementation → Visual review → Pre-PR component review → PR → Review → Merge → END WORK
 ```
 
 Core rule: **AI executes, the contributor decides**. The spec, visual criteria, and checkpoint approvals remain human responsibility. After the validated spec is written in the task, implementation stays blocked until the linked issue has the `status:approved` label and is not assigned to someone else.
@@ -22,7 +22,9 @@ Core rule: **AI executes, the contributor decides**. The spec, visual criteria, 
 | Architecture and code rules | [`GUIDELINES.en.md`](./GUIDELINES.en.md) |
 | Tokens and visual language | [`DESIGN.en.md`](./DESIGN.en.md), `src/styles/theme.css` |
 | Component visual states | [`COMPONENTS.en.md`](./COMPONENTS.en.md) |
-| Spec intake and validation | `skills/component-spec-proposer/SKILL.md` |
+| Cataloging and V1 recatalogation | [`COMPONENT-CATALOGING.en.md`](./COMPONENT-CATALOGING.en.md) |
+| Spec intake and proposal | `skills/component-spec-proposer/SKILL.md` |
+| Spec cataloging validation | `skills/component-spec-cataloging-validator/SKILL.md` |
 | Detailed AI workflow | `skills/component-contributor/SKILL.md` |
 | Pre-PR audit | `skills/components-auditor/SKILL.md` |
 
@@ -47,7 +49,7 @@ Before asking for implementation, research the component.
 Minimum checklist:
 
 - References: Radix UI primitives, MDN, or WAI-ARIA APG as applicable.
-- Atomic tier: `atom`, `molecule`, or `organism`.
+- Catalog tier: use [`COMPONENT-CATALOGING.en.md`](./COMPONENT-CATALOGING.en.md) to decide `primitives`, `atoms`, `molecules`, or `organisms` and document V1 follow-ups.
 - Props: name, type, default, required/optional.
 - CVA variants: keys and values.
 - States: base, hover, focus, active/pressed, disabled, loading, error, empty when relevant.
@@ -60,34 +62,61 @@ Do not do partial research. If the issue is incomplete, the component will be in
 
 ## Step 3 — Take and validate the spec with `component-spec-proposer`
 
-Before implementing, use the `component-spec-proposer` skill to turn the task and its reference into a validated spec.
+Before implementing, use the `component-spec-proposer` skill to turn the issue into a validated spec. There are two valid intake variants: capture-first and reference-component-first; both end at the same approval gate.
 
-When to use it:
+| Variant | When it applies | What the issue records |
+| ------- | --------------- | ---------------------- |
+| A — capture-first | A maintainer/user captures a component idea from a conversation or product need, even when no external reference exists yet. | Known context, constraints, unknowns, intended tier, and any missing reference or pattern. |
+| B — reference-component-first | The user provides a HeroUI, Radix, MDN, WAI-ARIA APG, or other reference component URL. | Reference behavior and how it adapts to Stack-and-Flow; it is not copied blindly. |
 
-- The issue references a Radix UI primitive, MDN, APG, or similar.
-- The task is still vague or has open decisions.
-- You need to prepare the issue before implementation.
+Mandatory convergence:
 
-Suggested prompt:
+```text
+captured issue or reference → proposed spec → assumptions/questions → cataloging validation → human validation → `## Validated component spec` in the issue → wait for `status:approved` label → START WORK → component-contributor
+```
+
+Before requesting human approval or writing `## Validated component spec`, run `component-spec-cataloging-validator`. That gate checks the proposal against [`COMPONENT-CATALOGING.en.md`](./COMPONENT-CATALOGING.en.md), inspects the current catalog, and returns `## Draft cataloging decision` with reuse, extraction, split, child issue candidates, and target issue, or `## Cataloging blockers/questions` when validation cannot complete. If blockers/questions remain, do not request approval yet. If child issues are needed, use `component-child-issues` later, only after the final decision is validated.
+
+When written to the issue, `## Cataloging decision` should sit immediately after `## Validated component spec` in the same comment or update, so the implementation contract and cataloging decision are reviewed together. This exact heading is reserved for the approved final version and must not contain unresolved blockers/questions.
+
+`status:approved` is an **issue label**. Project Status `In progress` belongs to **START WORK**, not to the spec proposal phase.
+
+Capture-first prompt:
 
 ```text
 Prepare the spec for this component using component-spec-proposer.
 
 Issue: {issue_url}
+Intake: capture-first from this conversation/product need.
+Known context: {context}
+Reference: pending or unknown
+
+Do not implement yet. Propose the spec, list assumptions/questions, flag missing references or patterns, run `component-spec-cataloging-validator`, and wait for my approval of the spec and `## Draft cataloging decision` before writing back to GitHub. If there are `## Cataloging blockers/questions`, do not request approval yet.
+```
+
+Reference-component-first prompt:
+
+```text
+Prepare the spec for this component using component-spec-proposer.
+
+Issue: {issue_url}
+Intake: reference-component-first
 Reference: {reference_url}
 
-Do not implement yet. First propose the spec, list assumptions to validate, and wait for my approval before writing back to GitHub.
+Do not implement yet. Adapt the reference to Stack-and-Flow, propose the spec, list assumptions to validate, run `component-spec-cataloging-validator`, and wait for my approval of the spec and `## Draft cataloging decision` before writing back to GitHub. If there are `## Cataloging blockers/questions`, do not request approval yet.
 ```
 
 The skill must:
 
-1. Read the issue and the reference.
+1. Read the issue and, when present, the reference.
 2. Propose a spec using the `component-spec-proposer` template.
-3. List assumptions to validate.
-4. Wait for human approval.
-5. Only after approval, write `## Validated component spec` in the issue.
-6. Leave the task waiting for approval: do not move it to `In progress` from `component-spec-proposer`.
-7. Indicate the next step: wait for the `status:approved` issue label and verify the issue is unassigned or assigned to the contributor/user before starting `component-contributor`.
+3. List assumptions to validate, including missing references or patterns in capture-first intake.
+4. Pass the proposal through `component-spec-cataloging-validator` before human approval.
+5. Include `## Draft cataloging decision` when validation passes, with deterministic `### Child issue candidates` when applicable; if blockers/questions remain, show `## Cataloging blockers/questions` and stop.
+6. Wait for human approval of both the proposed spec and `## Draft cataloging decision`.
+7. Only after that approval, write `## Validated component spec` and the validated `## Cataloging decision` immediately after it in the same issue comment or update.
+8. Leave the task waiting for approval: do not move it to `In progress` from `component-spec-proposer`.
+9. Indicate the next step: wait for the `status:approved` issue label and verify the issue is unassigned or assigned to the contributor/user before starting `component-contributor`.
 
 Do not use `component-contributor` to implement until the spec is validated, the issue has the `status:approved` label, and the assignee gate has passed.
 
@@ -100,12 +129,12 @@ The validated spec must live in the issue as a verifiable contract.
 | Field | What it must say |
 | ------------------ | ---------------------------------------------------------- |
 | Component name | PascalCase |
-| Atomic tier | atom / molecule / organism |
+| Catalog tier | primitive / atom / molecule / organism |
 | Props | Name, TypeScript type, default, required/optional |
 | CVA variants | Variant keys and possible values |
 | States | Visual and behavioral description per state |
 | Accessibility | Roles, attributes, keyboard, focus, reduced motion when applicable |
-| Reference URL | Radix UI primitives, MDN, APG, etc. |
+| Intake source / Reference | capture-first or reference-component-first; URL or pattern source when available |
 | Design notes | System-specific visual decisions |
 | Story requirements | Default, Disabled, key variants, edge cases |
 
@@ -175,7 +204,7 @@ Implement this component using component-contributor.
 
 Issue: {issue_url}
 
-Use the `## Validated component spec` section as the contract. Before reading the spec in detail, planning, or writing code, verify that the issue has the `status:approved` label and is not assigned to someone else; if the label is missing or the assignee gate fails, stop. Run START WORK before implementation intake. Do not invent props or behavior outside the spec. Pause at spec review, visual preflight, and plan checkpoints before writing code.
+Use the `## Validated component spec` section and the immediately following `## Cataloging decision` in the same comment/update as the contract. Before reading the spec in detail, planning, or writing code, verify that the issue has the `status:approved` label and is not assigned to someone else; if the label is missing or the assignee gate fails, stop. Run START WORK before implementation intake. Do not invent props or behavior outside the spec or cataloging decision. Pause at spec review, visual preflight, and plan checkpoints before writing code.
 ```
 
 The agent must load `component-contributor`, check the `status:approved` label, verify assignees, run START WORK, and only then consume the validated spec from `component-spec-proposer`. If it skips a phase, stop it.
@@ -186,13 +215,16 @@ The agent must load `component-contributor`, check the `status:approved` label, 
 
 ### Phase 1 — Read the validated spec
 
-Before this phase, the agent must already have verified the `status:approved` label, confirmed the issue is not assigned to someone else without explicit permission, and completed START WORK. It then reads the `## Validated component spec` section in the issue and extracts the component, tier, props, variants, states, accessibility, reference, and design notes.
+Before this phase, the agent must already have verified the `status:approved` label, confirmed the issue is not assigned to someone else without explicit permission, and completed START WORK. It then reads `## Validated component spec` and the immediately following `## Cataloging decision` in the same comment/update, and extracts the component, tier, props, variants, states, accessibility, reference, design notes, reuse/extraction, and child candidates.
+
+If the tier is `primitive`, the agent may proceed only when `## Cataloging decision` explicitly approves primitive support/path; otherwise it must stop and defer to the V1 inventory/recatalogation issue. Do not silently implement primitives as atoms.
 
 Expected output:
 
 - spec summary;
+- cataloging decision summary, reuse/extraction, and child candidates;
 - evidence of the `status:approved` label, assignee gate, and START WORK;
-- questions if anything is ambiguous;
+- questions if anything is ambiguous or if the spec conflicts with cataloging;
 - reference/token modules it plans to load.
 
 **Human checkpoint:** do not continue if the agent invents props, states, or behavior that are not in the validated spec. If a new decision appears, go back to spec proposal or update the issue before implementation.

--- a/docs/CONTRIBUTOR-FLOW.md
+++ b/docs/CONTRIBUTOR-FLOW.md
@@ -7,7 +7,7 @@ Este es el documento canónico para contribuir componentes al design system. `CO
 ## Resumen rápido
 
 ```text
-Project task → Research → Spec proposal skill → Validated issue spec → esperar `status:approved` → verificar assignee → START WORK → Spec review → Visual preflight → Plan → Implementación → Visual review → Pre-PR component review → PR → Review → Merge → END WORK
+Project task → Research → Spec proposal skill → Cataloging validator → Validated issue spec → esperar `status:approved` → verificar assignee → START WORK → Spec review → Visual preflight → Plan → Implementación → Visual review → Pre-PR component review → PR → Review → Merge → END WORK
 ```
 
 La regla central: **la IA ejecuta, el contributor decide**. La spec, los criterios visuales y la aprobación de checkpoints son responsabilidad humana. Después de escribir la spec validada en la tarea, la implementación queda bloqueada hasta que la issue asociada tenga el label `status:approved` y no esté asignada a otra persona.
@@ -22,7 +22,9 @@ La regla central: **la IA ejecuta, el contributor decide**. La spec, los criteri
 | Arquitectura y reglas de código | [`GUIDELINES.md`](./GUIDELINES.md)                 |
 | Tokens y lenguaje visual        | [`DESIGN.md`](./DESIGN.md), `src/styles/theme.css` |
 | Estados visuales por componente | [`COMPONENTS.md`](./COMPONENTS.md)                 |
-| Toma y validación de specs      | `skills/component-spec-proposer/SKILL.md`     |
+| Catalogación y recatalogación V1 | [`COMPONENT-CATALOGING.md`](./COMPONENT-CATALOGING.md) |
+| Toma y propuesta de specs       | `skills/component-spec-proposer/SKILL.md`     |
+| Validación de catalogación de specs | `skills/component-spec-cataloging-validator/SKILL.md` |
 | Flujo detallado con IA          | `skills/component-contributor/SKILL.md`       |
 | Auditoría pre-PR                | `skills/components-auditor/SKILL.md`          |
 
@@ -47,7 +49,7 @@ Antes de pedir implementación, investigá el componente.
 Checklist mínimo:
 
 - Referencias: Radix UI primitives, MDN o WAI-ARIA APG según aplique.
-- Nivel atómico: `atom`, `molecule` u `organism`.
+- Tier de catálogo: consultá [`COMPONENT-CATALOGING.md`](./COMPONENT-CATALOGING.md) para decidir `primitives`, `atoms`, `molecules` u `organisms` y documentar follow-ups V1.
 - Props: nombre, tipo, default, required/optional.
 - Variantes CVA: keys y valores.
 - Estados: base, hover, focus, active/pressed, disabled, loading, error, empty si aplica.
@@ -60,34 +62,61 @@ No hagas research a medias. Si la issue está incompleta, el componente sale inc
 
 ## Paso 3 — Tomar y validar la spec con `component-spec-proposer`
 
-Antes de implementar, usá la skill `component-spec-proposer` para convertir la tarea y su referencia en una spec validada.
+Antes de implementar, usá la skill `component-spec-proposer` para convertir la issue en una spec validada. Hay dos variantes válidas de intake: capture-first y reference-component-first; ambas terminan en el mismo gate de aprobación.
 
-Cuándo usarla:
+| Variante | Cuándo aplica | Qué registra la issue |
+| -------- | ------------- | --------------------- |
+| A — capture-first | Maintainer/usuario captura una idea de componente desde una conversación o necesidad de producto, aunque todavía no exista una referencia externa. | Contexto conocido, constraints, unknowns, tier esperado y cualquier referencia o patrón faltante. |
+| B — reference-component-first | El usuario trae una URL de HeroUI, Radix, MDN, WAI-ARIA APG u otro componente de referencia. | Comportamiento de referencia y cómo se adapta a Stack-and-Flow; no se copia a ciegas. |
 
-- La issue tiene una referencia Radix UI primitive, MDN, APG o similar.
-- La tarea todavía es vaga o tiene decisiones abiertas.
-- Necesitás preparar la issue antes de pasar a implementación.
+Convergencia obligatoria:
 
-Prompt sugerido:
+```text
+issue capturada o referencia → spec propuesta → assumptions/preguntas → validación de catalogación → validación humana → `## Validated component spec` en la issue → esperar label `status:approved` → START WORK → component-contributor
+```
+
+Antes de pedir aprobación humana o escribir `## Validated component spec`, corré `component-spec-cataloging-validator`. Ese gate contrasta la propuesta contra [`COMPONENT-CATALOGING.md`](./COMPONENT-CATALOGING.md), inspecciona el catálogo actual y devuelve `## Draft cataloging decision` con reuse, extracción, split, child issue candidates y target issue, o `## Cataloging blockers/questions` si no puede completar la validación. Si hay blockers/questions, no se pide aprobación todavía. Si hacen falta child issues, `component-child-issues` se usa después, solo con la decisión final validada.
+
+Cuando se escribe en la issue, `## Cataloging decision` debe quedar inmediatamente después de `## Validated component spec` en el mismo comentario o actualización, para que el contrato de implementación y la decisión de catálogo se revisen juntos. Ese heading exacto se reserva para la versión final aprobada y no debe contener blockers/questions sin resolver.
+
+`status:approved` es un **label de la issue**. El Project Status `In progress` pertenece a **START WORK**, no a la fase de propuesta de spec.
+
+Prompt capture-first:
 
 ```text
 Prepará la spec para este componente usando component-spec-proposer.
 
 Issue: {issue_url}
+Intake: capture-first desde esta conversación/necesidad de producto.
+Contexto conocido: {context}
+Referencia: pendiente o desconocida
+
+No implementes todavía. Proponé la spec, listá assumptions/preguntas, marcá referencias o patrones faltantes, corré `component-spec-cataloging-validator` y esperá mi aprobación de la spec y `## Draft cataloging decision` antes de escribir en GitHub. Si hay `## Cataloging blockers/questions`, no pidas aprobación todavía.
+```
+
+Prompt reference-component-first:
+
+```text
+Prepará la spec para este componente usando component-spec-proposer.
+
+Issue: {issue_url}
+Intake: reference-component-first
 Referencia: {reference_url}
 
-No implementes todavía. Primero proponé la spec, listá assumptions a validar y esperá mi aprobación antes de escribir en GitHub.
+No implementes todavía. Adaptá la referencia a Stack-and-Flow, proponé la spec, listá assumptions a validar, corré `component-spec-cataloging-validator` y esperá mi aprobación de la spec y `## Draft cataloging decision` antes de escribir en GitHub. Si hay `## Cataloging blockers/questions`, no pidas aprobación todavía.
 ```
 
 La skill debe:
 
-1. Leer la issue y la referencia.
+1. Leer la issue y, si existe, la referencia.
 2. Proponer una spec usando la plantilla de `component-spec-proposer`.
-3. Listar assumptions a validar.
-4. Esperar aprobación humana.
-5. Recién después de la aprobación, escribir `## Validated component spec` en la issue.
-6. Dejar la tarea esperando aprobación: no moverla a `In progress` desde `component-spec-proposer`.
-7. Indicar el siguiente paso: esperar el marcador `status:approved` y verificar que la issue esté sin assignee o asignada al contributor/usuario antes de arrancar `component-contributor`.
+3. Listar assumptions a validar, incluyendo referencias o patrones faltantes en capture-first.
+4. Pasar la propuesta por `component-spec-cataloging-validator` antes de aprobación humana.
+5. Incluir `## Draft cataloging decision` cuando la validación pase, con `### Child issue candidates` determinístico cuando aplique; si hay blockers/questions, mostrar `## Cataloging blockers/questions` y frenar.
+6. Esperar aprobación humana de la spec propuesta y de `## Draft cataloging decision`.
+7. Recién después de esa aprobación, escribir `## Validated component spec` y el `## Cataloging decision` validado inmediatamente después en el mismo comentario o actualización de la issue.
+8. Dejar la tarea esperando aprobación: no moverla a `In progress` desde `component-spec-proposer`.
+9. Indicar el siguiente paso: esperar el label de issue `status:approved` y verificar que la issue esté sin assignee o asignada al contributor/usuario antes de arrancar `component-contributor`.
 
 No uses `component-contributor` para implementar hasta que la spec esté validada, la issue tenga el label `status:approved` y el assignee gate haya pasado.
 
@@ -100,12 +129,12 @@ La spec validada debe quedar en la issue como contrato verificable.
 | Campo              | Qué debe decir                                             |
 | ------------------ | ---------------------------------------------------------- |
 | Component name     | PascalCase                                                 |
-| Atomic tier        | atom / molecule / organism                                 |
+| Catalog tier       | primitive / atom / molecule / organism                     |
 | Props              | Nombre, tipo TypeScript, default, required/optional        |
 | CVA variants       | Variant keys y valores posibles                            |
 | States             | Descripción visual y de comportamiento por estado          |
 | Accessibility      | Roles, atributos, teclado, focus, reduced motion si aplica |
-| Reference URL      | Radix UI primitives, MDN, APG, etc.                       |
+| Intake source / Reference | capture-first o reference-component-first; URL o patrón fuente si existe |
 | Design notes       | Decisiones visuales específicas del sistema                |
 | Story requirements | Default, Disabled, variantes clave, edge cases             |
 
@@ -175,7 +204,7 @@ Implementá este componente usando component-contributor.
 
 Issue: {issue_url}
 
-Usá la sección `## Validated component spec` como contrato. Antes de leer la spec en detalle, planificar o escribir código, verificá que la issue tenga el label `status:approved` y que no esté asignada a otra persona; si falta el label o el assignee gate falla, frená. Ejecutá START WORK antes del intake de implementación. No inventes props ni comportamiento fuera de la spec. Pausá en los checkpoints de spec review, visual preflight y plan antes de escribir código.
+Usá la sección `## Validated component spec` y el `## Cataloging decision` inmediatamente siguiente en el mismo comentario/actualización como contrato. Antes de leer la spec en detalle, planificar o escribir código, verificá que la issue tenga el label `status:approved` y que no esté asignada a otra persona; si falta el label o el assignee gate falla, frená. Ejecutá START WORK antes del intake de implementación. No inventes props ni comportamiento fuera de la spec o de la decisión de catálogo. Pausá en los checkpoints de spec review, visual preflight y plan antes de escribir código.
 ```
 
 El agente debe cargar `component-contributor`, comprobar el label `status:approved`, verificar assignees, correr START WORK y recién después consumir la spec validada por `component-spec-proposer`. Si salta una fase, frenalo.
@@ -186,13 +215,16 @@ El agente debe cargar `component-contributor`, comprobar el label `status:approv
 
 ### Fase 1 — Lectura de spec validada
 
-Antes de esta fase, el agente ya debe haber verificado el label `status:approved`, confirmado que la issue no está asignada a otra persona sin permiso explícito y completado START WORK. Luego lee la sección `## Validated component spec` de la issue y extrae componente, tier, props, variantes, estados, accesibilidad, referencia y notas de diseño.
+Antes de esta fase, el agente ya debe haber verificado el label `status:approved`, confirmado que la issue no está asignada a otra persona sin permiso explícito y completado START WORK. Luego lee `## Validated component spec` y el `## Cataloging decision` inmediatamente siguiente en el mismo comentario/actualización, y extrae componente, tier, props, variantes, estados, accesibilidad, referencia, notas de diseño, reuse/extracción y child candidates.
+
+Si el tier es `primitive`, solo puede avanzar cuando `## Cataloging decision` aprueba explícitamente soporte/ruta primitive; si no, debe frenar y deferir a la issue de inventario/recatalogación V1. No se implementa silenciosamente como `atom`.
 
 Salida esperada:
 
 - resumen de la spec;
+- resumen de la decisión de catálogo, reuse/extracción y child candidates;
 - evidencia del label `status:approved`, assignee gate y START WORK;
-- preguntas si algo es ambiguo;
+- preguntas si algo es ambiguo o si hay conflicto spec/catálogo;
 - módulos de referencia/tokens que va a cargar.
 
 **Checkpoint humano:** no avances si el agente inventa props, estados o comportamiento que no estén en la spec validada. Si aparece una decisión nueva, volvé a spec proposal o actualizá la issue antes de implementar.

--- a/skills/component-child-issues/SKILL.md
+++ b/skills/component-child-issues/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: component-child-issues
+description: "Trigger: component child issues, cataloging child issues, extracted primitives, atoms, molecules, organisms. Create or reuse child issues after validated component cataloging decisions."
+license: Apache-2.0
+metadata:
+  author: stack-and-flow
+  version: "1.0"
+---
+
+## Activation Contract
+
+Use this skill only after a parent component issue has `status:approved` and a same-comment/update handoff where `## Validated component spec` is followed immediately by an exact validated `## Cataloging decision` section that may extract reusable primitives, atoms, molecules, or organisms.
+
+Do not use it for generic GitHub Project operations, unapproved component ideas, draft cataloging output, or implementation planning without that validated adjacent parent handoff.
+
+## Hard Rules
+
+- Read and verify the parent issue labels, body, and comments before deciding children.
+- Require issue label `status:approved`; stop if it is missing or cannot be verified.
+- Require `## Validated component spec` immediately followed by exact heading `## Cataloging decision` in the same issue comment/update; stop if the decision is standalone, draft-only, missing, unvalidated, or ambiguous.
+- Immediately before creating, reusing, linking, adding to Project, or updating the parent checklist, re-check the parent still has `status:approved` and the same adjacent validated handoff. Stop if either gate changed.
+- Reject any `## Cataloging decision` that contains unresolved blockers/questions or candidate rows whose blockers/questions are not `none`.
+- Extract child candidates only from the `### Child issue candidates` block under the validated adjacent `## Cataloging decision`.
+- Require each candidate to include name, proposed tier, source/parent component, action, reuse target or extraction reason, scope summary, target issue, and blockers/questions.
+- Create or reuse child issues only for independently reviewable reusable
+  pieces with proposed tier `primitive`, `atom`, `molecule`, or `organism`.
+  Extracted lower-tier pieces are usually `primitive`, `atom`, or `molecule`.
+- Avoid duplicate child issues; search existing repo issues and parent issue
+  links first.
+- Link every child issue back to the parent and update the parent with a child
+  checklist.
+- Use `github-project-tasks` for issue creation, Project fields, milestones,
+  and mutation safety.
+- Default technical artifacts, issue titles, and issue bodies to English.
+
+## Decision Gates
+
+| Situation | Action |
+| --- | --- |
+| Parent lacks `status:approved` | Stop and request maintainer/project lead approval. |
+| Parent lacks the adjacent validated `## Validated component spec` + `## Cataloging decision` handoff | Stop and request validation. |
+| Validated decision or candidate row contains blockers/questions | Stop and request a resolved cataloging decision. |
+| Candidate row is missing required fields or uses vague placeholders | Stop and request a deterministic cataloging decision. |
+| Candidate action is `skip` or `defer` | Do not create a child; record the reason on the parent checklist. |
+| Candidate is not reusable/reviewable | Skip; keep it in parent scope. |
+| Matching child issue exists | Reuse it and link it to the parent. |
+| Candidate action is `create new` and no matching issue exists | Create it with the child template. |
+| Required Project field is missing | Ask before mutating GitHub. |
+| Parent approval or adjacent handoff changes during mutation preflight | Stop before further mutation and report the stale gate. |
+| A GitHub mutation partially succeeds and a later step fails | Mark the run partial, report every created/reused/linked issue and missing follow-up, and never claim silent success. |
+
+## Execution Steps
+
+1. Load `skills/github-project-tasks/SKILL.md` and follow it for all GitHub
+   and Project mutations.
+2. Read the parent issue title, body, labels, milestone, assignees, Project
+   fields, linked issues, and comments containing `## Validated component spec`.
+3. Select only a same-comment/update handoff where `## Validated component spec` is followed immediately by `## Cataloging decision`, the parent issue has `status:approved`, and no blockers/questions remain.
+4. Extract child candidates only from that validated `## Cataloging decision` section and its `### Child issue candidates` block.
+5. Reject vague candidates before mutating GitHub; every consumed candidate must include the required per-candidate fields.
+6. Search existing open and closed issues for equivalent child work.
+7. For each candidate, decide `create`, `reuse`, `skip`, or `defer` using the candidate action and the gates above.
+8. Run mutation preflight: re-read parent labels and the same issue comment/update, then verify `status:approved` and adjacent `## Validated component spec` + `## Cataloging decision` still match the consumed handoff.
+9. For new children, fill the child issue template and create the issue through
+   `github-project-tasks` CREATE mode.
+10. Add each child issue to the GitHub Project using the Team, Category, and
+   Milestone policy required by `github-project-tasks`.
+11. Update the parent issue with a checklist of created or reused children and
+   note skipped or deferred candidates.
+12. If any create, Project add, link, or parent update fails after an earlier mutation succeeded, stop further mutation unless `github-project-tasks` gives a safe retry. Return `partial`, list completed GitHub changes, list missing rollback/follow-up actions, and do not claim the parent is fully synchronized.
+
+## Output Contract
+
+Return:
+
+- Parent issue inspected, `status:approved` evidence, and adjacent `## Validated component spec` + `## Cataloging decision` status.
+- Child issues created: title, URL, Project fields.
+- Child issues reused: title, URL, reason.
+- Candidates skipped: name and reason.
+- Parent checklist update status.
+- Partial mutation recovery notes: completed mutations, failed step, safe retry or manual follow-up required.
+- Blockers, unresolved fields, or required human decisions.
+- Whether registry refresh is needed after skill changes.
+
+## References
+
+- `skills/component-child-issues/assets/child-issue-template.md`
+- `skills/github-project-tasks/SKILL.md`
+- `skills/github-project-tasks/references/issue-body-template.md`

--- a/skills/component-child-issues/assets/child-issue-template.md
+++ b/skills/component-child-issues/assets/child-issue-template.md
@@ -1,0 +1,55 @@
+# Component Child Issue Template
+
+Use this body content when `component-child-issues` decides a new independently
+reviewable reusable piece is needed. Then wrap it in the canonical GitHub issue
+structure required by
+`skills/github-project-tasks/references/issue-body-template.md`.
+
+```markdown
+## Child component extraction
+
+Parent issue: #{parent_issue_number} — {parent_issue_title}
+Parent URL: {parent_issue_url}
+Parent approval gate: `status:approved` verified
+Cataloging decision: {short_decision_summary_from_validated_adjacent_heading}
+Source validated handoff: same parent issue comment/update with `## Validated component spec` immediately followed by `## Cataloging decision`
+Source `## Cataloging decision` target issue: {parent_or_v1_issue_number}
+
+### Reusable piece
+
+- Name: {child_name}
+- Proposed tier: primitive / atom / molecule / organism
+- Scope rule: independently reviewable; extracted lower-tier pieces are usually primitive / atom / molecule, but organism is allowed when validated.
+- Source/parent component: {parent_component_name}
+- Candidate action: create new
+- Reuse target or extraction reason: {why_this_piece_is_shared_or_must_be_extracted}
+- Blockers/questions from cataloging decision: none
+
+### Scope
+
+This child issue is responsible for:
+
+- {scope_summary_from_cataloging_decision}
+- {independently_reviewable_scope_item}
+
+Out of scope:
+
+- Parent component integration beyond the public API needed by this child.
+- Other extracted pieces tracked in sibling child issues.
+
+### Acceptance criteria
+
+- [ ] The reusable piece has a clear public API or internal contract.
+- [ ] The implementation follows Stack-and-Flow component structure and token
+      rules.
+- [ ] Parent integration requirements are documented or linked.
+- [ ] Accessibility impact is documented when behavior or semantics are
+      affected.
+- [ ] Validation plan is recorded before implementation starts.
+
+### Parent tracking
+
+After creating or reusing this issue, add it to the parent checklist:
+
+- [ ] #{child_issue_number} — {child_issue_title}
+```

--- a/skills/component-contributor/SKILL.md
+++ b/skills/component-contributor/SKILL.md
@@ -44,6 +44,8 @@ Follow these phases in order. Do not skip gates because a component looks simple
 
 **Non-negotiable assignee gate:** before reading the implementation spec in detail, planning, creating a branch/worktree, mutating GitHub, or writing code from a linked issue, verify current assignees. If the issue is assigned to someone other than the contributor/user, stop and tell the user they must get explicit permission before reassigning it.
 
+**Non-negotiable validated handoff gate:** implementation intake must read `## Validated component spec` plus the immediately following `## Cataloging decision` from the same issue comment/update. Stop if either section is missing, standalone, ambiguous, contains blockers/questions, or conflicts with the other.
+
 ### 0 — Contributor onboarding
 
 Only when working directly with a contributor: confirm they understand React + strict TypeScript, Tailwind v4 tokens, CVA, the 6-file pattern, Storybook as docs, and tests in `.test.tsx`. If not, teach briefly before proceeding.
@@ -54,9 +56,11 @@ If implementation will proceed from a GitHub issue or Project board card, first 
 
 After the label and assignee gates pass, load `skills/github-project-tasks/SKILL.md` and run **START WORK** before spec intake, planning, or coding: verify assignees, assign the issue to the contributor/user, move Project status to `In progress`, and record the planned branch/worktree. Offline/no-network mode may only skip GitHub mutations after evidence confirms the issue already has `status:approved` and is unassigned or assigned to the contributor/user; it never bypasses the approval or assignee gates.
 
-Then extract component name, tier, props, variants, states, accessibility behavior, reference URL, and design notes. If the spec lives in a GitHub issue, read issue comments too; validated specs may live there.
+Then extract component name, tier, props, variants, states, accessibility behavior, reference URL, design notes, and the cataloging decision summary, reuse/extraction instructions, child issue candidates, and target issue. If the spec lives in a GitHub issue, read issue comments too; validated specs may live there.
 
-Stop and ask when the issue label `status:approved` is missing or cannot be verified, the issue is assigned to someone else without explicit reassignment permission, START WORK cannot be completed, or required behavior, accessibility, states, or variants are missing. Do not invent public API and do not begin implementation.
+Primitive tier specs may proceed only when the validated `## Cataloging decision` explicitly approves primitive support and path. If the repo has no primitive implementation support or the decision does not explicitly approve it, stop and defer to the V1 inventory/recatalogation issue instead of silently implementing the component as an atom.
+
+Stop and ask when the issue label `status:approved` is missing or cannot be verified, the issue is assigned to someone else without explicit reassignment permission, START WORK cannot be completed, the adjacent validated spec/cataloging handoff is missing or unresolved, the spec conflicts with the cataloging decision, primitive support is not explicitly approved for a primitive spec, or required behavior, accessibility, states, or variants are missing. Do not invent public API and do not begin implementation.
 
 ### 1.5 — Spec critique
 
@@ -67,6 +71,11 @@ Before planning, return:
 
 ### Gaps found
 - {missing requirement and impact}
+
+### Cataloging decision summary
+- Decision: {reuse existing / keep in parent / split/extract / needs child issue / defer to V1 inventory}
+- Reuse/extraction: {summary}
+- Child candidates: {none or list}
 
 ### Risks found
 - {implementation/product risk and mitigation}
@@ -100,8 +109,8 @@ Present a concise plan and wait for confirmation unless SDD delegation already a
 ## Implementation Plan
 
 **Component**: {ComponentName}
-**Tier**: atoms / molecules / organisms
-**Directory**: `src/components/{tier}/{kebab-name}/`
+**Tier**: primitives / atoms / molecules / organisms
+**Directory**: `src/components/{tier}/{kebab-name}/` (primitive only when explicitly approved by the validated cataloging decision and supported by the repo)
 
 ### Files
 1. `types.ts` — props, CVA variants, defaults
@@ -114,6 +123,7 @@ Present a concise plan and wait for confirmation unless SDD delegation already a
 ### Decisions
 - Tokens: {list}
 - Radix primitive: {yes/no; which one}
+- Cataloging decision: {reuse/extraction/child candidates summary}
 - States and accessibility: {summary}
 - Validation: {tests/build/storybook/manual visual checks}
 ```

--- a/skills/component-spec-cataloging-validator/SKILL.md
+++ b/skills/component-spec-cataloging-validator/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: component-spec-cataloging-validator
+description: "Trigger: component spec cataloging validation, validate component proposal tier, reuse or extraction audit. Validate a proposed component spec against the catalog tier system before approval."
+license: Apache-2.0
+metadata:
+  author: stack-and-flow
+  version: "1.0"
+---
+
+## Activation Contract
+
+Use this skill after `component-spec-proposer` drafts a proposal and before the proposal is accepted as `## Validated component spec` or the issue receives `status:approved`.
+
+Do not implement, approve, label, or create GitHub issues. Your job is to audit whether the proposed component should reuse existing pieces, stay in the parent issue, split/extract reusable pieces, produce child issue candidates, or defer to V1 inventory.
+
+## Hard Rules
+
+- Read the proposed spec and the source issue/comment/context that produced it.
+- Read `docs/COMPONENT-CATALOGING.md` or `docs/COMPONENT-CATALOGING.en.md`; it is the tier authority.
+- Inspect `src/components/{primitives,atoms,molecules,organisms}/` enough to detect existing reusable pieces, overlap, and naming/API conflicts; if a tier directory is missing, record that as evidence instead of assuming support exists.
+- Stop if anatomy, API, states, accessibility, or intended composition are too vague to reason about tiers or reuse.
+- Do not create GitHub issues. If child issues are needed, include complete candidate rows for later `component-child-issues` execution, but keep pre-approval output under a draft heading.
+- Before human approval, use `## Draft cataloging decision` when validation passes or `## Cataloging blockers/questions` when it cannot complete. Do not emit the final `## Cataloging decision` heading before approval.
+- The exact `## Cataloging decision` heading is reserved for the approved issue comment/update immediately after `## Validated component spec`.
+- When child issue candidates are `yes`, include the per-candidate handoff fields required by `component-child-issues` and leave every candidate's blockers/questions as `none` before final approval.
+- Do not add `status:approved` or claim implementation readiness.
+
+## Decision Gates
+
+| Finding | Action |
+| --- | --- |
+| Existing component already satisfies the need | Decide `reuse existing`; name the component and required adaptation. |
+| Proposal is one cohesive parent-scope component | Decide `keep in parent`; document why no child is needed. |
+| Proposal hides reusable pieces | Decide `split/extract`; list the pieces that must be conceptually divided, extracted, or reused. Extracted lower-tier pieces are usually primitives, atoms, or molecules; organism candidates are allowed when independently reviewable. |
+| Extracted piece is independently reviewable and should be tracked separately | Use `needs child issue` as the decision, mark `child issue candidates: yes`, add a complete row in `### Child issue candidates`, and target #224 for primitives/atoms or #225 for molecules/organisms. |
+| Evidence is incomplete or catalog status is uncertain | Decide `defer to V1 inventory`; target #223 and list missing evidence. |
+| Public exports/docs/story migration is the main work | Target #226; reserve #227 for final verification follow-up. |
+
+## Execution Steps
+
+1. Read the proposed spec, source issue/comment, and assumptions from `component-spec-proposer`.
+2. Load the cataloging guide and classify the proposed anatomy against tier contracts and atom disqualifiers.
+3. Inspect current component folders and public APIs for reuse, overlap, or extraction opportunities.
+4. Compare proposed tier, proposed path, and actual reusable pieces; call out mismatches.
+5. Choose one decision: `reuse existing`, `keep in parent`, `split/extract`, `needs child issue`, or `defer to V1 inventory`.
+6. Treat `split/extract` as conceptual scope division; treat `needs child issue` as a separately trackable extracted/reused unit that is independently reviewable.
+7. Produce the output block below and hand it to the user for approval before any validated spec or status label is added.
+8. If a candidate cannot be classified with a name, tier, source, action, reason, scope, target issue, and blockers/questions status, leave it under `## Cataloging blockers/questions` instead of a vague child candidate.
+
+## Output Contract
+
+When validation passes with no unresolved blockers/questions, return a paste-ready draft block with this exact heading:
+
+```markdown
+## Draft cataloging decision
+
+- Component:
+- Proposed tier: primitive | atom | molecule | organism
+- Current/proposed path:
+- Decision: reuse existing | keep in parent | split/extract | needs child issue | defer to V1 inventory
+- Existing pieces to reuse:
+- Pieces to extract/create:
+- Child issue candidates: yes | no
+- Target issue: parent | #223 | #224 | #225 | #226 | #227
+- Blockers/questions: none
+
+### Child issue candidates
+
+If `Child issue candidates` is `yes`, this section is the deterministic handoff consumed later by `component-child-issues` after approval. Include one row per candidate, and keep each candidate `Blockers/questions` value as `none`; if a candidate still has unresolved blockers or questions, return the blockers/questions output instead. Use the `{name or none}` placeholder only when candidates are `no`.
+
+| Candidate name | Proposed tier | Source/parent component | Action | Reuse target or extraction reason | Scope summary | Target issue | Blockers/questions |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| {name or none} | primitive/atom/molecule/organism | {source component} | reuse existing/create new/skip/defer | {existing component or why this must be extracted} | {independently reviewable scope} | parent/#223/#224/#225/#226/#227 | none |
+
+### Evidence
+
+- Tier contract check:
+- Existing catalog check:
+- Reuse/extraction rationale:
+```
+
+When validation cannot complete, return only:
+
+```markdown
+## Cataloging blockers/questions
+
+- Component:
+- Blockers/questions:
+- Evidence needed:
+- Next validation step:
+```
+
+After human approval, `component-spec-proposer` may convert the draft heading to the final `## Cataloging decision` heading only in the same issue comment/update immediately after `## Validated component spec`.
+
+## References
+
+- `docs/COMPONENT-CATALOGING.md`
+- `docs/COMPONENT-CATALOGING.en.md`
+- `skills/component-spec-proposer/SKILL.md`
+- `skills/component-child-issues/SKILL.md` — later execution only, after a validated `Cataloging decision`.

--- a/skills/component-spec-proposer/SKILL.md
+++ b/skills/component-spec-proposer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: component-spec-proposer
-description: "Trigger: HeroUI reference, component spec proposal, prepare component issue. Propose specs, iterate approval, then ready the GitHub Project task."
+description: "Trigger: capture-first component spec, reference-component-first spec, HeroUI/Radix/reference component, prepare component issue. Propose specs, run cataloging validation, and prepare the issue spec before implementation."
 license: Apache-2.0
 metadata:
   author: stack-and-flow
@@ -9,84 +9,61 @@ metadata:
 
 ## Activation Contract
 
-Use this skill when a user provides a component task or GitHub issue plus a reference implementation, usually HeroUI, and asks to prepare requirements before `component-contributor` implementation.
+Use this skill when a user provides a component task or GitHub issue and asks to prepare requirements before `component-contributor` implementation. It supports both capture-first intake from conversation/product need and reference-component-first intake from HeroUI, Radix, MDN, WAI-ARIA APG, or another reference URL.
 
-Do not implement the component. Your job is to turn a vague task into a validated, issue-backed implementation spec.
+Do not implement, approve implementation, label the issue, or move Project Status. Turn a vague task into a validated, issue-backed component spec.
 
 ## Hard Rules
 
-- Treat the reference as inspiration, not source of truth. Adapt to Stack-and-Flow tokens, 6-file pattern, accessibility rules, and Storybook conventions.
-- Never mark the task ready until the user explicitly validates the proposed spec.
-- Do not invent irreversible product decisions. Flag assumptions and ask for confirmation.
-- For interactive or composite components, the proposal must include a concrete accessibility contract: pattern reference, roles, accessible names, keyboard matrix, focus lifecycle, state announcements, and expected tests.
-- Do not accept vague accessibility placeholders such as "supports keyboard" or "uses ARIA". If behavior is unknown, ask before approval.
-- Prefer native semantics first; when using Radix or WAI-ARIA APG patterns, name the chosen pattern and document any intentional deviation.
-- Keep issue/project writes single-threaded: update the issue first, then the GitHub Project item.
-- Use ASCII-safe headings in GitHub comments and issue edits. No emojis in issue body or generated comments.
+- Treat any reference as inspiration, not source of truth. Adapt to Stack-and-Flow tokens, 6-file pattern, accessibility rules, and Storybook conventions.
+- Never claim implementation readiness from this skill; validation only covers the proposed spec and draft cataloging result.
+- Run `component-spec-cataloging-validator` after drafting and before final human approval or `## Validated component spec` writes.
+- Reserve the exact `## Cataloging decision` heading for the final approved issue comment/update, immediately after `## Validated component spec`.
+- Do not accept vague accessibility placeholders such as "supports keyboard" or "uses ARIA". For interactive/composite components, define pattern, roles, names, keyboard, focus lifecycle, announcements, and expected tests.
+- Prefer native semantics first; when using Radix or WAI-ARIA APG patterns, name the pattern and intentional deviations.
+- Use ASCII-safe headings in GitHub comments and issue edits. No emojis.
 - If `gh` lacks `read:project` or `project` scope, stop and ask the user to run `gh auth refresh -s read:project,project`.
 
 ## Decision Gates
 
-| Situation                                    | Action                                                                         |
-| -------------------------------------------- | ------------------------------------------------------------------------------ |
-| Reference URL missing                        | Ask for HeroUI/Radix/MDN/reference URL before proposing specs.                 |
-| Issue URL missing                            | Produce the proposal only; do not update GitHub.                               |
-| Component tier unclear                       | Ask whether it is atom, molecule, or organism.                                 |
-| Reference implies complex composite behavior | Flag possible molecule/organism mismatch before validation.                    |
-| Accessibility contract is vague or missing   | Stop and ask; do not produce a ready-to-approve spec.                          |
-| Composite keyboard/focus behavior unclear    | Ask for the intended pattern before validation.                                |
-| Expected a11y tests are missing              | Add them before asking for approval.                                           |
-| Linked issue assigned to someone else       | Stop before GitHub writes or implementation handoff; tell the user they need explicit permission before reassigning or taking over the issue. |
-| User approves proposal                       | Add the validated spec to the issue, then leave implementation blocked until a maintainer/project lead adds the issue label `status:approved`. |
-| User requests changes                        | Revise the proposal and ask for validation again.                              |
+| Situation | Action |
+| --- | --- |
+| Reference URL missing and intake is capture-first | Propose from issue/conversation context; flag missing reference or pattern as an assumption/question when behavior is ambiguous. |
+| Reference URL missing and context is insufficient | Ask for a reference URL or maintainer-provided behavior before proposing specs. |
+| Issue URL missing | Produce the proposal only; do not update GitHub. |
+| Component tier unclear | Ask whether it is primitive, atom, molecule, or organism. |
+| Reference implies complex composite behavior | Flag possible molecule/organism mismatch before validation. |
+| Accessibility contract is vague or expected tests are missing | Stop and ask; do not produce a ready-to-approve spec. |
+| Cataloging validator has not run | Run `component-spec-cataloging-validator`; do not ask for final approval or write `## Validated component spec`. |
+| Cataloging validator returns blockers/questions | Report them under `## Cataloging blockers/questions`; do not show `## Ready for validation`, ask for final approval, or write `## Validated component spec` until reuse/extraction is classified. |
+| Linked issue assigned to someone else | Stop before GitHub writes or handoff; require explicit permission before reassignment/takeover. |
+| User approves proposal and draft cataloging decision after validator passed with no blockers/questions | Add the validated spec and decision to the issue, then leave implementation blocked until `status:approved`. |
+| User requests changes | Revise, rerun cataloging validation, and ask for validation again. |
 
 ## Execution Steps
 
-1. Read the GitHub issue metadata first, if provided: title, assignees, labels, and URL. Confirm the contributor/user before comparing assignees. If the issue is assigned to someone other than the contributor/user, stop before further workflow action or GitHub writes and tell the user they need explicit permission before reassigning or taking over the issue.
-2. Read the GitHub issue body and comments, if provided. If the rendered issue page does not expose the comment thread, fetch the issue comments via the GitHub API (`/repos/{owner}/{repo}/issues/{number}/comments`) or `gh api` before continuing.
-3. Fetch and study the reference URL. Extract behavior, states, accessibility, anatomy, and examples.
-4. Identify the semantic pattern: native element, Radix primitive, or WAI-ARIA/APG pattern. For composites, define roles, relationships, keyboard behavior, focus lifecycle, and announced states before proposing API details.
-5. Compare against project rules from `component-contributor`, especially Phase 1 requirements.
-6. Present a proposed spec using `references/spec-template.md` with concrete accessibility acceptance criteria and expected tests.
-7. Include an `Assumptions to validate` section for choices not explicit in the issue/reference, especially screen reader, focus, or keyboard decisions.
-8. Ask the user to approve, reject, or edit the proposal. Do not write to GitHub before approval.
-9. After approval, append or update a GitHub issue comment headed `## Validated component spec` using the approved spec.
-10. Locate the Project item for the issue only to confirm it exists; do not move Project Status to `In progress` from this skill.
-11. Report the issue URL, project item ID, approval state, and next command/action: wait for the `status:approved` issue label, then run START WORK via `github-project-tasks`, then start `component-contributor`.
+1. Read issue metadata, assignees, labels, URL, body, and comments if provided.
+2. Determine intake source: capture-first or reference-component-first.
+3. Study the reference URL if present; otherwise use issue/conversation context and record missing pattern choices as assumptions.
+4. Identify the semantic pattern and compare against `component-contributor` Phase 1 requirements.
+5. Draft the spec from `references/spec-template.md`. Before approval, present it under `## Component Spec Proposal: {ComponentName}` and omit the final-only `## Validated component spec` heading.
+6. Include `Assumptions to validate` for unresolved product, accessibility, keyboard, focus, or reference decisions.
+7. Run `component-spec-cataloging-validator` and include its result with the proposal as `## Draft cataloging decision`, or as `## Cataloging blockers/questions` when validation cannot complete.
+8. If there are no blockers/questions, ask the user to approve, reject, or edit both the proposed spec and draft cataloging decision. If blockers/questions remain, do not show the approval prompt.
+9. After approval, write/update the issue with `## Validated component spec`, followed immediately by validated `## Cataloging decision` in the same comment/update.
+10. Confirm the Project item exists only; do not move it to `In progress`.
+11. Report the next gate: wait for `status:approved`, then START WORK via `github-project-tasks`, then `component-contributor`.
 
 ## Output Contract
 
-Before approval, return:
-
-```markdown
-## Component Spec Proposal: {ComponentName}
-
-{spec from references/spec-template.md}
-
-## Assumptions to validate
-
-- ...
-
-## Ready for validation
-
-Reply with approve, or list changes.
-```
-
-After approval and GitHub update, return:
-
-```markdown
-## Spec Ready
-
-**Issue**: #{number} {title}
-**Spec**: Added to issue as `Validated component spec`
-**Project setup**: {team/category present or missing setup}
-**Approval gate**: Waiting for issue label `status:approved`
-**Next**: After the issue has label `status:approved` and is unassigned or assigned to the contributor/user, run START WORK via `github-project-tasks`, then run `component-contributor` for implementation.
-```
+Use `references/proposal-output.md` for pre-approval and post-update response shapes.
 
 ## References
 
 - `references/spec-template.md` — required proposal and issue spec structure.
-- `references/github-project-update.md` — commands for issue comments and Project status updates.
+- `references/proposal-output.md` — pre-approval and post-update output shapes.
+- `references/github-project-update.md` — commands for issue comments and Project lookup/status guards.
+- `../component-spec-cataloging-validator/SKILL.md` — mandatory cataloging gate before final approval.
+- `../../docs/COMPONENT-CATALOGING.md` and `../../docs/COMPONENT-CATALOGING.en.md` — catalog tier authority.
 - `../component-contributor/SKILL.md` — implementation-readiness contract.
 - `../github-project-tasks/SKILL.md` — GitHub Project IDs and status option IDs.

--- a/skills/component-spec-proposer/references/proposal-output.md
+++ b/skills/component-spec-proposer/references/proposal-output.md
@@ -1,0 +1,53 @@
+# Component spec proposer output
+
+Use these output shapes for `component-spec-proposer`.
+
+## Before approval
+
+Present proposals under `## Component Spec Proposal: {ComponentName}`. Do not use the final-only `## Validated component spec` or `## Cataloging decision` headings before human approval.
+
+When cataloging validation passes with no blockers/questions, insert the validator output as-is. It already includes the `## Draft cataloging decision` heading.
+
+```markdown
+## Component Spec Proposal: {ComponentName}
+
+{spec body from references/spec-template.md, omitting the final-only `## Validated component spec` heading before approval}
+
+## Assumptions to validate
+
+- ...
+
+{validated output from component-spec-cataloging-validator inserted as-is}
+
+## Ready for validation
+
+Reply with approve to validate both the proposed spec and draft cataloging decision, or list changes.
+```
+
+When cataloging validation has blockers/questions, insert the validator output as-is. It already includes the `## Cataloging blockers/questions` heading.
+
+```markdown
+## Component Spec Proposal: {ComponentName}
+
+{spec body from references/spec-template.md, omitting the final-only `## Validated component spec` heading before approval}
+
+## Assumptions to validate
+
+- ...
+
+{blockers/questions output from component-spec-cataloging-validator inserted as-is}
+```
+
+Do not show `## Ready for validation` until cataloging blockers/questions are resolved.
+
+## After approval and GitHub update
+
+```markdown
+## Spec Ready
+
+**Issue**: #{number} {title}
+**Spec**: Added to issue as `Validated component spec` with validated `## Cataloging decision`
+**Project setup**: {team/category present or missing setup}
+**Approval gate**: Waiting for issue label `status:approved`
+**Next**: After the issue has label `status:approved` and is unassigned or assigned to the contributor/user, run START WORK via `github-project-tasks`, then run `component-contributor` for implementation.
+```

--- a/skills/component-spec-proposer/references/spec-template.md
+++ b/skills/component-spec-proposer/references/spec-template.md
@@ -3,15 +3,18 @@
 Use this exact structure for proposals and for the final GitHub issue comment.
 Keep headings ASCII-safe.
 
+The `## Validated component spec` heading below is the final GitHub comment heading only. Before human approval, present the same spec body under `## Component Spec Proposal: {ComponentName}` and omit the final-only validated heading.
+
 ```markdown
 ## Validated component spec
 
 ### Component
 
 - Name:
-- Atomic level:
-- Directory:
-- Reference URL:
+- Catalog tier: primitive / atom / molecule / organism
+- Directory: src/components/{primitives|atoms|molecules|organisms}/{kebab-name}/
+- Intake source: capture-first / reference-component-first
+- Reference URL or pattern source:
 
 ### Scope
 
@@ -132,6 +135,12 @@ Do not implement:
   - Disabled/invalid/loading/empty states, if applicable:
   - Axe/Storybook/manual notes:
 ```
+
+## Cataloging decision placement
+
+After the validated spec, append the validator output as a sibling section with the exact heading `## Cataloging decision`. Do not nest it inside the validated spec's `###` sections; it must immediately follow `## Validated component spec` in the same approved issue comment/update and must not contain unresolved blockers/questions.
+
+Before approval, use only draft headings such as `## Draft cataloging decision` or `## Cataloging blockers/questions`; never use the final `## Cataloging decision` heading in a proposal.
 
 ## Proposal guidance
 


### PR DESCRIPTION
## Summary

- Adds the V1 component recatalogation guide and links it from the component docs.
- Defines the proposal → cataloging validation → approval → implementation handoff.
- Adds reusable skills for cataloging validation and child issue creation.

Closes #222

## Review scope

- Primary files/areas:
  - `docs/COMPONENT-CATALOGING*.md`
  - `docs/CONTRIBUTOR-FLOW*.md`
  - `docs/CONTRIBUTING*.md`
  - `skills/component-spec-proposer/`
  - `skills/component-spec-cataloging-validator/`
  - `skills/component-child-issues/`
  - `skills/component-contributor/SKILL.md`
  - `AGENTS.md`
- Out of scope:
  - Creating a `develop` branch or changing branch governance.
  - Implementing any component primitives.
  - Changing design tokens, package exports, or runtime component code.
- Review workload: large; this is a docs/skills workflow change over 400 lines, reviewed with the 4R lenses before commit.

## Type of change

- [ ] New component
- [ ] Existing component update/refactor
- [ ] Bug fix
- [ ] Accessibility
- [ ] Design tokens
- [x] Storybook/docs
- [ ] Infrastructure/tooling
- [ ] NPM/dependencies

## Workflow gates

- [x] Linked issue is present with `Closes #NNN` or maintainer approved an exception.
- [x] Linked issue has label `status:approved` before implementation starts.
- [x] Linked issue assignee was checked before work started; if it was assigned to someone else, explicit reassignment permission is documented.
- [x] Work was started through the Project flow: assignee set, Project status `In progress`, branch/worktree recorded.
- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`.
- [x] Commits follow the same commitlint-enforced format.
- [x] Diff is focused; unrelated work is called out in Review scope.
- [x] MCP/runtime artifacts are absent: `.playwright-mcp`, `page-*.png`, `page-*.jpeg`, `*.md.playwright-output`.

## Component evidence (required for component changes)

- [ ] Validated component spec is linked or quoted in the issue.
- [ ] Accessibility contract from the spec was implemented or deviations are explained below.
- [ ] Follows the 6-file pattern: `types.ts`, `use*.ts`, `Component.tsx`, `Component.test.tsx`, `Component.stories.tsx`, `index.ts`.
- [ ] CVA variants live in `types.ts`; JSX component has no state, CVA calls, or business logic.
- [ ] Public props with runtime defaults have matching `@default` JSDoc in `types.ts` (`node scripts/verify-prop-default-docs.mjs`).
- [ ] Uses design tokens from `theme.css`; no hardcoded colors or arbitrary color utilities.
- [ ] Storybook covers default, variants, documented states, edge cases, and dark mode when visually different.
- [ ] Component audit result is PASS or accepted PASS WITH WARNINGS.
- [ ] Visual review result is included when visuals changed.

N/A: this PR does not implement or modify component source.

## Accessibility evidence

N/A: this PR changes documentation and agent skills only; it does not modify interactive component behavior or UI output.

## Validation evidence

- TypeScript: passed through pre-commit `typecheck`.
- Unit tests: N/A, docs/skills-only workflow change.
- Build/package: N/A, no package output, exports, declarations, or runtime source changed.
- Storybook or visual check: N/A, no visual component changes.
- Accessibility check: N/A, no runtime UI changes.
- Security/dependency check: no dependencies added; 4R review found no risk findings.
- Additional checks:
  - `git diff --check`: passed.
  - Pre-commit: `harness-skills`, `prop-docs`, `typecheck`, and `commitlint` passed.
  - Gentle review: final 4R review approved in lineage `review-194f45107cf13f5f`.

## Screenshots or recordings

N/A: no visual changes.

## Notes for reviewer

- The final `## Cataloging decision` heading is intentionally reserved for approved handoffs immediately following `## Validated component spec`.
- Draft proposal output uses validator output as-is and must not be consumed by child issue automation.
- Child issue creation requires `status:approved`, adjacent validated handoff, and no unresolved blockers/questions.
- Primitive implementation remains gated unless support/path is explicitly approved by the cataloging decision.
