### PR TITLE
docs(storybook): improve design system navigation

### DIFF
--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -1,6 +1,12 @@
 import { addons } from '@storybook/manager-api';
 import theme from './theme';
 
+export const storybookCollapsedRoots = ['primitives', 'atoms', 'molecules', 'organisms'];
+
 addons.setConfig({
-  theme: theme
+  theme: theme,
+  sidebar: {
+    showRoots: true,
+    collapsedRoots: storybookCollapsedRoots
+  }
 });

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -23,7 +23,25 @@ const preview: Preview = {
     options: {
       theme: theme,
       storySort: {
-        order: ['Primitives', 'Atoms', 'Molecules', 'Organisms', 'Controls', 'Docs', 'Stories']
+        order: [
+          'Design System',
+          [
+            'Welcome',
+            'Component Methodology',
+            'Primitive Colors',
+            'Semantic Colors',
+            'Breakpoints',
+            'Typography',
+            'Animations'
+          ],
+          'Primitives',
+          'Atoms',
+          'Molecules',
+          'Organisms',
+          'Controls',
+          'Docs',
+          'Stories'
+        ]
       }
     },
     controls: {

--- a/src/storybook-navigation.test.ts
+++ b/src/storybook-navigation.test.ts
@@ -1,0 +1,174 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import * as ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+
+type ParsedArray = Array<string | string[]>;
+
+const readProjectFile = (path: string) => readFileSync(join(root, path), 'utf8');
+
+const parseSourceFile = (path: string) =>
+  ts.createSourceFile(join(root, path), readProjectFile(path), ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+
+const getPropertyName = (name: ts.PropertyName) => {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+    return name.text;
+  }
+
+  return undefined;
+};
+
+const getObjectProperty = (objectLiteral: ts.ObjectLiteralExpression, propertyName: string) => {
+  const property = objectLiteral.properties.find(
+    (item): item is ts.PropertyAssignment =>
+      ts.isPropertyAssignment(item) && getPropertyName(item.name) === propertyName
+  );
+
+  return property?.initializer;
+};
+
+const parseStringArray = (arrayLiteral: ts.ArrayLiteralExpression): string[] =>
+  arrayLiteral.elements.map((element) => {
+    if (!ts.isStringLiteral(element)) {
+      throw new Error('Expected array item to be a string literal.');
+    }
+
+    return element.text;
+  });
+
+const parseStorySortOrder = (arrayLiteral: ts.ArrayLiteralExpression): ParsedArray =>
+  arrayLiteral.elements.map((element) => {
+    if (ts.isStringLiteral(element)) {
+      return element.text;
+    }
+
+    if (ts.isArrayLiteralExpression(element)) {
+      return parseStringArray(element);
+    }
+
+    throw new Error('Expected storySort.order items to be string literals or nested string arrays.');
+  });
+
+const readPreviewStorySortOrder = () => {
+  const sourceFile = parseSourceFile('.storybook/preview.tsx');
+  let storySortOrder: ParsedArray | undefined;
+
+  const visit = (node: ts.Node) => {
+    if (ts.isPropertyAssignment(node) && getPropertyName(node.name) === 'storySort') {
+      const storySort = node.initializer;
+
+      if (!ts.isObjectLiteralExpression(storySort)) {
+        throw new Error('Expected Storybook storySort to be configured inline.');
+      }
+
+      const order = getObjectProperty(storySort, 'order');
+
+      if (!order || !ts.isArrayLiteralExpression(order)) {
+        throw new Error('Expected Storybook storySort.order to be an inline array.');
+      }
+
+      storySortOrder = parseStorySortOrder(order);
+      return;
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+
+  if (!storySortOrder) {
+    throw new Error('Expected preview config to define storySort.order.');
+  }
+
+  return storySortOrder;
+};
+
+const readManagerCollapsedRoots = () => {
+  const sourceFile = parseSourceFile('.storybook/manager.ts');
+  let collapsedRoots: string[] | undefined;
+
+  const visit = (node: ts.Node) => {
+    if (ts.isPropertyAssignment(node) && getPropertyName(node.name) === 'collapsedRoots') {
+      const initializer = node.initializer;
+
+      if (ts.isArrayLiteralExpression(initializer)) {
+        collapsedRoots = parseStringArray(initializer);
+        return;
+      }
+
+      if (ts.isIdentifier(initializer)) {
+        const variable = sourceFile.statements.find(
+          (statement): statement is ts.VariableStatement =>
+            ts.isVariableStatement(statement) &&
+            statement.declarationList.declarations.some(
+              (declaration) => ts.isIdentifier(declaration.name) && declaration.name.text === initializer.text
+            )
+        );
+        const declaration = variable?.declarationList.declarations.find(
+          (item) => ts.isIdentifier(item.name) && item.name.text === initializer.text
+        );
+
+        if (declaration?.initializer && ts.isArrayLiteralExpression(declaration.initializer)) {
+          collapsedRoots = parseStringArray(declaration.initializer);
+          return;
+        }
+      }
+
+      throw new Error('Expected collapsedRoots to resolve to a string array.');
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+
+  if (!collapsedRoots) {
+    throw new Error('Expected manager config to define collapsedRoots.');
+  }
+
+  return collapsedRoots;
+};
+
+describe('Storybook navigation', () => {
+  it('keeps the sidebar roots ordered from design documentation to component tiers', () => {
+    expect(readPreviewStorySortOrder()).toEqual([
+      'Design System',
+      [
+        'Welcome',
+        'Component Methodology',
+        'Primitive Colors',
+        'Semantic Colors',
+        'Breakpoints',
+        'Typography',
+        'Animations'
+      ],
+      'Primitives',
+      'Atoms',
+      'Molecules',
+      'Organisms',
+      'Controls',
+      'Docs',
+      'Stories'
+    ]);
+  });
+
+  it('keeps only the design system root expanded on initial load', () => {
+    const collapsedRoots = readManagerCollapsedRoots();
+
+    expect(collapsedRoots).toEqual(['primitives', 'atoms', 'molecules', 'organisms']);
+    expect(collapsedRoots).not.toContain('design-system');
+  });
+
+  it('links methodology readers to the English project docs', () => {
+    const methodologyStory = readProjectFile('stories/Design system/6-component-methodology.mdx');
+
+    expect(methodologyStory).toContain('docs/GUIDELINES.en.md');
+    expect(methodologyStory).toContain('docs/DESIGN.en.md');
+    expect(methodologyStory).toContain('docs/CONTRIBUTING.en.md');
+    expect(methodologyStory).not.toContain('docs/GUIDELINES.md');
+    expect(methodologyStory).not.toContain('docs/DESIGN.md');
+    expect(methodologyStory).not.toContain('docs/CONTRIBUTING.md');
+  });
+});

--- a/stories/Design system/6-component-methodology.mdx
+++ b/stories/Design system/6-component-methodology.mdx
@@ -1,0 +1,81 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Design System/Component Methodology" />
+
+export const H2 = ({ children }) => (
+  <h2 style={{ color: '#ff0036', fontSize: '1.125rem', fontWeight: 700, paddingBottom: '12px', marginTop: '2rem', marginBottom: '1rem', borderBottom: '1px solid #172230' }}>
+    {children}
+  </h2>
+);
+
+export const Card = ({ children }) => (
+  <div style={{ background: '#0B131E', border: '1px solid #172230', borderRadius: '8px', padding: '1.25rem 1.5rem' }}>
+    {children}
+  </div>
+);
+
+export const LinkCard = ({ href, title, description }) => (
+  <a href={href} target="_blank" rel="noopener noreferrer" style={{ display: 'block', background: '#0B131E', border: '1px solid #172230', borderRadius: '8px', padding: '1rem 1.25rem', color: '#cccccc', textDecoration: 'none' }}>
+    <strong style={{ display: 'block', color: '#ffffff', marginBottom: '4px' }}>{title}</strong>
+    <span style={{ color: '#888888', fontSize: '13px' }}>{description}</span>
+  </a>
+);
+
+# Component Methodology
+
+<div style={{ color: '#cccccc', marginBottom: '2rem', maxWidth: '760px', lineHeight: 1.6 }}>
+  Stack-and-Flow follows <strong style={{ color: '#ffffff' }}>Atomic Design</strong> and the <strong style={{ color: '#ffffff' }}>Container/Presentational pattern</strong>. Components should be easy to understand, token-driven, accessible, and safe to reuse across React applications.
+</div>
+
+<H2>Composition model</H2>
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '1rem', marginBottom: '2rem' }}>
+  {[
+    { tier: 'Primitives', description: 'Low-level visual building blocks for spacing, dividers, and foundational layout pieces.' },
+    { tier: 'Atoms', description: 'Single-purpose UI controls such as Button, Input, Badge, Text, and Avatar.' },
+    { tier: 'Molecules', description: 'Small composed patterns such as Tabs, Breadcrumb, Accordion, and Pagination.' },
+    { tier: 'Organisms', description: 'Larger interactive structures such as Modal, Drawer, and Toast.' },
+  ].map(({ tier, description }) => (
+    <Card key={tier}>
+      <div style={{ color: '#ff335e', fontSize: '13px', fontWeight: 700, marginBottom: '8px', textTransform: 'uppercase', letterSpacing: '0.02em' }}>{tier}</div>
+      <div style={{ color: '#cccccc', fontSize: '14px', lineHeight: 1.5 }}>{description}</div>
+    </Card>
+  ))}
+</div>
+
+<H2>Component anatomy</H2>
+
+<Card>
+  <div style={{ color: '#cccccc', marginBottom: '1rem' }}>Implemented components use a predictable file layout by default:</div>
+  <pre style={{ margin: 0, color: '#cccccc', background: '#060B12', border: '1px solid #172230', borderRadius: '6px', padding: '1rem', overflowX: 'auto' }}><code>{`ComponentName.tsx         // Presentational JSX
+useComponentName.ts       // State, effects, handlers, CVA classes
+types.ts                  // Public types and variants
+ComponentName.test.tsx    // Hook and component coverage
+ComponentName.stories.tsx // Documentation and examples
+index.ts                  // Public re-exports`}</code></pre>
+</Card>
+
+<H2>Rules that protect consistency</H2>
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '1rem', marginBottom: '2rem' }}>
+  {[
+    'Use tokens for color, spacing, radius, typography, shadows, and motion.',
+    'Keep JSX presentational and move behavior into the component hook.',
+    'Model variants with CVA and typed props.',
+    'Write accessibility and interaction tests with the component.',
+    'Use type aliases, avoid any, and keep the public API explicit.',
+    'Do not duplicate docs here: link to the source-of-truth project docs.',
+  ].map((rule) => (
+    <Card key={rule}>
+      <div style={{ color: '#cccccc', lineHeight: 1.5 }}>{rule}</div>
+    </Card>
+  ))}
+</div>
+
+<H2>Project docs</H2>
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: '1rem' }}>
+  <LinkCard href="https://github.com/Stack-and-Flow/design-system/blob/main/docs/GUIDELINES.en.md" title="Guidelines" description="Architecture, component structure, conventions, and non-negotiable implementation rules." />
+  <LinkCard href="https://github.com/Stack-and-Flow/design-system/blob/main/docs/DESIGN.en.md" title="Visual Design" description="Tokens, typography, colors, breakpoints, motion, and visual design reference." />
+  <LinkCard href="https://github.com/Stack-and-Flow/design-system/blob/main/docs/CONTRIBUTING.en.md" title="Contributing" description="How to set up the project, work on changes, and prepare contributions." />
+</div>


### PR DESCRIPTION
## Summary

- Reorders Storybook sidebar roots so Design System appears before component tiers.
- Keeps component tier roots collapsed on initial Storybook entry.
- Adds a Design System methodology MDX story with links to the English project docs.

Closes #312

## Review scope

- Primary files/areas:
  - `.storybook/preview.tsx`
  - `.storybook/manager.ts`
  - `stories/Design system/6-component-methodology.mdx`
  - `src/storybook-navigation.test.ts`
- Out of scope:
  - Component source changes
  - Design token changes
  - Package output or public API changes
- Review workload: small; 4 focused files and under the 400-line review budget.

## Type of change

- [ ] New component
- [ ] Existing component update/refactor
- [ ] Bug fix
- [ ] Accessibility
- [ ] Design tokens
- [x] Storybook/docs
- [ ] Infrastructure/tooling
- [ ] NPM/dependencies

## Workflow gates

- [x] Linked issue is present with `Closes #NNN` or maintainer approved an exception.
- [x] Linked issue has label `status:approved` before implementation starts.
- [x] Linked issue assignee was checked before work started; if it was assigned to someone else, explicit reassignment permission is documented.
- [x] Work was started through the Project flow: assignee set, Project status `In progress`, branch/worktree recorded.
- [x] PR title follows Conventional Commit format: `<type>(<optional scope>): <description>`.
- [x] Commits follow the same commitlint-enforced format.
- [x] Diff is focused; unrelated work is called out in Review scope.
- [x] MCP/runtime artifacts are absent: `.playwright-mcp`, `page-*.png`, `page-*.jpeg`, `*.md.playwright-output`.

## Component evidence (required for component changes)

- [ ] Validated component spec is linked or quoted in the issue.
- [ ] Accessibility contract from the spec was implemented or deviations are explained below.
- [ ] Follows the 6-file pattern: `types.ts`, `use*.ts`, `Component.tsx`, `Component.test.tsx`, `Component.stories.tsx`, `index.ts`.
- [ ] CVA variants live in `types.ts`; JSX component has no state, CVA calls, or business logic.
- [ ] Public props with runtime defaults have matching `@default` JSDoc in `types.ts` (`node scripts/verify-prop-default-docs.mjs`).
- [ ] Uses design tokens from `theme.css`; no hardcoded colors or arbitrary color utilities.
- [ ] Storybook covers default, variants, documented states, edge cases, and dark mode when visually different.
- [ ] Component audit result is PASS or accepted PASS WITH WARNINGS.
- [ ] Visual review result is included when visuals changed.

N/A — this PR changes Storybook navigation and docs only; no component implementation changed.

## Accessibility evidence

- [ ] Role/name semantics verified with Testing Library queries or equivalent.
- [ ] Keyboard-only behavior verified: Tab / Shift+Tab, Enter / Space, Arrow keys, Escape, Home / End / typeahead where applicable.
- [ ] Focus lifecycle verified: initial focus, roving/active descendant, focus restore, trap/portal behavior where applicable.
- [ ] Disabled, required, invalid/error, loading, and empty states expose the expected semantics where applicable.
- [ ] Reduced motion behavior is respected where motion changed.
- [ ] Screen reader or axe/manual evidence is included below when applicable.

N/A — static documentation and Storybook manager configuration only; no interactive component behavior changed.

## Validation evidence

- TypeScript: `pnpm exec tsc --noEmit --pretty false` ✅
- Unit tests: `pnpm exec vitest run src/storybook-navigation.test.ts` ✅ — 1 file, 3 tests
- Build/package: pre-commit `typecheck`, `harness-skills`, `prop-docs` ✅; package verification not required because no package output/API changed.
- Storybook or visual check: `pnpm exec storybook build --quiet` ✅
- Accessibility check: N/A — docs/config only.
- Security/dependency check: N/A — no dependency or security-sensitive changes.

## Screenshots or recordings

N/A — no browser recording captured. Storybook static build passed.

## Notes for reviewer

- The new methodology story intentionally links to the English docs: `GUIDELINES.en.md`, `DESIGN.en.md`, and `CONTRIBUTING.en.md`.
- Final reliability review of committed `origin/main..HEAD` reported no findings.
